### PR TITLE
Document NavigateOptionsType#href behaviour with reloadDocument

### DIFF
--- a/docs/router/framework/react/api/router/NavigateOptionsType.md
+++ b/docs/router/framework/react/api/router/NavigateOptionsType.md
@@ -73,6 +73,6 @@ The `NavigateOptions` object accepts the following properties:
 
 - Type: `string`
 - Optional
-- This can be used instead of `to` to navigate to a fully built href, e.g. pointing to an external target.
+- This can be used instead of `to` to navigate to a fully built href, e.g. pointing to an external target. When using with a fully built href, `reloadDocument` should be set to `true`
 
 - [`ToOptions`](./ToOptionsType.md)


### PR DESCRIPTION
Discovered from this comment: https://github.com/TanStack/router/issues/3232#issuecomment-2620479336, and confirmed with testing. If `reloadDocument` is `false`, the given HTTP url is appended to the current route.