### PR TITLE
Fix search matching

### DIFF
--- a/packages/react-location/src/index.tsx
+++ b/packages/react-location/src/index.tsx
@@ -562,7 +562,7 @@ export class RouterInstance<
   defaultPendingMinMs?: number
   caseSensitive?: boolean
 
-  routesById: Record<string, Route<TGenerics>> = {}
+  routesById: Record<string, Route<TGenerics>[]> = {}
 
   constructor({
     location,
@@ -626,13 +626,17 @@ export class RouterInstance<
         }
 
         if (this.routesById[id]) {
-          if (process.env.NODE_ENV !== 'production') {
-            console.warn('Duplicate routes found:', this.routesById[id], route)
+          if (route.search) {
+            this.routesById[id]?.push(route);
+          } else {
+            if (process.env.NODE_ENV !== 'production') {
+              console.warn('Duplicate routes found:', this.routesById[id], route)
+            }
+            throw new Error()
           }
-          throw new Error()
+        } else {
+          this.routesById[id] = [route]
         }
-
-        this.routesById[id] = route
 
         route.children = route.children?.length
           ? recurseRoutes(route.children, route)


### PR DESCRIPTION
This is fixes #164 

Currently search match is broken, because two routes with the same path will throw an error as duplicates.

This change allows there to be multiple routes in `routesById`, provided that they have `search`. If it doesn't contain a search, a duplicate error will be thrown.