### PR TITLE
preload type fix (naive type change)

### DIFF
--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -395,7 +395,7 @@ export interface UpdatableRouteOptions<
   pendingMinMs?: number
   staleTime?: number
   gcTime?: number
-  preload?: boolean
+  preload?: false | 'intent' | 'viewport' | 'render'
   preloadStaleTime?: number
   preloadGcTime?: number
   search?: {


### PR DESCRIPTION
This PR is meant to bring the `preload` options to reflect the possible values listed in both `defaultPreload` (below) and the docs (https://tanstack.com/router/v1/docs/framework/react/guide/preloading#supported-preloading-strategies).

Currently the `preload` in `createFileRoute` allows only to pass `boolean` which seems wrong (see above):

`UpdatableRouteOptions`:
```
preload?: boolean
```

vs

`RouterOptions`:
```
  defaultPreload?: false | 'intent' | 'viewport' | 'render'
```

# state of this PR

due to flaky e2e tests I'm unable to get them running. I've got one e2e server functions test (`nx run tanstack-start-e2e-server-functions:test:e2e`, unrelated to the change) failing on 30s timeout: https://nx.app/runs/0YaAbzz0il

I need help here.
