### PR TITLE
add links to repository and homepage

### DIFF
--- a/packages/react-location/package.json
+++ b/packages/react-location/package.json
@@ -3,6 +3,8 @@
   "author": "Tanner Linsley",
   "version": "0.0.0",
   "license": "MIT",
+  "repository": "tannerlinsley/react-location",
+  "homepage": "https://react-location.tanstack.com/",
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"


### PR DESCRIPTION
The main npm package is missing links to repository and homepage.
As a consequence, the links are not displayed at https://www.npmjs.com/package/react-location.
Other tools like Moiva.io that rely on that information can't provide valuable information.

This PR adds the missing information