### PR TITLE
Fix/auto code splitting option

### DIFF
--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -4,12 +4,9 @@ import { z } from 'zod'
 import { configSchema, getConfig } from '@tanstack/router-generator'
 import type { NitroConfig } from 'nitropack'
 
-const tsrConfig = configSchema
-  // .omit({ autoCodeSplitting: true })
-  .partial()
-  .extend({
-    srcDirectory: z.string().optional().default('src'),
-  })
+const tsrConfig = configSchema.partial().extend({
+  srcDirectory: z.string().optional().default('src'),
+})
 
 export function createTanStackConfig<
   TFrameworkPlugin extends Record<string, unknown>,


### PR DESCRIPTION
Using `autoCodeSplitting` option in tsr block of vite config, raises a type error. When using is in experimental mode via `experimental.enableCodeSplitting` fails with the following build error:

```
$ vite build

------
⚠️ ⚠️ ⚠️
ERROR: The "experimental.enableCodeSplitting" flag has been made stable and is now "autoCodeSplitting". Please update your configuration file to use "autoCodeSplitting" instead of "experimental.enableCodeSplitting".
------

failed to load config from /Users/hackeronepro/Work/repo/vite.config.ts
error during build:
Error: 
------
⚠️ ⚠️ ⚠️
ERROR: The "experimental.enableCodeSplitting" flag has been made stable and is now "autoCodeSplitting". Please update your configuration file to use "autoCodeSplitting" instead of "experimental.enableCodeSplitting".
------
```

This PR would fixes two things:
-  Using `autoCodeSplitting` in tsr block no longer shows a type error (`experimental.enableCodeSplitting` is now made stable and is available via `autoCodeSplitting`).
- Fixes the build errors.

**Quick Fix:** Just use autoCodeSplitting option and use `// @ts-expect-error` for now.

```
export default defineConfig({
  server: {
    port: 3000,
  },
  plugins: [
    tsConfigPaths({
      projects: ['./tsconfig.json'],
    }),
    tanstackStart({
      tsr: {
        // @ts-expect-error - autoCodeSplitting is not typed
        autoCodeSplitting: true
      }
    }),
  ],
})
```

