### PR TITLE
Documentation fixes

### DIFF
--- a/docs/src/pages/guides/pending-states.md
+++ b/docs/src/pages/guides/pending-states.md
@@ -27,7 +27,7 @@ const routes = [
     path: '/',
     loader: () => loadHomeData()
     element: () => <div>Home</div>,
-    pendingElement: () => <div>Taking a long time...</div>,
+    pendingElement: async () => <div>Taking a long time...</div>,
     pendingMs: 1000 * 2, // 2 seconds
   },
 ]
@@ -46,7 +46,7 @@ const routes = [
     path: '/',
     loader: () => loadHomeData()
     element: () => <div>Home</div>,
-    pendingElement: () => <div>Taking a long time...</div>,
+    pendingElement: async () => <div>Taking a long time...</div>,
     pendingMs: 1000 * 2, // 2 seconds
     pendingMinMs: 500 // If it's shown, ensure the pending element is rendered for at least 500ms
   },

--- a/docs/src/pages/guides/route-loaders.md
+++ b/docs/src/pages/guides/route-loaders.md
@@ -266,4 +266,4 @@ function TeamsError() {
 
 ## Pending States
 
-Route loaders _and_ async elements both share a set of features to show **pending** states. Because they are shared, we have a dedicated [Pending States](../pending-states) section where you can learn more about them.
+Route loaders _and_ async elements both share a set of features to show **pending** states. Because they are shared, we have a dedicated [Pending States](../guides/pending-states) section where you can learn more about them.


### PR DESCRIPTION
- Add `async` to `pendingElement` callback on Pending States page
- Fix a dead link on Route Loaders page