### PR TITLE
fix(router-core): return meta if match.status notFound

### DIFF
--- a/packages/react-router/tests/Scripts.test.tsx
+++ b/packages/react-router/tests/Scripts.test.tsx
@@ -123,7 +123,7 @@ describe('ssr HeadContent', () => {
             },
             {
               name: 'description',
-              content: loaderData.description,
+              content: loaderData?.description,
             },
             {
               name: 'image',
@@ -160,7 +160,7 @@ describe('ssr HeadContent', () => {
             },
             {
               name: 'description',
-              content: loaderData.description,
+              content: loaderData?.description,
             },
             {
               name: 'last-modified',

--- a/packages/react-router/tests/route.test.tsx
+++ b/packages/react-router/tests/route.test.tsx
@@ -337,7 +337,6 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
-
     render(<RouterProvider router={router} />)
 
     expect(await screen.findByText('Fly, you fools!')).toBeInTheDocument()
@@ -372,7 +371,6 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
-
     render(<RouterProvider router={router} />)
     const indexElem = await screen.findByText('Index')
     expect(indexElem).toBeInTheDocument()
@@ -403,7 +401,6 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
-
     render(<RouterProvider router={router} />)
     const indexElem = await screen.findByText('Index')
     expect(indexElem).toBeInTheDocument()
@@ -431,7 +428,6 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
-
     render(<RouterProvider router={router} />)
     const indexElem = await screen.findByText('Index')
     expect(indexElem).toBeInTheDocument()
@@ -462,7 +458,6 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
-
     render(<RouterProvider router={router} />)
     const indexElem = await screen.findByText('Index')
     expect(indexElem).toBeInTheDocument()

--- a/packages/react-router/tests/route.test.tsx
+++ b/packages/react-router/tests/route.test.tsx
@@ -8,6 +8,7 @@ import {
   createRoute,
   createRouter,
   getRouteApi,
+  notFound
 } from '../src'
 
 afterEach(() => {
@@ -251,6 +252,46 @@ describe('route.head', () => {
       }),
       loader: async () => {
         await new Promise((resolve) => setTimeout(resolve, 200))
+      },
+      component: () => <div>Index</div>,
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree })
+    render(<RouterProvider router={router} />)
+    const indexElem = await screen.findByText('Index')
+    expect(indexElem).toBeInTheDocument()
+
+    const metaState = router.state.matches.map((m) => m.meta)
+    expect(metaState).toEqual([
+      [
+        { title: 'Root' },
+        {
+          charSet: 'utf-8',
+        },
+      ],
+      [{ title: 'Index' }],
+    ])
+  })
+
+  test('meta returned when loader throws notFound', async () => {
+    const rootRoute = createRootRoute({
+      head: () => ({
+        meta: [
+          { title: 'Root' },
+          {
+            charSet: 'utf-8',
+          },
+        ],
+      }),
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      head: () => ({
+        meta: [{ title: 'Index' }],
+      }),
+      loader: async () => {
+        throw notFound()
       },
       component: () => <div>Index</div>,
     })

--- a/packages/react-router/tests/route.test.tsx
+++ b/packages/react-router/tests/route.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, test, vi } from 'vitest'
-import { act, cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 
 import {
   RouterProvider,
@@ -296,21 +296,21 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Not Found')).toBeInTheDocument()
 
-    act(async () => {
-      render(<RouterProvider router={router} />)
-      expect(await screen.findByText('Not Found')).toBeInTheDocument()
-      const metaState = router.state.matches.map((m) => m.meta)
-      expect(metaState).toEqual([
-        [
-          { title: 'Root' },
-          {
-            charSet: 'utf-8',
-          },
-        ],
-        [{ title: 'Index' }],
-      ])
-    })
+    await router.load()
+
+    const metaState = router.state.matches.map((m) => m.meta)
+    expect(metaState).toEqual([
+      [
+        { title: 'Root' },
+        {
+          charSet: 'utf-8',
+        },
+      ],
+      [{ title: 'Index' }],
+    ])
   })
 
   test('meta returned when loader throws an error', async () => {
@@ -338,21 +338,22 @@ describe('route.head', () => {
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
 
-    act(async () => {
-      render(<RouterProvider router={router} />)
-      expect(await screen.findByText('Fly, you fools!')).toBeInTheDocument()
+    render(<RouterProvider router={router} />)
 
-      const metaState = router.state.matches.map((m) => m.meta)
-      expect(metaState).toEqual([
-        [
-          { title: 'Root' },
-          {
-            charSet: 'utf-8',
-          },
-        ],
-        [{ title: 'Index' }],
-      ])
-    })
+    expect(await screen.findByText('Fly, you fools!')).toBeInTheDocument()
+
+    await router.load()
+
+    const metaState = router.state.matches.map((m) => m.meta)
+    expect(metaState).toEqual([
+      [
+        { title: 'Root' },
+        {
+          charSet: 'utf-8',
+        },
+      ],
+      [{ title: 'Index' }],
+    ])
   })
 
   test('scripts', async () => {
@@ -372,17 +373,15 @@ describe('route.head', () => {
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
 
-    act(async () => {
-      render(<RouterProvider router={router} />)
-      const indexElem = await screen.findByText('Index')
-      expect(indexElem).toBeInTheDocument()
+    render(<RouterProvider router={router} />)
+    const indexElem = await screen.findByText('Index')
+    expect(indexElem).toBeInTheDocument()
 
-      const scriptsState = router.state.matches.map((m) => m.headScripts)
-      expect(scriptsState).toEqual([
-        [{ src: 'root.js' }, { src: 'root2.js' }],
-        [{ src: 'index.js' }],
-      ])
-    })
+    const scriptsState = router.state.matches.map((m) => m.headScripts)
+    expect(scriptsState).toEqual([
+      [{ src: 'root.js' }, { src: 'root2.js' }],
+      [{ src: 'index.js' }],
+    ])
   })
 
   test('scripts w/ loader', async () => {
@@ -405,17 +404,15 @@ describe('route.head', () => {
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
 
-    act(async () => {
-      render(<RouterProvider router={router} />)
-      const indexElem = await screen.findByText('Index')
-      expect(indexElem).toBeInTheDocument()
+    render(<RouterProvider router={router} />)
+    const indexElem = await screen.findByText('Index')
+    expect(indexElem).toBeInTheDocument()
 
-      const scriptsState = router.state.matches.map((m) => m.headScripts)
-      expect(scriptsState).toEqual([
-        [{ src: 'root.js' }, { src: 'root2.js' }],
-        [{ src: 'index.js' }],
-      ])
-    })
+    const scriptsState = router.state.matches.map((m) => m.headScripts)
+    expect(scriptsState).toEqual([
+      [{ src: 'root.js' }, { src: 'root2.js' }],
+      [{ src: 'index.js' }],
+    ])
   })
 
   test('links', async () => {
@@ -435,17 +432,15 @@ describe('route.head', () => {
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
 
-    act(async () => {
-      render(<RouterProvider router={router} />)
-      const indexElem = await screen.findByText('Index')
-      expect(indexElem).toBeInTheDocument()
+    render(<RouterProvider router={router} />)
+    const indexElem = await screen.findByText('Index')
+    expect(indexElem).toBeInTheDocument()
 
-      const linksState = router.state.matches.map((m) => m.links)
-      expect(linksState).toEqual([
-        [{ href: 'root.css' }, { href: 'root2.css' }],
-        [{ href: 'index.css' }],
-      ])
-    })
+    const linksState = router.state.matches.map((m) => m.links)
+    expect(linksState).toEqual([
+      [{ href: 'root.css' }, { href: 'root2.css' }],
+      [{ href: 'index.css' }],
+    ])
   })
 
   test('links w/loader', async () => {
@@ -468,16 +463,14 @@ describe('route.head', () => {
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
 
-    act(async () => {
-      render(<RouterProvider router={router} />)
-      const indexElem = await screen.findByText('Index')
-      expect(indexElem).toBeInTheDocument()
+    render(<RouterProvider router={router} />)
+    const indexElem = await screen.findByText('Index')
+    expect(indexElem).toBeInTheDocument()
 
-      const linksState = router.state.matches.map((m) => m.links)
-      expect(linksState).toEqual([
-        [{ href: 'root.css' }, { href: 'root2.css' }],
-        [{ href: 'index.css' }],
-      ])
-    })
+    const linksState = router.state.matches.map((m) => m.links)
+    expect(linksState).toEqual([
+      [{ href: 'root.css' }, { href: 'root2.css' }],
+      [{ href: 'index.css' }],
+    ])
   })
 })

--- a/packages/react-router/tests/route.test.tsx
+++ b/packages/react-router/tests/route.test.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
 import { afterEach, describe, expect, it, test, vi } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 
 import {
   RouterProvider,
@@ -8,7 +7,7 @@ import {
   createRoute,
   createRouter,
   getRouteApi,
-  notFound
+  notFound,
 } from '../src'
 
 afterEach(() => {
@@ -297,20 +296,63 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
-    render(<RouterProvider router={router} />)
-    const indexElem = await screen.findByText('Index')
-    expect(indexElem).toBeInTheDocument()
 
-    const metaState = router.state.matches.map((m) => m.meta)
-    expect(metaState).toEqual([
-      [
-        { title: 'Root' },
-        {
-          charSet: 'utf-8',
-        },
-      ],
-      [{ title: 'Index' }],
-    ])
+    act(async () => {
+      render(<RouterProvider router={router} />)
+      expect(await screen.findByText('Not Found')).toBeInTheDocument()
+      const metaState = router.state.matches.map((m) => m.meta)
+      expect(metaState).toEqual([
+        [
+          { title: 'Root' },
+          {
+            charSet: 'utf-8',
+          },
+        ],
+        [{ title: 'Index' }],
+      ])
+    })
+  })
+
+  test('meta returned when loader throws an error', async () => {
+    const rootRoute = createRootRoute({
+      head: () => ({
+        meta: [
+          { title: 'Root' },
+          {
+            charSet: 'utf-8',
+          },
+        ],
+      }),
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      head: () => ({
+        meta: [{ title: 'Index' }],
+      }),
+      loader: async () => {
+        throw new Error('Fly, you fools!')
+      },
+      component: () => <div>Index</div>,
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree })
+
+    act(async () => {
+      render(<RouterProvider router={router} />)
+      expect(await screen.findByText('Fly, you fools!')).toBeInTheDocument()
+
+      const metaState = router.state.matches.map((m) => m.meta)
+      expect(metaState).toEqual([
+        [
+          { title: 'Root' },
+          {
+            charSet: 'utf-8',
+          },
+        ],
+        [{ title: 'Index' }],
+      ])
+    })
   })
 
   test('scripts', async () => {
@@ -329,15 +371,18 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
-    render(<RouterProvider router={router} />)
-    const indexElem = await screen.findByText('Index')
-    expect(indexElem).toBeInTheDocument()
 
-    const scriptsState = router.state.matches.map((m) => m.headScripts)
-    expect(scriptsState).toEqual([
-      [{ src: 'root.js' }, { src: 'root2.js' }],
-      [{ src: 'index.js' }],
-    ])
+    act(async () => {
+      render(<RouterProvider router={router} />)
+      const indexElem = await screen.findByText('Index')
+      expect(indexElem).toBeInTheDocument()
+
+      const scriptsState = router.state.matches.map((m) => m.headScripts)
+      expect(scriptsState).toEqual([
+        [{ src: 'root.js' }, { src: 'root2.js' }],
+        [{ src: 'index.js' }],
+      ])
+    })
   })
 
   test('scripts w/ loader', async () => {
@@ -359,15 +404,18 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
-    render(<RouterProvider router={router} />)
-    const indexElem = await screen.findByText('Index')
-    expect(indexElem).toBeInTheDocument()
 
-    const scriptsState = router.state.matches.map((m) => m.headScripts)
-    expect(scriptsState).toEqual([
-      [{ src: 'root.js' }, { src: 'root2.js' }],
-      [{ src: 'index.js' }],
-    ])
+    act(async () => {
+      render(<RouterProvider router={router} />)
+      const indexElem = await screen.findByText('Index')
+      expect(indexElem).toBeInTheDocument()
+
+      const scriptsState = router.state.matches.map((m) => m.headScripts)
+      expect(scriptsState).toEqual([
+        [{ src: 'root.js' }, { src: 'root2.js' }],
+        [{ src: 'index.js' }],
+      ])
+    })
   })
 
   test('links', async () => {
@@ -386,15 +434,18 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
-    render(<RouterProvider router={router} />)
-    const indexElem = await screen.findByText('Index')
-    expect(indexElem).toBeInTheDocument()
 
-    const linksState = router.state.matches.map((m) => m.links)
-    expect(linksState).toEqual([
-      [{ href: 'root.css' }, { href: 'root2.css' }],
-      [{ href: 'index.css' }],
-    ])
+    act(async () => {
+      render(<RouterProvider router={router} />)
+      const indexElem = await screen.findByText('Index')
+      expect(indexElem).toBeInTheDocument()
+
+      const linksState = router.state.matches.map((m) => m.links)
+      expect(linksState).toEqual([
+        [{ href: 'root.css' }, { href: 'root2.css' }],
+        [{ href: 'index.css' }],
+      ])
+    })
   })
 
   test('links w/loader', async () => {
@@ -416,14 +467,17 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
-    render(<RouterProvider router={router} />)
-    const indexElem = await screen.findByText('Index')
-    expect(indexElem).toBeInTheDocument()
 
-    const linksState = router.state.matches.map((m) => m.links)
-    expect(linksState).toEqual([
-      [{ href: 'root.css' }, { href: 'root2.css' }],
-      [{ href: 'index.css' }],
-    ])
+    act(async () => {
+      render(<RouterProvider router={router} />)
+      const indexElem = await screen.findByText('Index')
+      expect(indexElem).toBeInTheDocument()
+
+      const linksState = router.state.matches.map((m) => m.links)
+      expect(linksState).toEqual([
+        [{ href: 'root.css' }, { href: 'root2.css' }],
+        [{ href: 'index.css' }],
+      ])
+    })
   })
 })

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -959,7 +959,7 @@ type AssetFnContextOptions<
     TLoaderDeps
   >
   params: ResolveAllParamsFromParent<TParentRoute, TParams>
-  loaderData: ResolveLoaderData<TLoaderFn>
+  loaderData?: ResolveLoaderData<TLoaderFn>
 }
 
 export interface DefaultUpdatableRouteOptionsExtensions {
@@ -1069,9 +1069,20 @@ export interface UpdatableRouteOptions<
       TLoaderDeps
     >,
   ) => void
-  headers?: (ctx: {
-    loaderData: ResolveLoaderData<TLoaderFn>
-  }) => Record<string, string>
+  headers?: (
+    ctx: AssetFnContextOptions<
+      TRouteId,
+      TFullPath,
+      TParentRoute,
+      TParams,
+      TSearchValidator,
+      TLoaderFn,
+      TRouterContext,
+      TRouteContextFn,
+      TBeforeLoadFn,
+      TLoaderDeps
+    >,
+  ) => Record<string, string>
   head?: (
     ctx: AssetFnContextOptions<
       TRouteId,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1443,7 +1443,7 @@ export class RouterCore<
       // If it's already a success, update headers and head content
       // These may get updated again if the match is refreshed
       // due to being stale
-      if (match.status === 'success') {
+      if (match.status === 'success' || match.status === 'notFound') {
         match.headers = route.options.headers?.({
           loaderData: match.loaderData,
         })

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1440,18 +1440,19 @@ export class RouterCore<
         }
       }
 
-      // If it's already a success or notFound, update headers and head content
+      // If the match status is already error, notFound or success, update headers and head content
       // These may get updated again if the match is refreshed
       // due to being stale
-      if (match.status === 'success' || match.status === 'notFound') {
+      if (['error', 'notFound', 'success'].includes(match.status)) {
+        const { loaderData } = match
         match.headers = route.options.headers?.({
-          ...(match?.loaderData && { loaderData: match.loaderData }),
+          ...(loaderData && { loaderData }),
         })
         const assetContext = {
           matches,
           match,
           params: match.params,
-          loaderData: match.loaderData,
+          ...(loaderData && { loaderData }),
         }
         const headFnContent = route.options.head?.(assetContext)
         match.links = headFnContent?.links

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1444,16 +1444,13 @@ export class RouterCore<
       // These may get updated again if the match is refreshed
       // due to being stale
       if (['error', 'notFound', 'success'].includes(match.status)) {
-        const { loaderData } = match
-        match.headers = route.options.headers?.({
-          ...(loaderData && { loaderData }),
-        })
         const assetContext = {
           matches,
           match,
           params: match.params,
-          ...(loaderData && { loaderData }),
+          loaderData: match.loaderData,
         }
+        match.headers = route.options.headers?.(assetContext)
         const headFnContent = route.options.head?.(assetContext)
         match.links = headFnContent?.links
         match.headScripts = headFnContent?.scripts
@@ -2644,9 +2641,7 @@ export class RouterCore<
                           const headScripts = headFnContent?.scripts
 
                           const scripts = route.options.scripts?.(assetContext)
-                          const headers = route.options.headers?.({
-                            loaderData,
-                          })
+                          const headers = route.options.headers?.(assetContext)
 
                           updateMatch(matchId, (prev) => ({
                             ...prev,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1440,12 +1440,12 @@ export class RouterCore<
         }
       }
 
-      // If it's already a success, update headers and head content
+      // If it's already a success or notFound, update headers and head content
       // These may get updated again if the match is refreshed
       // due to being stale
       if (match.status === 'success' || match.status === 'notFound') {
         match.headers = route.options.headers?.({
-          loaderData: match.loaderData,
+          ...(match?.loaderData && { loaderData: match.loaderData }),
         })
         const assetContext = {
           matches,

--- a/packages/solid-router/tests/route.test.tsx
+++ b/packages/solid-router/tests/route.test.tsx
@@ -7,6 +7,7 @@ import {
   createRoute,
   createRouter,
   getRouteApi,
+  notFound
 } from '../src'
 
 afterEach(() => {
@@ -250,6 +251,46 @@ describe('route.head', () => {
       }),
       loader: async () => {
         await new Promise((resolve) => setTimeout(resolve, 200))
+      },
+      component: () => <div>Index</div>,
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree })
+    render(() => <RouterProvider router={router} />)
+    const indexElem = await screen.findByText('Index')
+    expect(indexElem).toBeInTheDocument()
+
+    const metaState = router.state.matches.map((m) => m.meta)
+    expect(metaState).toEqual([
+      [
+        { title: 'Root' },
+        {
+          charSet: 'utf-8',
+        },
+      ],
+      [{ title: 'Index' }],
+    ])
+  })
+
+  test('meta returned when loader throws notFound', async () => {
+    const rootRoute = createRootRoute({
+      head: () => ({
+        meta: [
+          { title: 'Root' },
+          {
+            charSet: 'utf-8',
+          },
+        ],
+      }),
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      head: () => ({
+        meta: [{ title: 'Index' }],
+      }),
+      loader: async () => {
+        throw notFound()
       },
       component: () => <div>Index</div>,
     })

--- a/packages/solid-router/tests/route.test.tsx
+++ b/packages/solid-router/tests/route.test.tsx
@@ -7,7 +7,7 @@ import {
   createRoute,
   createRouter,
   getRouteApi,
-  notFound
+  notFound,
 } from '../src'
 
 afterEach(() => {
@@ -272,7 +272,7 @@ describe('route.head', () => {
     ])
   })
 
-  test('meta returned when loader throws notFound', async () => {
+  test.skip('meta returned when loader throws notFound', async () => {
     const rootRoute = createRootRoute({
       head: () => ({
         meta: [
@@ -297,8 +297,47 @@ describe('route.head', () => {
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
     render(() => <RouterProvider router={router} />)
-    const indexElem = await screen.findByText('Index')
-    expect(indexElem).toBeInTheDocument()
+    expect(await screen.findByText('Not Found')).toBeInTheDocument()
+
+    const metaState = router.state.matches.map((m) => m.meta)
+    expect(metaState).toEqual([
+      [
+        { title: 'Root' },
+        {
+          charSet: 'utf-8',
+        },
+      ],
+      [{ title: 'Index' }],
+    ])
+  })
+
+  test.skip('meta returned when loader throws an error', async () => {
+    const rootRoute = createRootRoute({
+      head: () => ({
+        meta: [
+          { title: 'Root' },
+          {
+            charSet: 'utf-8',
+          },
+        ],
+      }),
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      head: () => ({
+        meta: [{ title: 'Index' }],
+      }),
+      loader: async () => {
+        throw new Error('Fly, you fools!')
+      },
+      component: () => <div>Index</div>,
+      errorComponent: () => <div>Fly, you fools!</div>,
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree })
+    render(() => <RouterProvider router={router} />)
+    expect(await screen.findByText('Fly, you fools!')).toBeInTheDocument()
 
     const metaState = router.state.matches.map((m) => m.meta)
     expect(metaState).toEqual([

--- a/packages/solid-router/tests/route.test.tsx
+++ b/packages/solid-router/tests/route.test.tsx
@@ -272,7 +272,7 @@ describe('route.head', () => {
     ])
   })
 
-  test.skip('meta returned when loader throws notFound', async () => {
+  test('meta returned when loader throws notFound', async () => {
     const rootRoute = createRootRoute({
       head: () => ({
         meta: [
@@ -296,8 +296,11 @@ describe('route.head', () => {
     })
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = createRouter({ routeTree })
+
     render(() => <RouterProvider router={router} />)
     expect(await screen.findByText('Not Found')).toBeInTheDocument()
+
+    await router.load()
 
     const metaState = router.state.matches.map((m) => m.meta)
     expect(metaState).toEqual([
@@ -311,7 +314,7 @@ describe('route.head', () => {
     ])
   })
 
-  test.skip('meta returned when loader throws an error', async () => {
+  test('meta returned when loader throws an error', async () => {
     const rootRoute = createRootRoute({
       head: () => ({
         meta: [
@@ -338,6 +341,8 @@ describe('route.head', () => {
     const router = createRouter({ routeTree })
     render(() => <RouterProvider router={router} />)
     expect(await screen.findByText('Fly, you fools!')).toBeInTheDocument()
+
+    await router.load()
 
     const metaState = router.state.matches.map((m) => m.meta)
     expect(metaState).toEqual([


### PR DESCRIPTION
Fixes #3657

Updates the match `meta`, `links`, `script` etc. if  in case of `match.status` being `notFound` or an error.