### PR TITLE
fix: allow json literals in serializer

### DIFF
--- a/packages/router-core/src/serializer.ts
+++ b/packages/router-core/src/serializer.ts
@@ -5,17 +5,23 @@ export interface StartSerializer {
   decode: <T>(value: T) => T
 }
 
+type JSONLiteral = string | boolean | null | number
+
 export type SerializerStringifyBy<T, TSerializable> = T extends TSerializable
   ? T
-  : T extends (...args: Array<any>) => any
-    ? 'Function is not serializable'
-    : { [K in keyof T]: SerializerStringifyBy<T[K], TSerializable> }
+  : T extends JSONLiteral
+    ? T
+    : T extends (...args: Array<any>) => any
+      ? 'Function is not serializable'
+      : { [K in keyof T]: SerializerStringifyBy<T[K], TSerializable> }
 
 export type SerializerParseBy<T, TSerializable> = T extends TSerializable
   ? T
-  : T extends React.JSX.Element
-    ? ReadableStream
-    : { [K in keyof T]: SerializerParseBy<T[K], TSerializable> }
+  : T extends JSONLiteral
+    ? T
+    : T extends React.JSX.Element
+      ? ReadableStream
+      : { [K in keyof T]: SerializerParseBy<T[K], TSerializable> }
 
 export type Serializable = Date | undefined | Error | FormData | bigint
 

--- a/packages/start-client-core/src/tests/createServerMiddleware.test-d.ts
+++ b/packages/start-client-core/src/tests/createServerMiddleware.test-d.ts
@@ -201,7 +201,7 @@ test('createMiddleware merges client context and sends to the server', () => {
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
         context: { a: boolean; b: string; c: number }
-        sendContext: { a: boolean; b: string; c: number; d: number }
+        sendContext: { a: boolean; b: string; c: number; d: 5 }
         headers: HeadersInit
       }>()
 
@@ -215,7 +215,7 @@ test('createMiddleware merges client context and sends to the server', () => {
         a: boolean
         b: string
         c: number
-        d: number
+        d: 5
       }>()
 
       const result = await options.next({
@@ -232,7 +232,7 @@ test('createMiddleware merges client context and sends to the server', () => {
           }
           sendContext: undefined
         }
-        context: { a: boolean; b: string; c: number; d: number; e: string }
+        context: { a: boolean; b: string; c: number; d: 5; e: string }
         sendContext: undefined
       }>()
 


### PR DESCRIPTION
Closes #3157 

This PR allows literal values to be passed without transformation in types. As a side effect it allows to pass branded types. See example:

```tsx
import { createFileRoute } from '@tanstack/react-router'
import { createServerFn } from '@tanstack/react-start'
import { z } from 'zod'

const UserIdSchema = z
  .string()
  .brand('UserId') // this didn't work in the past, now works

const UserSchema = z
  .object({
    id: UserIdSchema,
    name: z.string(),
  })
  .brand('User') // this worked in the past

const getUserInfo = createServerFn({ method: 'GET' })
  .validator(z.number())
  .handler(() => {
    return UserSchema.parse({
      id: '123',
      name: 'asdf',
    })
  })

export const Route = createFileRoute('/')({
  component: Home,
  loader: async () => await getUserInfo({ data: 5 }),
})

function Home() {
  const state = Route.useLoaderData()

  const renderUser = (user: z.infer<typeof UserSchema>) => {
    return (
      <div>
        <h1>{user.name}</h1>
        <p>{user.id}</p>
      </div>
    )
  }

  return renderUser(state)
}
```