### PR TITLE
Fix typos and grammar issues in docs Home and Supporting pages

### DIFF
--- a/docs/src/pages/comparison.md
+++ b/docs/src/pages/comparison.md
@@ -4,7 +4,7 @@ title: Comparison | React Location vs React Router
 toc: false
 ---
 
-Before you commit to a new tool, it's always nice to know it stacks up against the competition!
+Before you commit to a new tool, it's always nice to know how it stacks up against the competition!
 
 > This comparison table strives to be as accurate and as unbiased as possible. If you use any of these libraries and feel the information could be improved, feel free to suggest changes (with notes or evidence of claims) using the "Edit this page on Github" link at the bottom of this page.
 

--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -317,7 +317,7 @@ const routes: Route[] = [
 
 ## useMatch
 
-The `useMatch` hook returns the nearest current route match within context of where it's called. It can be used to access:
+The `useMatch` hook returns the nearest current route match within the context of where it's called. It can be used to access:
 
 - Route Data
 - Route Params (eg. `/:invoiceId` => `params.invoiceId`)
@@ -415,10 +415,10 @@ In React Location, search params are considered first-class objects that can be 
 
 **Parsing & Serialization**
 
-The first level of search params always have standard encoding, eg. `?param1=value&param2=value&param3=value`. This keeps things at the root level of the search params experience as compatible as possible with the rest of the web ecosystem. There are many tools frameworks and core web browsers APIs that use this basic expectation. **Starting with at value level of search params, however, React Location offers much more power**.
+The first level of search params always have standard encoding, eg. `?param1=value&param2=value&param3=value`. This keeps things at the root level of the search params experience as compatible as possible with the rest of the web ecosystem. There are many tools frameworks and core web browser APIs that use this basic expectation. **Starting with at value level of search params, however, React Location offers much more power**.
 
 - By default, React Location uses `JSON.parse` and `JSON.stringify` to ensure your search params can contain complex JSON objects.
-- Custom `stringifySearch` and `parseSearch` functions can be provided to your `ReactLocation` instance to further enhance the way search objects are encoded. We suggest using our `react-location-jsurl` package if you're truly looking for the best UX around search param encoding. It keeps URLs small, readable and safely encoded for users to share and bookmark.
+- Custom `stringifySearch` and `parseSearch` functions can be provided to your `ReactLocation` instance to further enhance the way search objects are encoded. We suggest using our `react-location-jsurl` package if you're truly looking for the best UX around search param encoding. It keeps URLs small, readable, and safely encoded for users to share and bookmark.
 - Regardless of the serialization strategy you pick for React Location, it will _always_ guarantee a stable, immutable and structurally-safe object reference. This means that even though your search params' source of truth is technically a string, it will behave as if it is an immutable object, stored in your application's memory.
 
 ## useSearch
@@ -734,7 +734,7 @@ function Root() {
 
 ## MatchRoute
 
-The `MatchRoute` component is merely a component-version of `useMatchRoute`. It takes all of the same options, but comes with some different affordances.
+The `MatchRoute` component is merely a component-version of `useMatchRoute`. It takes all of the same options but comes with some different affordances.
 
 - If the options provided _do not_ result in a match, `null` will be rendered.
 - If the options provided **do** result in a match

--- a/docs/src/pages/guides/history-types-and-location.md
+++ b/docs/src/pages/guides/history-types-and-location.md
@@ -5,7 +5,7 @@ title: History Types & Location
 
 > NOTE: If you don't need **hash or memory routing, then you can skip this section**.
 
-While it's not required to know the `history` API itself to use React Location, it's a good idea to understand how it works. Under the hood React Location requires and uses a `history` instance to manage the browser history.
+While it's not required to know the `history` API itself to use React Location, it's a good idea to understand how it works. Under the hood, React Location requires and uses a `history` instance to manage the browser history.
 
 - If you don't create a history instance, a default `createBrowserHistory` instance is created for you automatically when you call `new ReactLocation()`
 - If you **need a special history instance type**, You can use the history package to create your own history instance:
@@ -42,7 +42,7 @@ The `createBrowserHistory` is the default history type. It uses the browser's `h
 
 ## Hash Routing
 
-Hash routing can be helpful if your server doesn't support rewrites to `index.html` for http requests (among other environments that don't have a server).
+Hash routing can be helpful if your server doesn't support rewrites to `index.html` for HTTP requests (among other environments that don't have a server).
 
 ```tsx
 import { createHashHistory, ReactLocation } from 'react-location'

--- a/docs/src/pages/guides/pending-states.md
+++ b/docs/src/pages/guides/pending-states.md
@@ -7,17 +7,17 @@ Pending route states are similar to a React Suspense `fallback` state, or if you
 
 ## Why Pending States?
 
-React Location is different from other routing libraries. Because it is asynchronous, it has it's own "suspense"-like **pending state** when a new route is being loaded. If a route doesn't have any data requirements or async dependencies, it can be loaded immediately and the pending state isn't ever observed.
+React Location is different from other routing libraries. Because it is asynchronous, it has its own "suspense"-like **pending state** when a new route is being loaded. If a route doesn't have any data requirements or async dependencies, it can be loaded immediately and the pending state isn't ever observed.
 
 However, if a route has data requirements or async dependencies, it will be loaded in the background and the pending state can be observed in a few ways:
 
 - Route pending elements triggered by a timeout
 - Global pending navigation indicators
-- Location specific pending UI for the pending route
+- Location-specific pending UI for the pending route
 
 ## Pending Element Timeouts
 
-Routes can be configured to have a timeout before the route is considered pending. This timeout is essentialy the amount of time we are willing to "suspend" and wait on the current route for the next one to load.
+Routes can be configured to have a timeout before the route is considered pending. This timeout is essentially the amount of time we are willing to "suspend" and wait on the current route for the next one to load.
 
 Configure a pending timeout in milliseconds with the `pendingMs` prop:
 
@@ -34,7 +34,7 @@ const routes = [
 ```
 
 - If all of a route's asynchronous behavior is completed before the timeout, the pending state will never be shown.
-- If the timeout is reached, the route will be considered pending and the `pendingElement` will be shown until the routes is fully loaded.
+- If the timeout is reached, the route will be considered pending and the `pendingElement` will be shown until the route is fully loaded.
 
 ## Minimum Pending Element Timeouts
 
@@ -72,14 +72,14 @@ function Root() {
 }
 ```
 
-Here's some more tips to try!
+Here are some more tips to try!
 
-- Try using css to hide/show your loader instead of rendering `null`
-- Try using a css transition with different delays per-indicator-state to wait to show the loading indicator for bit when loading, then immmediately hiding it when complete.
+- Try using CSS to hide/show your loader instead of rendering `null`
+- Try using a CSS transition with different delays per-indicator-state to wait to show the loading indicator for a bit when loading, then immediately hiding it when complete.
 
 ## Location Specific Pending UI
 
-When a navigation is started to an asynchronous route, the current route will remain visible while it loads (unless a pending state is shown). While still visible, it is possible to show pending UI elements in the current route that are specific and conditional to the pending location. The two best tools to do this are the `useMatchRoute` hook and `MatchRoute` component.
+When a transition is started to an asynchronous route, the current route will remain visible while it loads (unless a pending state is shown). While still visible, it is possible to show pending UI elements in the current route that are specific and conditional to the pending location. The two best tools to do this are the `useMatchRoute` hook and `MatchRoute` component.
 
 Here's an example using the `MatchRoute` component with the `pending` prop to show a pending UI element when the link to that route matches:
 
@@ -111,7 +111,7 @@ function App() {
 }
 ```
 
-Likewise, you can use the `useMatchRoute` hook to get a more functional approach to the same end:
+Likewise, the `useMatchRoute` hook is an option if you would like a more functional approach:
 
 ```tsx
 function App() {

--- a/docs/src/pages/guides/route-elements.md
+++ b/docs/src/pages/guides/route-elements.md
@@ -13,7 +13,7 @@ There are 3 types of route elements:
 
 ## What exactly is an element?
 
-We refer to route elements with the same context as React. It is the result of a rendered block of JSX, a string, number, or even `null`. Here's a few examples:
+We refer to route elements with the same context as React. It is the result of a rendered block of JSX, a string, number, or even `null`. Here are a few examples:
 
 ```tsx
 const routes = [
@@ -57,4 +57,4 @@ For more information, see the [Route Loaders - Handling Loader Errors](../route-
 
 The pending `element` property of a route is what the router will render when a route loader enters the `pending` state.
 
-Because pending state shares some context with other sections, you can read all about it in its own [Pending States](../pending-states) guide.
+Because a pending state shares some context with other sections, you can read all about it in its own [Pending States](../pending-states) guide.

--- a/docs/src/pages/guides/route-loaders.md
+++ b/docs/src/pages/guides/route-loaders.md
@@ -11,7 +11,7 @@ Route loaders are route-level functions that can specify arbitrary data requirem
 
 ## Why should I use route loaders? Why are they cool?!
 
-Routes requiring data are nothing new, but the way React Location orchestrates these requirements is where the magic happens. In a traditional React application, usually the route is rendered immediately, and the data is fetched asynchronously either via a custom hook or a suspense boundary that is hit. This is a great way to get data from a server, but it also means that the route is rendered before the data is available. It introduces the need for a lot of boilerplate code to handle the asynchronous data fetching and even worse, **spinners** everywhere. This is usually a sub-optimal user experience, and with route loaders, **it's one that we can avoid!**
+Routes requiring data are nothing new, but the way React Location orchestrates these requirements is where the magic happens. In a traditional React application, usually, the route is rendered immediately, and the data is fetched asynchronously either via a custom hook or a suspense boundary that is hit. This is a great way to get data from a server, but it also means that the route is rendered before the data is available. It introduces the need for a lot of boilerplate code to handle the asynchronous data fetching and even worse, **spinners** everywhere. This is usually a sub-optimal user experience, and with route loaders, **it's one that we can avoid!**
 
 Route loaders are called when:
 
@@ -20,7 +20,7 @@ Route loaders are called when:
 
 ## Route Loader Promises
 
-Route loaders are extremely agnostic as to how you fetch your data. You can use any data fetching means that you like! Here's some of our favorites:
+Route loaders are extremely agnostic as to how you fetch your data. You can use any data fetching means that you like! Here are some of our favorites:
 
 - `fetch`
 - `axios`
@@ -138,7 +138,7 @@ function Team() {
 
 ## Route Loader Caching
 
-> The built-in caching mechanisms for React Location are extremely basic on purpose, since **caching is not the core responsibility or purpose of React Location**. That said, it ensures a very good UX out of the box by doing the bare minimum to retain navigational consistency.
+> The built-in caching mechanisms for React Location are extremely basic on purpose since **caching is not the core responsibility or purpose of React Location**. That said, it ensures a very good UX out of the box by doing the bare minimum to retain navigational consistency.
 
 By default, route loaders are called for **new or changed routes in the route hierarchy that resulted from a navigation**.
 
@@ -185,7 +185,7 @@ const routes = [{
 }]
 ```
 
-The dispatcher takes an event object as its only argument. The event object must have a `type` property, and any additional properties that correspond to that event. Here is the event type::
+The dispatcher takes an event object as its only argument. The event object must have a `type` property and any additional properties that correspond to that event. Here is the event type:
 
 ```tsx
 export type LoaderDispatchEvent<
@@ -212,7 +212,6 @@ export type LoaderDispatchEvent<
 - The `loading` event can be used to indicate that the route loader is in a loading state.
 - The `resolve` event can be used to indicate that the route loader has completed successfully and is required to pass the new loader data.
 - The `reject` event can be used to indicate that the route loader has failed and is required to pass the error that caused the failure.
--
 
 Here's an example of using a `Response`'s `max-age` header to set the `maxAge` for the loader:
 

--- a/docs/src/pages/guides/routes.md
+++ b/docs/src/pages/guides/routes.md
@@ -5,7 +5,7 @@ title: Routes
 
 ## What is a route?
 
-A React Location route is just an **object**. The `path` property can be used to define the path of the route it should match. Every property of the `Route` type is optional, but clearly recommended for varying circumstances. Here's the simplest use-case, path matching!
+A React Location route is just an **object**. The `path` defines the path of the route it should match. Every property of the `Route` type is optional but clearly recommended for varying circumstances. Here's the simplest use-case for path matching!
 
 ```tsx
 const routes = [
@@ -24,7 +24,7 @@ A route path can be a string _(regular expression support is coming soon!)_, and
 - `about/`
 - `about`
 
-**Leading and trailing slashes are optional because they do not affect the hierarchy of the route structure.** To build hierarchy, you can either use slashes inside your route path eg.
+**Leading and trailing slashes are optional because they do not affect the hierarchy of the route structure.** To build hierarchy, you can use slashes inside of your route path:
 
 - `about/me`
 - `about/me/`
@@ -86,7 +86,7 @@ const routes = [
 ]
 ```
 
-All other route path types that are not root/index (`/`) routes are **fuzzy** matched. This means that if they either an exact match OR are a prefix of the current location, they will match. For example:
+All other route path types that are not root/index (`/`) routes are **fuzzy** matched. This means that if they are either an exact match OR are a prefix of the current location, they will match. For example:
 
 ```tsx
 const routes = [

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -129,9 +129,9 @@ const Home = (props) => {
                   </h3>
                   <div className="mt-2  lg:mt-4 text-base xl:text-lg lg:leading-normal leading-6 text-gray-600">
                     Where most other routers provide minimum-to-no support for
-                    intelligent URL search param management, React Location take
+                    intelligent URL search param management, React Location takes
                     them very seriously to provide highly integrated support for
-                    matching, consuming and manipulating URL search params at
+                    matching, consuming, and manipulating URL search params at
                     scale.
                   </div>
                 </div>

--- a/docs/src/pages/overview.md
+++ b/docs/src/pages/overview.md
@@ -54,7 +54,7 @@ Much how React Query made handling server-state in your React applications a bre
 
 ### How does React Location handle Search Params?
 
-Most applications, even large ones will get away with requiring only a few string-based search query params in the URL, probably something like `?page=3` or `?filter-name=tanner`. The main reason you'll find this **state** inside of the URL is because while it may not fit the hierarchical patterns of the pathname section of the URL, it's still very important to the output of a page. Both the ability to consume these search params and manipulate them without restriction is paramount to your app's developer and user experience. Your users should be able to bookmark/copy-paste/share a link from your app and have consistency with the original state of the page.
+Most applications, even large ones will get away with requiring only a few string-based search query params in the URL, probably something like `?page=3` or `?filter-name=tanner`. The main reason you'll find this **state** inside of the URL is that while it may not fit the hierarchical patterns of the pathname section of the URL, it's still very important to the output of a page. Both the ability to consume these search params and manipulate them without restriction is paramount to your app's developer and user experience. Your users should be able to bookmark/copy-paste/share a link from your app and have consistency with the original state of the page.
 
 When you begin to store more state in the URL you will inevitably and naturally want to reach for JSON to store it. Storing JSON state in the URL has its own complications involving:
 
@@ -62,7 +62,7 @@ When you begin to store more state in the URL you will inevitably and naturally 
 - Parsing/Serialization. I'm talking about full-customization here; BYO stringifier/parser.
 - Immutability & Structural Sharing. This one is tricky to explain, but essentially it will save you from the inevitable infinite side-effect rerenders.
 - Compression & Readability. While not out-of-the-box, this is usually desired, so making it simple to get should be as simple as including a library.
-- Low-level declarative APIs to manipulate query state (think `<Link>`, `<Navigate>` and `useNavigate`). This is one where most routers can't or won't go. To do this correctly, you have to buy into your search-param APIs whole-sale at the core of the architecture and provide them as a consistent experience through the entire library.
+- Low-level declarative APIs to manipulate query state (think `<Link>`, `<Navigate>` and `useNavigate`). This is one where most routers can't or won't go. To do this correctly, you have to buy into your search-param APIs wholesale at the core of the architecture and provide them as a consistent experience through the entire library.
 
 Let's just say React Location doesn't skimp on search params. It handles all of this out of the box and goes the extra mile!
 
@@ -70,9 +70,9 @@ Let's just say React Location doesn't skimp on search params. It handles all of 
 
 Popularized by frameworks like [Next.js](https://nextjs.org) and now [Remix](https://remix.run), **specifying asynchronous dependencies for routes that can all resolve in parallel before rendering** is quickly becoming table stakes for almost every React Framework out there. It would be nice if Suspense on its own could give us the solution, but without a router to indicate what needs to be pre-loaded, only suspending on render doesn't allow you to avoid waterfall suspense requests.
 
-This capability of knowing everything that needs to be fetched up front before navigating is being explored heavily in SSR frameworks, but not in client-side apps. React Location's goal is to provide that same first-class support for specifying arbitrary asynchronous dependencies for your routes while asynchronously suspending navigation rendering until these dependencies are met.
+This capability of knowing everything that needs to be fetched upfront before navigating is being explored heavily in SSR frameworks, but not in client-side apps. React Location's goal is to provide that same first-class support for specifying arbitrary asynchronous dependencies for your routes while asynchronously suspending navigation rendering until these dependencies are met.
 
-To do this properly, routing and navigation needs to be designed from the ground up to be **fully asynchronous**. The following features in React Location are first-class and native to the entire routing architecture:
+To do this properly, routing and navigation need to be designed from the ground up to be **fully asynchronous**. The following features in React Location are first-class and native to the entire routing architecture:
 
 - Scheduling
 - Batching

--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -7,11 +7,11 @@ The `basic` example below illustrates a few of the basic concepts you'll encount
 
 - Creating Routes
 - Using path params
-- Fetching data in routes
+- Fetching data in Routes
 - Using the Router
 - Creating Links
-- Styling Active Links
-- Using route data in components
+- Styling active Links
+- Using Route data in components
 
 <iframe
   src="https://codesandbox.io/embed/github/tannerlinsley/react-location/tree/main/examples/basic?autoresize=1&fontsize=14&theme=dark"

--- a/docs/src/pages/tools/devtools.md
+++ b/docs/src/pages/tools/devtools.md
@@ -7,7 +7,7 @@ Wave your hands in the air and shout hooray because React Location comes with de
 
 When you begin your React Location journey, you'll want these devtools by your side. They help visualize all of the inner workings of React Location and will likely save you hours of debugging if you find yourself in a pinch!
 
-> Please note that for now, the devtools **do not support React Native**. If you would like to help us make the devtools platform agnostic, please let us know!
+> Please note that for now, the devtools **do not support React Native**. If you would like to help us make the devtools platform-agnostic, please let us know!
 
 ## Import the Devtools
 
@@ -41,7 +41,7 @@ function App() {
 ### Options
 
 - `initialIsOpen: Boolean`
-  - Set this `true` if you want the dev tools to default to being open
+  - Set this `true` if you want the devtools to default to being open
 - `panelProps: PropsObject`
   - Use this to add props to the panel. For example, you can add `className`, `style` (merge and override default style), etc.
 - `closeButtonProps: PropsObject`
@@ -71,7 +71,7 @@ function App() {
 
 ### Options
 
-Use these options to style the dev tools.
+Use these options to style the devtools.
 
 - `style: StyleObject`
   - The standard React style object used to style a component with inline styles

--- a/docs/src/pages/tools/ranked-routes.md
+++ b/docs/src/pages/tools/ranked-routes.md
@@ -61,7 +61,7 @@ function App() {
 }
 ```
 
-The Routes above will be filtered/ranked to the following order:
+The Routes above will be filtered and ranked in the following order:
 
 ```tsx
 const routes = [

--- a/docs/src/pages/tools/simple-cache.md
+++ b/docs/src/pages/tools/simple-cache.md
@@ -3,7 +3,7 @@ id: simple-cache
 title: React Location Simple Cache
 ---
 
-A simple cache created for React Location route loaders.
+A simple cache created for React Location Route loaders.
 
 - Fetch Policies
 - Stale-While-Revalidate
@@ -59,7 +59,7 @@ const simpleCache = new ReactLocationSimpleCache()
 
 ### SimpleCacheRecord
 
-This is the underlying shape of each record that is stored in the cache
+This is the underlying shape of each record that is stored in the cache:
 
 ```tsx
 import { LoaderData, RouteMatch } from 'react-location'
@@ -79,7 +79,7 @@ export type SimpleCacheRecord<
 
 ### Fetch Policies
 
-The caching functionality of the simple cache allows for a few different fetch policies to be used when determining if and when your loader function is called again.
+The caching functionality of the simple cache allows for a few different fetch policies to be used when determining if and when your loader function gets called again.
 
 ```tsx
 type FetchPolicy = 'cache-and-network' | 'cache-first' | 'network-only'


### PR DESCRIPTION
These are just the most obvious typos and grammatical changes I could make. I went through every docs page simply ensuring that what I was reading made sense and try to spot errosr.

---

Sidenote: I also noticed 4 empty markdown links:

Line **186** and line **190** in `guides/routes.md`

But I had an issue running docs locally and did not want to make a change that I could not verify works.