### PR TITLE
Always scroll to hash

### DIFF
--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -178,10 +178,7 @@ function Transitioner() {
           routerState.location!.href !== routerState.resolvedLocation?.href,
       })
 
-      if (
-        routerState.location.hash !== routerState.resolvedLocation?.hash &&
-        (document as any).querySelector
-      ) {
+      if ((document as any).querySelector) {
         console.log('hello', routerState.location.hash)
         const el = document.getElementById(
           routerState.location.hash,


### PR DESCRIPTION
This addresses issue #837

Link component replicates the native html anchor element's behaviour of always scrolling into view (regarless of the current URL)