### PR TITLE
Fixed broken Link style caused by an incorrect cache key

### DIFF
--- a/examples/with-react-query/src/index.tsx
+++ b/examples/with-react-query/src/index.tsx
@@ -122,7 +122,7 @@ function Posts() {
                       style={
                         // We can access the query data here to show bold links for
                         // ones that are cached
-                        queryClient.getQueryData(["post", post.id])
+                        queryClient.getQueryData(["posts", `${post.id}`])
                           ? {
                               fontWeight: "bold",
                               color: "green",


### PR DESCRIPTION
The example didn't work because the `id` return by the params is a `string` but the `id` returned from the API is a `number`.