### PR TITLE
fix route match description

### DIFF
--- a/docs/src/pages/guides/routes.md
+++ b/docs/src/pages/guides/routes.md
@@ -173,7 +173,7 @@ const routes = [
     path: 'dashboard',
     children: [
       {
-        path: '/', // matches /teams
+        path: '/', // matches /dashboard exactly
       },
       {
         path: 'teams', // matches /dashboard/teams/*


### PR DESCRIPTION
A route defined as '/' with a parent of dashboard will match /dashboard