### PR TITLE
docs(npm/yarn commands): change yarn to npm command in docs

### DIFF
--- a/examples/basic/public/index.html
+++ b/examples/basic/public/index.html
@@ -32,7 +32,7 @@
       The build step will place the bundled scripts into the <body> tag.
 
       To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `yarn build` or `yarn build`.
+      To create a production bundle, use `npm build` or `yarn build`.
     -->
   </body>
 </html>

--- a/examples/kitchen-sink/public/index.html
+++ b/examples/kitchen-sink/public/index.html
@@ -32,7 +32,7 @@
       The build step will place the bundled scripts into the <body> tag.
 
       To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `yarn build` or `yarn build`.
+      To create a production bundle, use `npm build` or `yarn build`.
     -->
   </body>
 </html>

--- a/examples/with-react-query/README.md
+++ b/examples/with-react-query/README.md
@@ -3,4 +3,4 @@
 To run this example:
 
 - `npm install` or `yarn`
-- `yarn start` or `yarn start`
+- `npm start` or `yarn start`

--- a/examples/with-react-query/public/index.html
+++ b/examples/with-react-query/public/index.html
@@ -32,7 +32,7 @@
       The build step will place the bundled scripts into the <body> tag.
 
       To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `yarn build` or `yarn build`.
+      To create a production bundle, use `npm build` or `yarn build`.
     -->
   </body>
 </html>

--- a/examples/with-simple-cache/public/index.html
+++ b/examples/with-simple-cache/public/index.html
@@ -32,7 +32,7 @@
       The build step will place the bundled scripts into the <body> tag.
 
       To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `yarn build` or `yarn build`.
+      To create a production bundle, use `npm build` or `yarn build`.
     -->
   </body>
 </html>


### PR DESCRIPTION
Just something I found in the code while looking at old pr's. It seems like that it should be npm on the places I've changed it.


Happy new year!