### PR TITLE
fix: remove rejectLoader call inside of reject function

### DIFF
--- a/packages/react-location/src/index.tsx
+++ b/packages/react-location/src/index.tsx
@@ -914,7 +914,7 @@ export class RouteMatch<TGenerics extends PartialGenerics = DefaultGenerics> {
           ? Promise.resolve().then(() => {
               this.status = 'resolved'
             })
-          : new Promise(async (resolveLoader, rejectLoader) => {
+          : new Promise(async (resolveLoader) => {
               let pendingTimeout: Timeout
 
               const resolve = (data: any) => {
@@ -927,7 +927,6 @@ export class RouteMatch<TGenerics extends PartialGenerics = DefaultGenerics> {
                 console.error(err)
                 this.status = 'rejected'
                 this.error = err
-                rejectLoader(err)
               }
 
               const finish = () => {


### PR DESCRIPTION
The rejectLoader call inside of reject was causing the loader promise to never finish.  Removing it makes the error elements work, as well as the default error page in cases where there are no error elements