### PR TITLE
remove duplicate console.error in CatchBoundary

### DIFF
--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -50,7 +50,6 @@ export class CatchBoundaryImpl extends React.Component<{
     }
   }
   componentDidCatch(error: any) {
-    console.error(error)
     this.props.onCatch?.(error)
   }
   render() {


### PR DESCRIPTION
Would you consider removing the console.error call from the CatchBoundary component since its already logged by [react itself](https://github.com/facebook/react/blob/d0289c7e3a2dfc349dcce7f9eb3dee22464e97bd/packages/react-reconciler/src/ReactFiberErrorLogger.js#L86)?
My console is bloated with errors which i handle properly and i dont want to log :(

Related to: https://github.com/facebook/react/issues/15069