### PR TITLE
Remove unwanted `console.log`

### DIFF
--- a/packages/react-location/src/index.tsx
+++ b/packages/react-location/src/index.tsx
@@ -1545,8 +1545,6 @@ export function Outlet<TGenerics extends PartialGenerics = DefaultGenerics>() {
 
     const matchElement = match.element ?? router.defaultElement
 
-    console.log(matchElement)
-
     return matchElement ?? <Outlet />
   })()
 


### PR DESCRIPTION
Not sure if this is intended, but I'm pretty sure someone left it there by accident.