### PR TITLE
Repair "With Simple Cache" example which is rendering a white screen

### DIFF
--- a/examples/with-simple-cache/src/index.tsx
+++ b/examples/with-simple-cache/src/index.tsx
@@ -71,7 +71,9 @@ function App() {
           ],
         },
       ]}
-    />
+    >
+      <Outlet />
+    </Router>
   );
 }
 


### PR DESCRIPTION
The example in [here](https://react-location.tanstack.com/examples/with-simple-cache) it's showing white screen

[Here](https://codesandbox.io/s/adoring-dan-ypw89?file=/src/index.tsx:1716-1742) is the same example after i added the Outlet element as Router child

ps: i think that this is temporary solution, because Router should render an implicit Outlet when there is not a Router's children as is described in [here](https://react-location.tanstack.com/docs/api#router)

if it's a bug in Router, tell me that i can open a issue too 😅