### PR TITLE
Mocked example of Link without "from" behavior change

### DIFF
--- a/examples/react/basic-file-based-codesplitting/src/linkWrapper.tsx
+++ b/examples/react/basic-file-based-codesplitting/src/linkWrapper.tsx
@@ -1,0 +1,9 @@
+import { Link, type LinkProps } from '@tanstack/react-router';  
+
+export function LinkWrapper({ className, children, search, to }: { className?: string; children: React.ReactNode; to: string, search: (prev: Record<string, string>) => Record<string, string> }) {
+  return <Link rel="noreferrer" preload="intent" to={to} search={search} className={className}>{children}</Link>
+}
+
+export function LinkWrapperWithFrom({ className, children, from, search, to }: { className?: string; children: React.ReactNode; to: string, from?: LinkProps['from'], search: (prev: Record<string, string>) => Record<string, string> }) {
+  return <Link rel="noreferrer" preload="intent" to={to} search={search} from={from} className={className}>{children}</Link>
+}

--- a/examples/react/basic-file-based-codesplitting/src/routes/_layout-test.lazy.tsx
+++ b/examples/react/basic-file-based-codesplitting/src/routes/_layout-test.lazy.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Link, Outlet, createLazyFileRoute } from '@tanstack/react-router'
+import { LinkWrapper, LinkWrapperWithFrom } from '../linkWrapper'
 
 export const Route = createLazyFileRoute('/_layout-test')({
   component: LayoutComponent,
@@ -10,6 +11,8 @@ function LayoutComponent() {
     <div>
       <div>I'm a layout</div>
       <div className="flex gap-2">
+        <LinkWrapper to="." search={(prev) => ({ ...prev, test: 'test' })} className="text-red-500">Doesn't Work</LinkWrapper>
+        <LinkWrapperWithFrom to="." from={undefined} search={(prev) => ({ ...prev, test: 'test' })} className="text-green-500">Works</LinkWrapperWithFrom>
         <Link
           to="/layout-a"
           activeProps={{

--- a/examples/react/basic-file-based-codesplitting/src/routes/_layout-test/layout-a.tsx
+++ b/examples/react/basic-file-based-codesplitting/src/routes/_layout-test/layout-a.tsx
@@ -1,10 +1,18 @@
 import * as React from 'react'
 import { createFileRoute } from '@tanstack/react-router'
+import { LinkWrapper } from '../../linkWrapper'
 
 export const Route = createFileRoute('/_layout-test/layout-a')({
   component: LayoutAComponent,
 })
 
 function LayoutAComponent() {
-  return <div>I'm A!</div>
+  return (
+    <div>
+      I'm A!
+      {/* <div>
+        <LinkWrapper to="." search={(prev) => ({ ...prev, test: 'test' })} className="text-green-500">Wrapper Test (Works as Expected)</LinkWrapper>
+      </div> */}
+    </div>
+  )
 }

--- a/examples/react/quickstart-file-based/src/routeTree.gen.ts
+++ b/examples/react/quickstart-file-based/src/routeTree.gen.ts
@@ -8,13 +8,26 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
+import { createFileRoute } from '@tanstack/react-router'
+
 // Import Routes
 
 import { Route as rootRoute } from './routes/__root'
 import { Route as AboutImport } from './routes/about'
 import { Route as IndexImport } from './routes/index'
 
+// Create Virtual Routes
+
+const WorkingpreloadLazyImport = createFileRoute('/workingpreload')()
+
 // Create/Update Routes
+
+const WorkingpreloadLazyRoute = WorkingpreloadLazyImport.update({
+  path: '/workingpreload',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() =>
+  import('./routes/workingpreload.lazy').then((d) => d.Route),
+)
 
 const AboutRoute = AboutImport.update({
   id: '/about',
@@ -46,6 +59,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AboutImport
       parentRoute: typeof rootRoute
     }
+    '/workingpreload': {
+      id: '/workingpreload'
+      path: '/workingpreload'
+      fullPath: '/workingpreload'
+      preLoaderRoute: typeof WorkingpreloadLazyImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
@@ -54,36 +74,41 @@ declare module '@tanstack/react-router' {
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/workingpreload': typeof WorkingpreloadLazyRoute
 }
 
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/workingpreload': typeof WorkingpreloadLazyRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/workingpreload': typeof WorkingpreloadLazyRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/about'
+  fullPaths: '/' | '/about' | '/workingpreload'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/about'
-  id: '__root__' | '/' | '/about'
+  to: '/' | '/about' | '/workingpreload'
+  id: '__root__' | '/' | '/about' | '/workingpreload'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  WorkingpreloadLazyRoute: typeof WorkingpreloadLazyRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  WorkingpreloadLazyRoute: WorkingpreloadLazyRoute,
 }
 
 export const routeTree = rootRoute
@@ -97,7 +122,8 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/",
-        "/about"
+        "/about",
+        "/workingpreload"
       ]
     },
     "/": {
@@ -105,6 +131,9 @@ export const routeTree = rootRoute
     },
     "/about": {
       "filePath": "about.tsx"
+    },
+    "/workingpreload": {
+      "filePath": "workingpreload.lazy.tsx"
     }
   }
 }

--- a/examples/react/quickstart-file-based/src/routes/__root.tsx
+++ b/examples/react/quickstart-file-based/src/routes/__root.tsx
@@ -26,6 +26,14 @@ function RootComponent() {
           }}
         >
           About
+        </Link>{' '}
+        <Link
+          to="/workingpreload"
+          activeProps={{
+            className: 'font-bold',
+          }}
+        >
+          Hover me!
         </Link>
       </div>
       <hr />

--- a/examples/react/quickstart-file-based/src/routes/workingpreload.lazy.tsx
+++ b/examples/react/quickstart-file-based/src/routes/workingpreload.lazy.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react'
+import { createLazyFileRoute } from '@tanstack/react-router'
+
+export const Route = createLazyFileRoute('/workingpreload')({
+  component: WorkingPreloadComponent,
+})
+
+function WorkingPreloadComponent() {
+  return (
+    <div className="p-2">
+      <h3>Working Preload</h3>
+    </div>
+  )
+}

--- a/examples/react/quickstart-file-based/vite.config.js
+++ b/examples/react/quickstart-file-based/vite.config.js
@@ -4,5 +4,5 @@ import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [TanStackRouterVite(), react()],
+  plugins: [TanStackRouterVite({ autoCodeSplitting: true }), react()],
 })


### PR DESCRIPTION
👋 

After stubbing an example, it makes sense as to why things behave the way they do — It just caught me off guard ([this](https://github.com/TanStack/router/compare/v1.81.9...v1.81.10#diff-5fd7a0f05758a78cf8b73c09e4d71d21af63fe3d9b312b0ee75b04041ef078e7R654-R663) changes existing behavior).

I have a layout-level component (a user navigation dropdown). My application spawn modals based on a search param, `modalId`. For example, I can be on `/_layout/route-b` and click a link in the user dropdown (mounts inside `_layout.tsx`) intended to stay on the current visible route with the only change being a modal spawned on top of the current content.

I was triggering modals by way of ```<Link to="." search={{(prev) => ({...prev, modalId: 'sign-out-confirmation' }) }} />```
This worked up until `v1.81.9`. As of `v1.81.10`, I'm passing an extra `from={undefined}` to retain the same behavior. Without this change, modals fall back to using the root.