### PR TITLE
fix: fix  SSR page on the React Start docs returns 404.

### DIFF
--- a/docs/start/config.json
+++ b/docs/start/config.json
@@ -50,10 +50,6 @@
               "to": "framework/react/server-routes"
             },
             {
-              "label": "SSR",
-              "to": "framework/react/ssr"
-            },
-            {
               "label": "SPA Mode",
               "to": "framework/react/spa-mode"
             },
@@ -125,10 +121,6 @@
             {
               "label": "Server Routes",
               "to": "framework/solid/server-routes"
-            },
-            {
-              "label": "SSR",
-              "to": "framework/solid/ssr"
             },
             {
               "label": "SPA Mode",


### PR DESCRIPTION
As I said in https://github.com/TanStack/router/issues/4454 
> The problem is happened in https://github.com/TanStack/router/commit/15b8ed6af384f6748c6a1179c8ad933adaccb4d4 commit, when developer deleted [docs/start/framework/react/ssr.md](https://github.com/TanStack/router/commit/15b8ed6af384f6748c6a1179c8ad933adaccb4d4#diff-3cc9f8b386fa1ebaf8d16c9368b3c3c6d1c71ad8e08db7d7ed245ac3619ee0a7), they forgot to cleanup this in docs config, which located [here](https://github.com/TanStack/router/blob/main/docs/start/config.json).
>
>BTW, this also happen on solid version of ssr.md.
>....

This is a PR fixing this issue by delete reference in docs config.