### PR TITLE
test(react-router): reproducer starter for #2255

### DIFF
--- a/packages/react-router/tests/notFoundComponent.test.tsx
+++ b/packages/react-router/tests/notFoundComponent.test.tsx
@@ -20,17 +20,19 @@ afterEach(() => {
 
 const getStartComponent = (href: string) => {
   const startTextLinkName = 'Link to test'
-  function RouteComponent() {
+  function StartComponent() {
     return <Link to={href}>{startTextLinkName}</Link>
   }
-  RouteComponent.startTextLinkName = startTextLinkName
-  return RouteComponent
+  StartComponent.startTextLinkName = startTextLinkName
+  StartComponent.linkScreenElement = () => screen.findByText(startTextLinkName)
+  return StartComponent
 }
 const getNotFoundComponent = (text: string) => {
   function NotFoundComponent() {
     return <div>{text}</div>
   }
   NotFoundComponent.notFoundTextName = text
+  NotFoundComponent.screenElement = () => screen.findByText(text)
   return NotFoundComponent
 }
 const getRootComponent = () => {
@@ -44,6 +46,7 @@ const getRootComponent = () => {
     )
   }
   RootComponent.rootTextName = rootTextName
+  RootComponent.screenElement = () => screen.findByText(rootTextName)
   return RootComponent
 }
 
@@ -79,19 +82,15 @@ describe('notFoundComp rendered when notFound thrown in beforeLoad', () => {
     render(<RouterProvider router={router} />)
 
     // setup
-    const link = await screen.findByRole('link', {
-      name: IndexComponent.startTextLinkName,
-    })
+    const link = await IndexComponent.linkScreenElement()
     expect(link).toBeInTheDocument()
     fireEvent.click(link)
 
     // actual assertions
-    const notFoundText = await screen.findByText(
-      NotFoundComponent.notFoundTextName,
-    )
+    const notFoundText = await NotFoundComponent.screenElement()
     expect(notFoundText).toBeInTheDocument()
 
-    const rootText = await screen.findByText(RootComponent.rootTextName)
+    const rootText = await RootComponent.screenElement()
     expect(rootText).toBeInTheDocument()
   })
 
@@ -127,19 +126,15 @@ describe('notFoundComp rendered when notFound thrown in beforeLoad', () => {
     render(<RouterProvider router={router} />)
 
     // setup
-    const link = await screen.findByRole('link', {
-      name: IndexComponent.startTextLinkName,
-    })
+    const link = await IndexComponent.linkScreenElement()
     expect(link).toBeInTheDocument()
     fireEvent.click(link)
 
     // actual assertions
-    const notFoundText = await screen.findByText(
-      NotFoundComponent.notFoundTextName,
-    )
+    const notFoundText = await NotFoundComponent.screenElement()
     expect(notFoundText).toBeInTheDocument()
 
-    const rootText = await screen.findByText(RootComponent.rootTextName)
+    const rootText = await RootComponent.screenElement()
     expect(rootText).toBeInTheDocument()
   })
 })
@@ -180,19 +175,15 @@ describe('notFoundComp rendered when notFound thrown in loader', () => {
     render(<RouterProvider router={router} />)
 
     // setup
-    const link = await screen.findByRole('link', {
-      name: IndexComponent.startTextLinkName,
-    })
+    const link = await IndexComponent.linkScreenElement()
     expect(link).toBeInTheDocument()
     fireEvent.click(link)
 
     // actual assertions
-    const notFoundText = await screen.findByText(
-      NotFoundComponent.notFoundTextName,
-    )
+    const notFoundText = await NotFoundComponent.screenElement()
     expect(notFoundText).toBeInTheDocument()
 
-    const rootText = await screen.findByText(RootComponent.rootTextName)
+    const rootText = await RootComponent.screenElement()
     expect(rootText).toBeInTheDocument()
   })
 
@@ -228,19 +219,15 @@ describe('notFoundComp rendered when notFound thrown in loader', () => {
     render(<RouterProvider router={router} />)
 
     // setup
-    const link = await screen.findByRole('link', {
-      name: IndexComponent.startTextLinkName,
-    })
+    const link = await IndexComponent.linkScreenElement()
     expect(link).toBeInTheDocument()
     fireEvent.click(link)
 
     // actual assertions
-    const notFoundText = await screen.findByText(
-      NotFoundComponent.notFoundTextName,
-    )
+    const notFoundText = await NotFoundComponent.screenElement()
     expect(notFoundText).toBeInTheDocument()
 
-    const rootText = await screen.findByText(RootComponent.rootTextName)
+    const rootText = await RootComponent.screenElement()
     expect(rootText).toBeInTheDocument()
   })
 })
@@ -264,19 +251,15 @@ describe('route does not exist', () => {
     render(<RouterProvider router={router} />)
 
     // setup
-    const link = await screen.findByRole('link', {
-      name: IndexComponent.startTextLinkName,
-    })
+    const link = await IndexComponent.linkScreenElement()
     expect(link).toBeInTheDocument()
     fireEvent.click(link)
 
     // actual assertions
-    const notFoundText = await screen.findByText(
-      NotFoundComponent.notFoundTextName,
-    )
+    const notFoundText = await NotFoundComponent.screenElement()
     expect(notFoundText).toBeInTheDocument()
 
-    const rootText = await screen.findByText(RootComponent.rootTextName)
+    const rootText = await RootComponent.screenElement()
     expect(rootText).toBeInTheDocument()
   })
 })

--- a/packages/react-router/tests/notFoundComponent.test.tsx
+++ b/packages/react-router/tests/notFoundComponent.test.tsx
@@ -1,0 +1,215 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import {
+  Link,
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  notFound,
+} from '../src'
+import { sleep } from './utils'
+
+afterEach(() => {
+  vi.resetAllMocks()
+  window.history.replaceState(null, 'root', '/')
+  cleanup()
+})
+
+const getStartComponent = (href: string) => {
+  const startTextLinkName = 'Link to test'
+  function RouteComponent() {
+    return <Link to={href}>{startTextLinkName}</Link>
+  }
+  RouteComponent.startTextLinkName = startTextLinkName
+  return RouteComponent
+}
+const getNotFoundComponent = (text: string) => {
+  function NotFoundComponent() {
+    return <div>{text}</div>
+  }
+  NotFoundComponent.notFoundTextName = text
+  return NotFoundComponent
+}
+
+describe('notFoundComp rendered when notFound thrown in beforeLoad', () => {
+  test('blank notFound in sync fn', async () => {
+    const NotFoundComponent = getNotFoundComponent('Not Found root')
+    const Component = getStartComponent(
+      '/sync-before-load-throws-empty-not-found',
+    )
+    const rootRoute = createRootRoute({ notFoundComponent: NotFoundComponent })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: Component,
+    })
+    const syncBeforeLoadThrowsEmptyNotFound = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/sync-before-load-throws-empty-not-found',
+      beforeLoad: () => {
+        throw notFound()
+      },
+    })
+    const routeTree = rootRoute.addChildren([
+      syncBeforeLoadThrowsEmptyNotFound,
+      indexRoute,
+    ])
+    const router = createRouter({ routeTree, notFoundMode: 'fuzzy' })
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByRole('link', {
+      name: Component.startTextLinkName,
+    })
+    expect(link).toBeInTheDocument()
+    fireEvent.click(link)
+
+    const notFoundText = await screen.findByText(
+      NotFoundComponent.notFoundTextName,
+    )
+    expect(notFoundText).toBeInTheDocument()
+  })
+
+  test('blank notFound in async fn', async () => {
+    const NotFoundComponent = getNotFoundComponent('Not Found root')
+    const Component = getStartComponent(
+      '/async-before-load-throws-empty-not-found',
+    )
+    const rootRoute = createRootRoute({ notFoundComponent: NotFoundComponent })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: Component,
+    })
+    const asyncBeforeLoadThrowsEmptyNotFound = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/async-before-load-throws-empty-not-found',
+      beforeLoad: async () => {
+        await sleep(1)
+        throw notFound()
+      },
+    })
+    const routeTree = rootRoute.addChildren([
+      asyncBeforeLoadThrowsEmptyNotFound,
+      indexRoute,
+    ])
+    const router = createRouter({ routeTree, notFoundMode: 'fuzzy' })
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByRole('link', {
+      name: Component.startTextLinkName,
+    })
+    expect(link).toBeInTheDocument()
+    fireEvent.click(link)
+
+    const notFoundText = await screen.findByText(
+      NotFoundComponent.notFoundTextName,
+    )
+    expect(notFoundText).toBeInTheDocument()
+  })
+})
+
+describe('notFoundComp rendered when notFound thrown in loader', () => {
+  /**
+   * This test is currently rendering the DefaultGlobalNotFound component.
+   * This probably shouldn't be happening, since we haven't configured it.
+   */
+  test('blank notFound in sync fn', async () => {
+    const NotFoundComponent = getNotFoundComponent('Not Found root')
+    const Component = getStartComponent('/sync-loader-throws-empty-not-found')
+    const rootRoute = createRootRoute({ notFoundComponent: NotFoundComponent })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: Component,
+    })
+    const syncLoaderThrowsEmptyNotFound = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/sync-loader-throws-empty-not-found',
+      loader: () => {
+        throw notFound()
+      },
+    })
+    const routeTree = rootRoute.addChildren([
+      syncLoaderThrowsEmptyNotFound,
+      indexRoute,
+    ])
+    const router = createRouter({ routeTree, notFoundMode: 'fuzzy' })
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByRole('link', {
+      name: Component.startTextLinkName,
+    })
+    expect(link).toBeInTheDocument()
+    fireEvent.click(link)
+
+    const notFoundText = await screen.findByText(
+      NotFoundComponent.notFoundTextName,
+    )
+    expect(notFoundText).toBeInTheDocument()
+  })
+
+  test('blank notFound in async fn', async () => {
+    const NotFoundComponent = getNotFoundComponent('Not Found root')
+    const Component = getStartComponent('/async-loader-throws-empty-not-found')
+    const rootRoute = createRootRoute({ notFoundComponent: NotFoundComponent })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: Component,
+    })
+    const asyncLoaderThrowsEmptyNotFound = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/async-loader-throws-empty-not-found',
+      loader: async () => {
+        await sleep(1)
+        throw notFound()
+      },
+    })
+    const routeTree = rootRoute.addChildren([
+      asyncLoaderThrowsEmptyNotFound,
+      indexRoute,
+    ])
+    const router = createRouter({ routeTree, notFoundMode: 'fuzzy' })
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByRole('link', {
+      name: Component.startTextLinkName,
+    })
+    expect(link).toBeInTheDocument()
+    fireEvent.click(link)
+
+    const notFoundText = await screen.findByText(
+      NotFoundComponent.notFoundTextName,
+    )
+    expect(notFoundText).toBeInTheDocument()
+  })
+})
+
+describe('route does not exist', () => {
+  test('navigate from the index route to expect a notFoundComponent', async () => {
+    const NotFoundComponent = getNotFoundComponent('Not Found root')
+    const Component = getStartComponent('/route-does-not-exist')
+    const rootRoute = createRootRoute({ notFoundComponent: NotFoundComponent })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: Component,
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree, notFoundMode: 'fuzzy' })
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByRole('link', {
+      name: Component.startTextLinkName,
+    })
+    expect(link).toBeInTheDocument()
+    fireEvent.click(link)
+
+    const notFoundText = await screen.findByText(
+      NotFoundComponent.notFoundTextName,
+    )
+    expect(notFoundText).toBeInTheDocument()
+  })
+})

--- a/packages/react-router/tests/notFoundComponent.test.tsx
+++ b/packages/react-router/tests/notFoundComponent.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 
 import {
   Link,
+  Outlet,
   RouterProvider,
   createRootRoute,
   createRoute,
@@ -32,18 +33,36 @@ const getNotFoundComponent = (text: string) => {
   NotFoundComponent.notFoundTextName = text
   return NotFoundComponent
 }
+const getRootComponent = () => {
+  const rootTextName = 'RootComponent'
+  function RootComponent() {
+    return (
+      <>
+        <div>{rootTextName}</div>
+        <Outlet />
+      </>
+    )
+  }
+  RootComponent.rootTextName = rootTextName
+  return RootComponent
+}
 
 describe('notFoundComp rendered when notFound thrown in beforeLoad', () => {
   test('blank notFound in sync fn', async () => {
+    const RootComponent = getRootComponent()
     const NotFoundComponent = getNotFoundComponent('Not Found root')
-    const Component = getStartComponent(
+    const rootRoute = createRootRoute({
+      component: RootComponent,
+      notFoundComponent: NotFoundComponent,
+    })
+
+    const IndexComponent = getStartComponent(
       '/sync-before-load-throws-empty-not-found',
     )
-    const rootRoute = createRootRoute({ notFoundComponent: NotFoundComponent })
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: Component,
+      component: IndexComponent,
     })
     const syncBeforeLoadThrowsEmptyNotFound = createRoute({
       getParentRoute: () => rootRoute,
@@ -59,28 +78,38 @@ describe('notFoundComp rendered when notFound thrown in beforeLoad', () => {
     const router = createRouter({ routeTree, notFoundMode: 'fuzzy' })
     render(<RouterProvider router={router} />)
 
+    // setup
     const link = await screen.findByRole('link', {
-      name: Component.startTextLinkName,
+      name: IndexComponent.startTextLinkName,
     })
     expect(link).toBeInTheDocument()
     fireEvent.click(link)
 
+    // actual assertions
     const notFoundText = await screen.findByText(
       NotFoundComponent.notFoundTextName,
     )
     expect(notFoundText).toBeInTheDocument()
+
+    const rootText = await screen.findByText(RootComponent.rootTextName)
+    expect(rootText).toBeInTheDocument()
   })
 
   test('blank notFound in async fn', async () => {
+    const RootComponent = getRootComponent()
     const NotFoundComponent = getNotFoundComponent('Not Found root')
-    const Component = getStartComponent(
+    const rootRoute = createRootRoute({
+      component: RootComponent,
+      notFoundComponent: NotFoundComponent,
+    })
+
+    const IndexComponent = getStartComponent(
       '/async-before-load-throws-empty-not-found',
     )
-    const rootRoute = createRootRoute({ notFoundComponent: NotFoundComponent })
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: Component,
+      component: IndexComponent,
     })
     const asyncBeforeLoadThrowsEmptyNotFound = createRoute({
       getParentRoute: () => rootRoute,
@@ -97,16 +126,21 @@ describe('notFoundComp rendered when notFound thrown in beforeLoad', () => {
     const router = createRouter({ routeTree, notFoundMode: 'fuzzy' })
     render(<RouterProvider router={router} />)
 
+    // setup
     const link = await screen.findByRole('link', {
-      name: Component.startTextLinkName,
+      name: IndexComponent.startTextLinkName,
     })
     expect(link).toBeInTheDocument()
     fireEvent.click(link)
 
+    // actual assertions
     const notFoundText = await screen.findByText(
       NotFoundComponent.notFoundTextName,
     )
     expect(notFoundText).toBeInTheDocument()
+
+    const rootText = await screen.findByText(RootComponent.rootTextName)
+    expect(rootText).toBeInTheDocument()
   })
 })
 
@@ -116,13 +150,20 @@ describe('notFoundComp rendered when notFound thrown in loader', () => {
    * This probably shouldn't be happening, since we haven't configured it.
    */
   test('blank notFound in sync fn', async () => {
+    const RootComponent = getRootComponent()
     const NotFoundComponent = getNotFoundComponent('Not Found root')
-    const Component = getStartComponent('/sync-loader-throws-empty-not-found')
-    const rootRoute = createRootRoute({ notFoundComponent: NotFoundComponent })
+    const rootRoute = createRootRoute({
+      component: RootComponent,
+      notFoundComponent: NotFoundComponent,
+    })
+
+    const IndexComponent = getStartComponent(
+      '/sync-loader-throws-empty-not-found',
+    )
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: Component,
+      component: IndexComponent,
     })
     const syncLoaderThrowsEmptyNotFound = createRoute({
       getParentRoute: () => rootRoute,
@@ -138,26 +179,38 @@ describe('notFoundComp rendered when notFound thrown in loader', () => {
     const router = createRouter({ routeTree, notFoundMode: 'fuzzy' })
     render(<RouterProvider router={router} />)
 
+    // setup
     const link = await screen.findByRole('link', {
-      name: Component.startTextLinkName,
+      name: IndexComponent.startTextLinkName,
     })
     expect(link).toBeInTheDocument()
     fireEvent.click(link)
 
+    // actual assertions
     const notFoundText = await screen.findByText(
       NotFoundComponent.notFoundTextName,
     )
     expect(notFoundText).toBeInTheDocument()
+
+    const rootText = await screen.findByText(RootComponent.rootTextName)
+    expect(rootText).toBeInTheDocument()
   })
 
   test('blank notFound in async fn', async () => {
+    const RootComponent = getRootComponent()
     const NotFoundComponent = getNotFoundComponent('Not Found root')
-    const Component = getStartComponent('/async-loader-throws-empty-not-found')
-    const rootRoute = createRootRoute({ notFoundComponent: NotFoundComponent })
+    const rootRoute = createRootRoute({
+      component: RootComponent,
+      notFoundComponent: NotFoundComponent,
+    })
+
+    const IndexComponent = getStartComponent(
+      '/async-loader-throws-empty-not-found',
+    )
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: Component,
+      component: IndexComponent,
     })
     const asyncLoaderThrowsEmptyNotFound = createRoute({
       getParentRoute: () => rootRoute,
@@ -174,42 +227,56 @@ describe('notFoundComp rendered when notFound thrown in loader', () => {
     const router = createRouter({ routeTree, notFoundMode: 'fuzzy' })
     render(<RouterProvider router={router} />)
 
+    // setup
     const link = await screen.findByRole('link', {
-      name: Component.startTextLinkName,
+      name: IndexComponent.startTextLinkName,
     })
     expect(link).toBeInTheDocument()
     fireEvent.click(link)
 
+    // actual assertions
     const notFoundText = await screen.findByText(
       NotFoundComponent.notFoundTextName,
     )
     expect(notFoundText).toBeInTheDocument()
+
+    const rootText = await screen.findByText(RootComponent.rootTextName)
+    expect(rootText).toBeInTheDocument()
   })
 })
 
 describe('route does not exist', () => {
   test('navigate from the index route to expect a notFoundComponent', async () => {
+    const RootComponent = getRootComponent()
     const NotFoundComponent = getNotFoundComponent('Not Found root')
-    const Component = getStartComponent('/route-does-not-exist')
-    const rootRoute = createRootRoute({ notFoundComponent: NotFoundComponent })
+    const rootRoute = createRootRoute({
+      component: RootComponent,
+      notFoundComponent: NotFoundComponent,
+    })
+    const IndexComponent = getStartComponent('/route-does-not-exist')
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: Component,
+      component: IndexComponent,
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree, notFoundMode: 'fuzzy' })
     render(<RouterProvider router={router} />)
 
+    // setup
     const link = await screen.findByRole('link', {
-      name: Component.startTextLinkName,
+      name: IndexComponent.startTextLinkName,
     })
     expect(link).toBeInTheDocument()
     fireEvent.click(link)
 
+    // actual assertions
     const notFoundText = await screen.findByText(
       NotFoundComponent.notFoundTextName,
     )
     expect(notFoundText).toBeInTheDocument()
+
+    const rootText = await screen.findByText(RootComponent.rootTextName)
+    expect(rootText).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
> [!IMPORTANT]
> These reproductions need to be corrected to match the expected route tree and the content to be displayed on the screen.

Starting for the reproductions for #2255 
