### PR TITLE
examples: remove unnecessary awaits in start-supabase-basic example

### DIFF
--- a/examples/react/start-supabase-basic/src/routes/__root.tsx
+++ b/examples/react/start-supabase-basic/src/routes/__root.tsx
@@ -16,7 +16,7 @@ import { seo } from '../utils/seo'
 import { getSupabaseServerClient } from '../utils/supabase'
 
 const fetchUser = createServerFn({ method: 'GET' }).handler(async () => {
-  const supabase = await getSupabaseServerClient()
+  const supabase = getSupabaseServerClient()
   const { data, error: _error } = await supabase.auth.getUser()
 
   if (!data.user?.email) {

--- a/examples/react/start-supabase-basic/src/routes/_authed.tsx
+++ b/examples/react/start-supabase-basic/src/routes/_authed.tsx
@@ -6,7 +6,7 @@ import { getSupabaseServerClient } from '../utils/supabase'
 export const loginFn = createServerFn({ method: 'POST' })
   .validator((d: { email: string; password: string }) => d)
   .handler(async ({ data }) => {
-    const supabase = await getSupabaseServerClient()
+    const supabase = getSupabaseServerClient()
     const { error } = await supabase.auth.signInWithPassword({
       email: data.email,
       password: data.password,

--- a/examples/react/start-supabase-basic/src/routes/logout.tsx
+++ b/examples/react/start-supabase-basic/src/routes/logout.tsx
@@ -3,7 +3,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { getSupabaseServerClient } from '../utils/supabase'
 
 const logoutFn = createServerFn().handler(async () => {
-  const supabase = await getSupabaseServerClient()
+  const supabase = getSupabaseServerClient()
   const { error } = await supabase.auth.signOut()
 
   if (error) {

--- a/examples/react/start-supabase-basic/src/routes/signup.tsx
+++ b/examples/react/start-supabase-basic/src/routes/signup.tsx
@@ -9,7 +9,7 @@ export const signupFn = createServerFn({ method: 'POST' })
     (d: { email: string; password: string; redirectUrl?: string }) => d,
   )
   .handler(async ({ data }) => {
-    const supabase = await getSupabaseServerClient()
+    const supabase = getSupabaseServerClient()
     const { error } = await supabase.auth.signUp({
       email: data.email,
       password: data.password,


### PR DESCRIPTION
Function `getSupabaseServerClient` isn't async and doesn't return a `Promise`.