### PR TITLE
Declare CatchBoundary's `onCatch` prop as optional

### DIFF
--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -4,7 +4,7 @@ export function CatchBoundary(props: {
   getResetKey: () => string
   children: any
   errorComponent?: any
-  onCatch: (error: any) => void
+  onCatch?: (error: any) => void
 }) {
   const errorComponent = props.errorComponent ?? ErrorComponent
 


### PR DESCRIPTION
Align the CatchBoundary implementation with the docs by declaring the `onCatch` prop as optional