### PR TITLE
chore(examples): dont watch sqlite file

### DIFF
--- a/examples/react/start-basic-auth/app.config.ts
+++ b/examples/react/start-basic-auth/app.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
       tsConfigPaths({
         projects: ['./tsconfig.json'],
       }),
+      {
+        name: 'dont-watch-sqlite-file',
+        handleHotUpdate({ file }) {
+          if (file.endsWith('.db')) {
+            return []
+          }
+        },
+      },
     ],
   },
 })


### PR DESCRIPTION
Fixes a bug in `start-basic-auth` where sqlite updates inside a serverFunction will cause vite to do a full page reload

![image](https://github.com/user-attachments/assets/43b92bb2-da17-4443-9b5b-2d83bdf6e0b8)
