### PR TITLE
fix: export RedirectOptions type

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -203,6 +203,7 @@ export type {
   UseNavigateResult,
   AnyRedirect,
   Redirect,
+  RedirectOptions,
   ResolvedRedirect,
   MakeRouteMatch,
   MakeRouteMatchUnion,

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -372,7 +372,12 @@ export type { UseLoaderDepsResult, ResolveUseLoaderDeps } from './useLoaderDeps'
 
 export type { UseLoaderDataResult, ResolveUseLoaderData } from './useLoaderData'
 
-export type { Redirect, ResolvedRedirect, AnyRedirect } from './redirect'
+export type {
+  Redirect,
+  RedirectOptions,
+  ResolvedRedirect,
+  AnyRedirect,
+} from './redirect'
 
 export {
   redirect,

--- a/packages/solid-router/src/index.tsx
+++ b/packages/solid-router/src/index.tsx
@@ -167,6 +167,7 @@ export type {
   UseNavigateResult,
   AnyRedirect,
   Redirect,
+  RedirectOptions,
   ResolvedRedirect,
   RouteOptions,
   FileBaseRouteOptions,


### PR DESCRIPTION
RedirectOptions type recently introduced but missing exports from index.