### PR TITLE
fix: typo in devtools router area

### DIFF
--- a/packages/react-location-devtools/src/devtools.tsx
+++ b/packages/react-location-devtools/src/devtools.tsx
@@ -562,7 +562,7 @@ export const ReactLocationDevtoolsPanel = React.forwardRef<
                   basepath: router.basepath,
                   routes: router.routes,
                   routesById: router.routesById,
-                  matchCachgffe: router.matchCache,
+                  matchCache: router.matchCache,
                   defaultLinkPreloadMaxAge: router.defaultLinkPreloadMaxAge,
                   defaultLoaderMaxAge: router.defaultLoaderMaxAge,
                   defaultPendingMinMs: router.defaultPendingMinMs,


### PR DESCRIPTION
There was a typo "matchCachgffe" which  should be "matchCache"