### PR TITLE
fix: handle deferred loading promise rejections properly

### DIFF
--- a/packages/start-client-core/src/ssr-client.tsx
+++ b/packages/start-client-core/src/ssr-client.tsx
@@ -35,6 +35,15 @@ export interface StartSsrGlobal {
     id: number
     promiseState: DeferredPromiseState<any>
   }) => void
+  rejectPromise: (opts: {
+    matchId: string
+    id: number
+    error: {
+      message: string
+      stack?: string
+      name: string
+    }
+  }) => void
   injectChunk: (opts: { matchId: string; id: number; chunk: string }) => void
   closeStream: (opts: { matchId: string; id: number }) => void
 }

--- a/packages/start-server-core/src/tsrScript.ts
+++ b/packages/start-server-core/src/tsrScript.ts
@@ -58,6 +58,23 @@ const __TSR_SSR__: StartSsrGlobal = {
     }
     return false
   },
+  rejectPromise: ({ matchId, id, error }) => {
+    const match = __TSR_SSR__.matches.find((m) => m.id === matchId)
+    if (match) {
+      const ex = match.extracted?.[id]
+      if (ex && ex.type === 'promise' && ex.value) {
+        // Rebuild the error object and pass it to the client
+        const reconstructedError = new Error(error.message)
+        reconstructedError.name = error.name
+        if (error.stack) {
+          reconstructedError.stack = error.stack
+        }
+        ex.value.reject(reconstructedError)
+        return true
+      }
+    }
+    return false
+  },
   injectChunk: ({ matchId, id, chunk }) => {
     const match = __TSR_SSR__.matches.find((m) => m.id === matchId)
 


### PR DESCRIPTION
TanStack Start had an issue where rejected deferred promises would crash the server and errors wouldn't propagate to the client, preventing React Error Boundaries from working properly.

#4084 