### PR TITLE
fix: fix start vite plugin during dev and prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,9 +68,6 @@
     "vite": "6.3.5",
     "vitest": "^3.0.6"
   },
-  "resolutions": {
-    "use-sync-external-store": "1.2.2"
-  },
   "pnpm": {
     "overrides": {
       "react": "$react",
@@ -81,7 +78,6 @@
       "vite": "$vite",
       "@playwright/test": "$@playwright/test",
       "@tanstack/react-query": "5.66.0",
-      "use-sync-external-store": "1.2.2",
       "@tanstack/history": "workspace:*",
       "@tanstack/router-core": "workspace:*",
       "@tanstack/react-router": "workspace:*",

--- a/packages/react-start-plugin/package.json
+++ b/packages/react-start-plugin/package.json
@@ -41,17 +41,12 @@
   },
   "type": "module",
   "types": "dist/esm/index.d.ts",
-  "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.cts",
-        "default": "./dist/cjs/index.cjs"
       }
     },
     "./package.json": "./package.json"
@@ -66,6 +61,7 @@
   },
   "dependencies": {
     "@tanstack/start-plugin-core": "workspace:*",
+    "pathe": "^2.0.3",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/packages/react-start-plugin/src/index.ts
+++ b/packages/react-start-plugin/src/index.ts
@@ -1,5 +1,7 @@
+import { fileURLToPath } from 'node:url'
 import viteReact from '@vitejs/plugin-react'
 import { TanStackStartVitePluginCore } from '@tanstack/start-plugin-core'
+import path from 'pathe'
 import { getTanStackStartOptions } from './schema'
 import type { TanStackStartInputConfig, WithReactPlugin } from './schema'
 import type { PluginOption } from 'vite'
@@ -26,7 +28,39 @@ export function TanStackStartVitePlugin(
     )
   }
 
+  const isInsideRouterMonoRepo = (() => {
+    const currentDir = path.dirname(fileURLToPath(import.meta.url))
+    return path.basename(path.resolve(currentDir, '../../../')) === 'packages'
+  })()
+
   return [
+    {
+      name: 'tanstack-react-start:config',
+      configEnvironment() {
+        return {
+          resolve: {
+            dedupe: ['react', 'react-dom', '@tanstack/react-router'],
+
+            external: isInsideRouterMonoRepo
+              ? ['@tanstack/react-router', '@tanstack/react-router-devtools']
+              : undefined,
+          },
+
+          optimizeDeps: {
+            exclude: ['@tanstack/react-router-devtools'],
+            include: [
+              'react',
+              'react/jsx-runtime',
+              'react/jsx-dev-runtime',
+              'react-dom',
+              'react-dom/client',
+              '@tanstack/react-router',
+              '@tanstack/react-store',
+            ],
+          },
+        }
+      },
+    },
     TanStackStartVitePluginCore(
       {
         framework: 'react',

--- a/packages/react-start-plugin/vite.config.ts
+++ b/packages/react-start-plugin/vite.config.ts
@@ -17,5 +17,6 @@ export default mergeConfig(
     entry: './src/index.ts',
     srcDir: './src',
     outDir: './dist',
+    cjs: false,
   }),
 )

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -126,23 +126,17 @@ export function TanStackStartVitePluginCore(
           },
           resolve: {
             noExternal: [
-              '@tanstack/start-client',
-              '@tanstack/start-client-core',
-              '@tanstack/start-server',
-              '@tanstack/start-server-core',
-              '@tanstack/start-server-functions-fetcher',
-              '@tanstack/start-server-functions-client',
-              '@tanstack/start-server-functions-server',
-              '@tanstack/start-router-manifest',
-              '@tanstack/start-config',
-              '@tanstack/server-functions-plugin',
-              'nitropack',
-              '@tanstack/**start**',
+              '@tanstack/start**',
+              `@tanstack/${opts.framework}-start**`,
               ...Object.values(VIRTUAL_MODULES),
             ],
+            dedupe: [`@tanstack/${opts.framework}-start`],
           },
           optimizeDeps: {
-            exclude: [...Object.values(VIRTUAL_MODULES)],
+            exclude: [
+              ...Object.values(VIRTUAL_MODULES),
+              `@tanstack/${opts.framework}-start`,
+            ],
           },
           /* prettier-ignore */
           define: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  use-sync-external-store: 1.2.2
   react: ^19.0.0
   react-dom: ^19.0.0
   '@types/react': ^19.0.8
@@ -6468,6 +6467,9 @@ importers:
       '@tanstack/start-plugin-core':
         specifier: workspace:*
         version: link:../start-plugin-core
+      pathe:
+        specifier: ^2.0.3
+        version: 2.0.3
       zod:
         specifier: ^3.24.2
         version: 3.25.57
@@ -15358,8 +15360,8 @@ packages:
       '@types/react':
         optional: true
 
-  use-sync-external-store@1.2.2:
-    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
     peerDependencies:
       react: ^19.0.0
 
@@ -19203,7 +19205,7 @@ snapshots:
       '@tanstack/store': 0.7.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      use-sync-external-store: 1.2.2(react@19.0.0)
+      use-sync-external-store: 1.5.0(react@19.0.0)
 
   '@tanstack/react-virtual@3.13.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -24312,7 +24314,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
       react: 19.0.0
-      use-sync-external-store: 1.2.2(react@19.0.0)
+      use-sync-external-store: 1.5.0(react@19.0.0)
 
   symbol-tree@3.2.4: {}
 
@@ -24773,7 +24775,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.8
 
-  use-sync-external-store@1.2.2(react@19.0.0):
+  use-sync-external-store@1.5.0(react@19.0.0):
     dependencies:
       react: 19.0.0
 


### PR DESCRIPTION
- ensure vite plugins execute on internal start packages
- dedupe start/router packages to ensure unique singletons
- do not pint use-sync-external-store to old version anymore since this version has ESM issues during dev
- build react-start-plugin only as ESM to make it easier to access file location via import.meta.url

fixes #4729
fixes #4409