### PR TITLE
feat(router-core) path: pre-compile encodePathParam during router initialization

### DIFF
--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  compileEncodePathParam,
   exactPathTest,
   interpolatePath,
   matchPathname,
@@ -390,9 +391,7 @@ describe('interpolatePath', () => {
         path: '/users/$id',
         params: { id: '?#@john+smith' },
         result: '/users/%3F%23@john+smith',
-        decodeCharMap: new Map(
-          ['@', '+'].map((char) => [encodeURIComponent(char), char]),
-        ),
+        encodePathParam: compileEncodePathParam(['@', '+']),
       },
       {
         name: 'should interpolate the path with the splat param at the end',
@@ -429,12 +428,12 @@ describe('interpolatePath', () => {
         params: { _splat: 'sean/cassiere' },
         result: '/users/sean/cassiere',
       },
-    ])('$name', ({ path, params, decodeCharMap, result }) => {
+    ])('$name', ({ path, params, encodePathParam, result }) => {
       expect(
         interpolatePath({
           path,
           params,
-          decodeCharMap,
+          encodePathParam,
         }).interpolatedPath,
       ).toBe(result)
     })

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -163,7 +163,7 @@ function RouteComp({
       params: allParams,
       leaveWildcards: false,
       leaveParams: false,
-      decodeCharMap: router().pathParamsDecodeCharMap,
+      encodePathParam: router().encodePathParam,
     })
 
     // only if `interpolated` is not missing params, return the path since this


### PR DESCRIPTION
When NOT using the `pathParamsAllowedCharacters` option, this implementation is identical to the previous one. Both simply use `encodeURIComponent`. The bench comparison is a coin flip.
```
 ✓  @tanstack/router-core  tests/temp.bench.ts > compare with no replacements 2892ms
     name            hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · old   8,305,805.98  0.0000  0.0291  0.0001  0.0001  0.0002  0.0002  0.0002  ±0.03%  4152903
   · new   8,310,709.30  0.0000  0.0286  0.0001  0.0001  0.0002  0.0002  0.0002  ±0.04%  4155355   fastest
```

When using `pathParamsAllowedCharacters`, this implementation "pre-compiles" a `Function` during the router initialization. This makes it consistently faster. Though it's only a ~10% speed-up, this method is called *a lot*, so any gain is beneficial.
```
 ✓  @tanstack/router-core  tests/temp.bench.ts > compare with many replacements 1611ms
     name            hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · old   1,365,878.18  0.0006  1.1122  0.0007  0.0007  0.0010  0.0010  0.0018  ±0.55%   682940
   · new   1,500,735.70  0.0005  0.2715  0.0007  0.0007  0.0009  0.0009  0.0013  ±0.11%   750368   fastest
```

This is technically a **breaking change** because `interpolatePath` is part of the public API surface.