### PR TITLE
Enter pending state if pendingMs is set to 0 ms

### DIFF
--- a/packages/react-location/src/index.tsx
+++ b/packages/react-location/src/index.tsx
@@ -842,7 +842,7 @@ export class RouteMatch<TGenerics extends PartialGenerics = DefaultGenerics> {
       clearTimeout(this.pendingTimeout)
     }
 
-    if (this.route.pendingMs) {
+    if (this.route.pendingMs !== undefined) {
       this.pendingTimeout = setTimeout(() => {
         this.notify?.()
         if (typeof this.route.pendingMinMs !== 'undefined') {


### PR DESCRIPTION
This would fix #162  which also caught me off guard. I'm not sure if you should even need to set `pendingMs` if you set `pendingElement`, but I think if you set `pendingMs` to 0, you'd want it to always enter the pending state immediately. 