### PR TITLE
fix: include es directory in packages json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "dist",
     "src",
     "lib",
-    "types"
+    "types",
+    "es"
   ],
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
This PR just simply includes the `es` directory in the `package.json` which should output that directory in the final package. This is a fix for issue #35