### PR TITLE
fix(router-core, start-client-core): Additional types to help with types in `head` and warning in dev if unexpected keys provided.

### DIFF
--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -116,7 +116,7 @@ export { encode, decode } from './qss'
 export { rootRouteId } from './root'
 export type { RootRouteId } from './root'
 
-export { BaseRoute, BaseRouteApi, BaseRootRoute } from './route'
+export { BaseRoute, BaseRouteApi, BaseRootRoute, routeOptionsHeadUnexpectedKeysWarning } from './route'
 export type {
   AnyPathParams,
   SearchSchemaInput,

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -116,7 +116,12 @@ export { encode, decode } from './qss'
 export { rootRouteId } from './root'
 export type { RootRouteId } from './root'
 
-export { BaseRoute, BaseRouteApi, BaseRootRoute, routeOptionsHeadUnexpectedKeysWarning } from './route'
+export {
+  BaseRoute,
+  BaseRouteApi,
+  BaseRootRoute,
+  routeOptionsHeadUnexpectedKeysWarning,
+} from './route'
 export type {
   AnyPathParams,
   SearchSchemaInput,

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1683,18 +1683,27 @@ export class BaseRootRoute<
 export function routeOptionsHeadUnexpectedKeysWarning(result: unknown): void {
   if (process.env.NODE_ENV === 'development') {
     const keys = Object.keys(result as HeadResult)
-    const unexpectedKeys = keys.filter(key => !headExpectedKeys.includes(key as HeadExpectedKey))
+    const unexpectedKeys = keys.filter(
+      (key) => !headExpectedKeys.includes(key as HeadExpectedKey),
+    )
 
     if (unexpectedKeys.length === 0) {
       return
     }
 
-    console.warn(`Route head option result has unexpected keys: "${unexpectedKeys.join('", "')}".`, 'Only "links", "scripts", and "meta" are allowed');
+    console.warn(
+      `Route head option result has unexpected keys: "${unexpectedKeys.join('", "')}".`,
+      'Only "links", "scripts", and "meta" are allowed',
+    )
   }
 }
 
 type HeadExpectedKey = keyof Required<HeadResult>
-const headExpectedKeys = ['links', 'scripts', 'meta'] satisfies Array<HeadExpectedKey>
+const headExpectedKeys = [
+  'links',
+  'scripts',
+  'meta',
+] satisfies Array<HeadExpectedKey>
 
 type HeadResult = {
   links?: AnyRouteMatch['links']

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -26,6 +26,7 @@ import {
 } from './path'
 import { isNotFound } from './not-found'
 import { setupScrollRestoration } from './scroll-restoration'
+import { routeOptionsHeadUnexpectedKeysWarning } from './route'
 import { defaultParseSearch, defaultStringifySearch } from './searchParams'
 import { rootRouteId } from './root'
 import { isRedirect, isResolvedRedirect } from './redirect'
@@ -2602,6 +2603,8 @@ export class RouterCore<
                         loaderData: match.loaderData,
                       }
                       const headFnContent = route.options.head?.(assetContext)
+                      routeOptionsHeadUnexpectedKeysWarning(headFnContent)
+
                       const meta = headFnContent?.meta
                       const links = headFnContent?.links
                       const headScripts = headFnContent?.scripts

--- a/packages/router-core/tests/route.test.ts
+++ b/packages/router-core/tests/route.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { routeOptionsHeadUnexpectedKeysWarning } from '../src/route'
+
+describe('routeOptionsHeadUnexpectedKeysWarning', () => {
+  const originalEnv = process.env.NODE_ENV
+  const originalWarn = console.warn
+
+  beforeEach(() => {
+    console.warn = vi.fn()
+  })
+
+  afterEach(() => {
+    console.warn = originalWarn
+    process.env.NODE_ENV = originalEnv
+  })
+
+  it('should not warn when all keys are valid', () => {
+    process.env.NODE_ENV = 'development'
+    const validResult = {
+      links: [],
+      scripts: [],
+      meta: []
+    }
+
+    routeOptionsHeadUnexpectedKeysWarning(validResult)
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should warn when there are unexpected keys', () => {
+    process.env.NODE_ENV = 'development'
+    const invalidResult = {
+      links: [],
+      scripts: [],
+      meta: [],
+      unexpectedKey: 'value'
+    }
+
+    routeOptionsHeadUnexpectedKeysWarning(invalidResult)
+    expect(console.warn).toHaveBeenCalledWith(
+      'Route head option result has unexpected keys: "unexpectedKey".',
+      'Only "links", "scripts", and "meta" are allowed'
+    )
+  })
+
+  it('should not warn in production environment', () => {
+    process.env.NODE_ENV = 'production'
+    const invalidResult = {
+      links: [],
+      scripts: [],
+      meta: [],
+      unexpectedKey: 'value'
+    }
+
+    routeOptionsHeadUnexpectedKeysWarning(invalidResult)
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should not warn when missing expected keys', () => {
+    process.env.NODE_ENV = 'development'
+    const partialResult = {
+      links: []
+      // missing scripts and meta
+    }
+
+    routeOptionsHeadUnexpectedKeysWarning(partialResult)
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should warn when all keys are unexpected', () => {
+    process.env.NODE_ENV = 'development'
+    const allInvalidResult = {
+      invalidKey1: 'value1',
+      invalidKey2: 'value2'
+    } as any
+
+    routeOptionsHeadUnexpectedKeysWarning(allInvalidResult)
+    expect(console.warn).toHaveBeenCalledWith(
+      'Route head option result has unexpected keys: "invalidKey1", "invalidKey2".',
+      'Only "links", "scripts", and "meta" are allowed'
+    )
+  })
+}) 

--- a/packages/router-core/tests/route.test.ts
+++ b/packages/router-core/tests/route.test.ts
@@ -19,7 +19,7 @@ describe('routeOptionsHeadUnexpectedKeysWarning', () => {
     const validResult = {
       links: [],
       scripts: [],
-      meta: []
+      meta: [],
     }
 
     routeOptionsHeadUnexpectedKeysWarning(validResult)
@@ -32,13 +32,13 @@ describe('routeOptionsHeadUnexpectedKeysWarning', () => {
       links: [],
       scripts: [],
       meta: [],
-      unexpectedKey: 'value'
+      unexpectedKey: 'value',
     }
 
     routeOptionsHeadUnexpectedKeysWarning(invalidResult)
     expect(console.warn).toHaveBeenCalledWith(
       'Route head option result has unexpected keys: "unexpectedKey".',
-      'Only "links", "scripts", and "meta" are allowed'
+      'Only "links", "scripts", and "meta" are allowed',
     )
   })
 
@@ -48,7 +48,7 @@ describe('routeOptionsHeadUnexpectedKeysWarning', () => {
       links: [],
       scripts: [],
       meta: [],
-      unexpectedKey: 'value'
+      unexpectedKey: 'value',
     }
 
     routeOptionsHeadUnexpectedKeysWarning(invalidResult)
@@ -58,7 +58,7 @@ describe('routeOptionsHeadUnexpectedKeysWarning', () => {
   it('should not warn when missing expected keys', () => {
     process.env.NODE_ENV = 'development'
     const partialResult = {
-      links: []
+      links: [],
       // missing scripts and meta
     }
 
@@ -70,13 +70,13 @@ describe('routeOptionsHeadUnexpectedKeysWarning', () => {
     process.env.NODE_ENV = 'development'
     const allInvalidResult = {
       invalidKey1: 'value1',
-      invalidKey2: 'value2'
+      invalidKey2: 'value2',
     } as any
 
     routeOptionsHeadUnexpectedKeysWarning(allInvalidResult)
     expect(console.warn).toHaveBeenCalledWith(
       'Route head option result has unexpected keys: "invalidKey1", "invalidKey2".',
-      'Only "links", "scripts", and "meta" are allowed'
+      'Only "links", "scripts", and "meta" are allowed',
     )
   })
-}) 
+})

--- a/packages/start-client-core/src/ssr-client.tsx
+++ b/packages/start-client-core/src/ssr-client.tsx
@@ -154,7 +154,7 @@ export function hydrate(router: AnyRouter) {
       }
 
       // Handle extracted
-      ; (match as unknown as SsrMatch).extracted?.forEach((ex) => {
+      ;(match as unknown as SsrMatch).extracted?.forEach((ex) => {
         deepMutableSetByPath(match, ['loaderData', ...ex.path], ex.value)
       })
     } else {
@@ -232,7 +232,7 @@ export function hydrate(router: AnyRouter) {
 function deepMutableSetByPath<T>(obj: T, path: Array<string>, value: any) {
   // mutable set by path retaining array and object references
   if (path.length === 1) {
-    ; (obj as any)[path[0]!] = value
+    ;(obj as any)[path[0]!] = value
   }
 
   const [key, ...rest] = path

--- a/packages/start-client-core/src/ssr-client.tsx
+++ b/packages/start-client-core/src/ssr-client.tsx
@@ -10,6 +10,7 @@ import type {
   MakeRouteMatch,
   Manifest,
   RouteContextOptions,
+  routeOptionsHeadUnexpectedKeysWarning,
 } from '@tanstack/router-core'
 
 declare global {
@@ -153,7 +154,7 @@ export function hydrate(router: AnyRouter) {
       }
 
       // Handle extracted
-      ;(match as unknown as SsrMatch).extracted?.forEach((ex) => {
+      ; (match as unknown as SsrMatch).extracted?.forEach((ex) => {
         deepMutableSetByPath(match, ['loaderData', ...ex.path], ex.value)
       })
     } else {
@@ -215,6 +216,7 @@ export function hydrate(router: AnyRouter) {
       loaderData: match.loaderData,
     }
     const headFnContent = route.options.head?.(assetContext)
+    routeOptionsHeadUnexpectedKeysWarning(headFnContent)
 
     const scripts = route.options.scripts?.(assetContext)
 
@@ -230,7 +232,7 @@ export function hydrate(router: AnyRouter) {
 function deepMutableSetByPath<T>(obj: T, path: Array<string>, value: any) {
   // mutable set by path retaining array and object references
   if (path.length === 1) {
-    ;(obj as any)[path[0]!] = value
+    ; (obj as any)[path[0]!] = value
   }
 
   const [key, ...rest] = path


### PR DESCRIPTION
This is an attempt to provide some feedback to the developer if they provide unexpected keys to the head property.

source: https://discord.com/channels/719702312431386674/1372533009563258880

FYI if someone knows how to enforce the shape for a function like this without having super complex generics I'm all for it.