### PR TITLE
remove unnecessary sanitization to fix file based routing for windows

### DIFF
--- a/packages/router-cli/src/generator.ts
+++ b/packages/router-cli/src/generator.ts
@@ -310,7 +310,7 @@ export async function generator(config: Config) {
     imports.length
       ? `import { ${imports.join(', ')} } from '@tanstack/react-router'\n`
       : '',
-    `import { Route as rootRoute } from './${sanitize(
+    `import { Route as rootRoute } from './${replaceBackslash(
       path.relative(
         path.dirname(config.generatedRouteTree),
         path.resolve(config.routesDirectory, routePathIdPrefix + rootPathId),
@@ -321,7 +321,7 @@ export async function generator(config: Config) {
       .map((node) => {
         return `import { Route as ${
           node.variableName
-        }Import } from './${sanitize(
+        }Import } from './${replaceBackslash(
           removeExt(
             path.relative(
               path.dirname(config.generatedRouteTree),
@@ -363,7 +363,7 @@ export async function generator(config: Config) {
             .join(',')}
         } as any)`,
           loaderNode
-            ? `.updateLoader({ loader: lazyFn(() => import('./${sanitize(
+            ? `.updateLoader({ loader: lazyFn(() => import('./${replaceBackslash(
                 removeExt(
                   path.relative(
                     path.dirname(config.generatedRouteTree),
@@ -385,7 +385,7 @@ export async function generator(config: Config) {
                 .map((d) => {
                   return `${
                     d[0]
-                  }: lazyRouteComponent(() => import('./${sanitize(
+                  }: lazyRouteComponent(() => import('./${replaceBackslash(
                     removeExt(
                       path.relative(
                         path.dirname(config.generatedRouteTree),
@@ -508,10 +508,6 @@ export function multiSortBy<T>(
 function capitalize(s: string) {
   if (typeof s !== 'string') return ''
   return s.charAt(0).toUpperCase() + s.slice(1)
-}
-
-function sanitize(s: string) {
-  return replaceBackslash(s.replace(/\\index/gi, ''))
 }
 
 function removeUnderscores(s?: string) {


### PR DESCRIPTION
fixes following problem for windows users:

following structure:
```
routes
├── posts
│   ├── index.tsx
│   └── $postId.tsx
├── posts.tsx
├── index.tsx
└── __root.tsx
```

should produce following output:
```
import { Route as rootRoute } from "./routes/__root"
import { Route as PostsImport } from "./routes/posts"
import { Route as IndexImport } from "./routes/index"
import { Route as PostsPostIdImport } from "./routes/posts/$postId"
import { Route as PostsIndexImport } from "./routes/posts/index"
```

but produced without this change:
```
import { Route as rootRoute } from "./routes/__root"
import { Route as PostsImport } from "./routes/posts"
import { Route as IndexImport } from "./routes"
import { Route as PostsPostIdImport } from "./routes/posts/$postId"
import { Route as PostsIndexImport } from "./routes/posts"
```

which would obviously fail because of the wrong import of the PostIndexRoute