### PR TITLE
docs(router): update links in how-to guides

### DIFF
--- a/docs/router/framework/react/how-to/arrays-objects-dates-search-params.md
+++ b/docs/router/framework/react/how-to/arrays-objects-dates-search-params.md
@@ -756,7 +756,7 @@ const onlyNeededData = Route.useSearch({
 
 ## Related Resources
 
-- [Search Params Guide](../guide/search-params.md) - Core concepts and JSON-first approach
+- [Search Params Guide](../../guide/search-params.md) - Core concepts and JSON-first approach
 - [Zod Documentation](https://zod.dev/) - Schema validation library
 - [MDN Date.toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) - Date serialization reference
 - [URLSearchParams Limits](https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers) - Browser URL length limits

--- a/docs/router/framework/react/how-to/debug-router-issues.md
+++ b/docs/router/framework/react/how-to/debug-router-issues.md
@@ -753,8 +753,8 @@ const route = createRoute({
 
 After debugging router issues, you might want to:
 
-- [How to Set Up Testing](./setup-testing.md) - Add tests to prevent regressions
-- [How to Deploy to Production](./deploy-to-production.md) - Ensure issues don't occur in production
+- [How to Set Up Testing](../setup-testing.md) - Add tests to prevent regressions
+- [How to Deploy to Production](../deploy-to-production.md) - Ensure issues don't occur in production
 
 <!-- TODO: Uncomment as guides are created
 - [How to Optimize Performance](./optimize-performance.md)

--- a/docs/router/framework/react/how-to/deploy-to-production.md
+++ b/docs/router/framework/react/how-to/deploy-to-production.md
@@ -434,9 +434,9 @@ Before deploying, ensure you have:
 
 After deployment, you might want to:
 
-- [How to Set Up Basic Authentication](./setup-authentication.md) - Secure your application with auth
-- [Migrate from React Router v7](./migrate-from-react-router.md) - Complete migration guide if you're coming from React Router
-- [How to Set Up Server-Side Rendering (SSR)](./setup-ssr.md)
+- [How to Set Up Basic Authentication](../setup-authentication.md) - Secure your application with auth
+- [Migrate from React Router v7](../migrate-from-react-router.md) - Complete migration guide if you're coming from React Router
+- [How to Set Up Server-Side Rendering (SSR)](../setup-ssr.md)
 
 <!-- TODO: Uncomment as how-to guides are created
 - [How to Optimize Performance](./optimize-performance.md)

--- a/docs/router/framework/react/how-to/migrate-from-react-router.md
+++ b/docs/router/framework/react/how-to/migrate-from-react-router.md
@@ -678,7 +678,7 @@ Before deploying your migrated application:
 1. TanStack Router has built-in SSR capabilities - use TanStack Start for full-stack applications
 2. Use TanStack Router's lazy routes for code splitting
 3. Configure SSR using TanStack Router's native APIs
-4. Follow the [SSR setup guide](./setup-ssr.md) for detailed instructions
+4. Follow the [SSR setup guide](../setup-ssr.md) for detailed instructions
 
 ### Routes Not Matching
 
@@ -737,8 +737,8 @@ After successfully migrating to TanStack Router, consider these enhancements:
 ## Related Resources
 
 - [TanStack Router Documentation](https://tanstack.com/router) - Complete API reference
-- [File-Based Routing Guide](../routing/file-based-routing.md) - Detailed routing concepts
-- [Navigation Guide](../guide/navigation.md) - Complete navigation patterns
-- [Search Parameters Guide](../guide/search-params.md) - Advanced search param usage
-- [Type Safety Guide](../guide/type-safety.md) - TypeScript integration details
+- [File-Based Routing Guide](../../routing/file-based-routing.md) - Detailed routing concepts
+- [Navigation Guide](../../guide/navigation.md) - Complete navigation patterns
+- [Search Parameters Guide](../../guide/search-params.md) - Advanced search param usage
+- [Type Safety Guide](../../guide/type-safety.md) - TypeScript integration details
 - [React Router v7 Changelog](https://reactrouter.com/start/changelog) - What changed in v7

--- a/docs/router/framework/react/how-to/navigate-with-search-params.md
+++ b/docs/router/framework/react/how-to/navigate-with-search-params.md
@@ -4,7 +4,7 @@ title: How to Navigate with Search Parameters
 
 This guide covers updating and managing search parameters during navigation using TanStack Router's Link components and programmatic navigation methods.
 
-**Prerequisites:** [Set Up Basic Search Parameters](./setup-basic-search-params.md) - Foundation concepts for reading and validating search params.
+**Prerequisites:** [Set Up Basic Search Parameters](../setup-basic-search-params.md) - Foundation concepts for reading and validating search params.
 
 ## Quick Start
 
@@ -333,8 +333,8 @@ function ConditionalNavigation() {
 
 After mastering navigation with search parameters, you might want to:
 
-- [Validate Search Parameters with Schemas](./validate-search-params.md) - Add robust validation with Zod, Valibot, or ArkType
-- [Work with Arrays, Objects, and Dates](./arrays-objects-dates-search-params.md) - Handle arrays, objects, dates, and nested data structures
+- [Validate Search Parameters with Schemas](../validate-search-params.md) - Add robust validation with Zod, Valibot, or ArkType
+- [Work with Arrays, Objects, and Dates](../arrays-objects-dates-search-params.md) - Handle arrays, objects, dates, and nested data structures
 
 <!-- Uncomment when guides are available
 - [Share Search Parameters Across Routes](./share-search-params-across-routes.md) - Inherit and manage search params across route hierarchies

--- a/docs/router/framework/react/how-to/setup-auth-providers.md
+++ b/docs/router/framework/react/how-to/setup-auth-providers.md
@@ -619,8 +619,8 @@ export const Route = createFileRoute('/_authenticated')({
 
 After integrating authentication providers, you might want to:
 
-- [How to Set Up Role-Based Access Control](./setup-rbac.md) - Add permission-based routing
-- [How to Set Up Basic Authentication](./setup-authentication.md) - Custom auth implementation
+- [How to Set Up Role-Based Access Control](../setup-rbac.md) - Add permission-based routing
+- [How to Set Up Basic Authentication](../setup-authentication.md) - Custom auth implementation
 
 <!-- TODO: Uncomment as how-to guides are created
 - [How to Handle User Sessions](./handle-user-sessions.md)

--- a/docs/router/framework/react/how-to/setup-authentication.md
+++ b/docs/router/framework/react/how-to/setup-authentication.md
@@ -470,8 +470,8 @@ export const Route = createFileRoute('/_authenticated/dashboard')({
 
 After setting up basic authentication, you might want to:
 
-- [How to Integrate Authentication Providers](./setup-auth-providers.md) - Use Auth0, Clerk, or Supabase
-- [How to Set Up Role-Based Access Control](./setup-rbac.md) - Add permission-based routing
+- [How to Integrate Authentication Providers](../setup-auth-providers.md) - Use Auth0, Clerk, or Supabase
+- [How to Set Up Role-Based Access Control](../setup-rbac.md) - Add permission-based routing
 
 <!-- TODO: Uncomment as how-to guides are created
 - [How to Handle User Sessions](./handle-user-sessions.md)
@@ -480,6 +480,6 @@ After setting up basic authentication, you might want to:
 
 ## Related Resources
 
-- [Authenticated Routes Guide](../guide/authenticated-routes.md) - Detailed conceptual guide
-- [Router Context Guide](../guide/router-context.md) - Understanding context in TanStack Router
+- [Authenticated Routes Guide](../../guide/authenticated-routes.md) - Detailed conceptual guide
+- [Router Context Guide](../../guide/router-context.md) - Understanding context in TanStack Router
 - [Authentication Examples](https://github.com/TanStack/router/tree/main/examples/react/authenticated-routes) - Complete working examples

--- a/docs/router/framework/react/how-to/setup-basic-search-params.md
+++ b/docs/router/framework/react/how-to/setup-basic-search-params.md
@@ -71,7 +71,7 @@ export const Route = createFileRoute('/products')({
 })
 ```
 
-**For detailed validation library comparisons and advanced validation patterns, see:** [Validate Search Parameters with Schemas](./validate-search-params.md)
+**For detailed validation library comparisons and advanced validation patterns, see:** [Validate Search Parameters with Schemas](../validate-search-params.md)
 
 ## Step-by-Step Setup with Zod
 
@@ -414,9 +414,9 @@ const schema = z.object({
 
 After setting up basic search parameters, you might want to:
 
-- [Validate Search Parameters with Schemas](./validate-search-params.md) - Add robust validation with Zod, Valibot, or ArkType
-- [Navigate with Search Parameters](./navigate-with-search-params.md) - Learn to update search params with Links and navigation
-- [Work with Arrays, Objects, and Dates](./arrays-objects-dates-search-params.md) - Handle arrays, objects, dates, and nested data structures
+- [Validate Search Parameters with Schemas](../validate-search-params.md) - Add robust validation with Zod, Valibot, or ArkType
+- [Navigate with Search Parameters](../navigate-with-search-params.md) - Learn to update search params with Links and navigation
+- [Work with Arrays, Objects, and Dates](../arrays-objects-dates-search-params.md) - Handle arrays, objects, dates, and nested data structures
 
 ## Related Resources
 
@@ -427,5 +427,5 @@ After setting up basic search parameters, you might want to:
 - **TanStack Router:**
   - [TanStack Zod Adapter](https://tanstack.com/router/latest/docs/framework/react/api/router/zodValidator) - Official Zod adapter
   - [TanStack Valibot Adapter](https://tanstack.com/router/latest/docs/framework/react/api/router/valibotValidator) - Official Valibot adapter
-  - [Search Parameters Guide](../guide/search-params.md) - Comprehensive search parameters documentation
-  - [Type Safety Guide](../guide/type-safety.md) - Understanding TanStack Router's type safety
+  - [Search Parameters Guide](../../guide/search-params.md) - Comprehensive search parameters documentation
+  - [Type Safety Guide](../../guide/type-safety.md) - Understanding TanStack Router's type safety

--- a/docs/router/framework/react/how-to/setup-rbac.md
+++ b/docs/router/framework/react/how-to/setup-rbac.md
@@ -723,8 +723,8 @@ function usePermissions() {
 
 After setting up RBAC, you might want to:
 
-- [How to Set Up Basic Authentication](./setup-authentication.md) - Core auth implementation
-- [How to Integrate Authentication Providers](./setup-auth-providers.md) - Use external auth services
+- [How to Set Up Basic Authentication](../setup-authentication.md) - Core auth implementation
+- [How to Integrate Authentication Providers](../setup-auth-providers.md) - Use external auth services
 
 <!-- TODO: Uncomment as how-to guides are created
 - [How to Implement Dynamic Permissions](./setup-dynamic-permissions.md)
@@ -733,6 +733,6 @@ After setting up RBAC, you might want to:
 
 ## Related Resources
 
-- [Authenticated Routes Guide](../guide/authenticated-routes.md) - Core authentication concepts
-- [Router Context Guide](../guide/router-context.md) - Understanding router context
+- [Authenticated Routes Guide](../../guide/authenticated-routes.md) - Core authentication concepts
+- [Router Context Guide](../../guide/router-context.md) - Understanding router context
 - [RBAC Best Practices](https://auth0.com/docs/manage-users/access-control/rbac) - General RBAC principles

--- a/docs/router/framework/react/how-to/setup-ssr.md
+++ b/docs/router/framework/react/how-to/setup-ssr.md
@@ -2,7 +2,7 @@
 title: How to Set Up Server-Side Rendering (SSR)
 ---
 
-> [!IMPORTANT] > **[TanStack Start](../guide/tanstack-start.md) is the recommended way to set up SSR** - it provides SSR, streaming, and deployment with zero configuration.
+> [!IMPORTANT] > **[TanStack Start](../../guide/tanstack-start.md) is the recommended way to set up SSR** - it provides SSR, streaming, and deployment with zero configuration.
 >
 > Use the manual setup below only if you need to integrate with an existing server.
 
@@ -423,7 +423,7 @@ export default defineConfig(({ isSsrBuild }) => ({
 
 ## Common Problems
 
-> [!TIP] > **Most of these problems are automatically solved by [TanStack Start](../guide/tanstack-start.md).** The issues below are primarily relevant for manual SSR setups.
+> [!TIP] > **Most of these problems are automatically solved by [TanStack Start](../../guide/tanstack-start.md).** The issues below are primarily relevant for manual SSR setups.
 
 ### React Import Errors
 
@@ -537,15 +537,15 @@ const ssrConfig = {
 
 ## Related Resources
 
-- [TanStack Start](../guide/tanstack-start.md) - **Recommended full-stack React framework with SSR**
-- [SSR Guide (Detailed)](../guide/ssr.md) - Comprehensive SSR concepts, utilities, and theory
-- [Data Loading](../guide/data-loading.md) - SSR-compatible data loading patterns
+- [TanStack Start](../../guide/tanstack-start.md) - **Recommended full-stack React framework with SSR**
+- [SSR Guide (Detailed)](../../guide/ssr.md) - Comprehensive SSR concepts, utilities, and theory
+- [Data Loading](../../guide/data-loading.md) - SSR-compatible data loading patterns
 
 ## Common Next Steps
 
-- [Deploy to Production](./deploy-to-production.md) - Deploy your SSR app
-- [Setup Authentication](./setup-authentication.md) - Add auth to SSR routes
-- [Debug Router Issues](./debug-router-issues.md) - Troubleshoot SSR-specific routing problems
+- [Deploy to Production](../deploy-to-production.md) - Deploy your SSR app
+- [Setup Authentication](../setup-authentication.md) - Add auth to SSR routes
+- [Debug Router Issues](../debug-router-issues.md) - Troubleshoot SSR-specific routing problems
 
 <!-- TODO: Uncomment as guides are created
 - [Fix Build Issues](./fix-build-issues.md) - Troubleshoot bundler problems

--- a/docs/router/framework/react/how-to/setup-testing.md
+++ b/docs/router/framework/react/how-to/setup-testing.md
@@ -6,7 +6,7 @@ This guide covers setting up comprehensive testing for TanStack Router applicati
 
 Set up testing by configuring your test framework (Vitest/Jest), creating router test utilities, and implementing patterns for testing navigation, route components, and data loading with manually defined routes.
 
-> **Using File-Based Routing?** See [How to Test File-Based Routing](./test-file-based-routing.md) for patterns specific to file-based routing applications.
+> **Using File-Based Routing?** See [How to Test File-Based Routing](../test-file-based-routing.md) for patterns specific to file-based routing applications.
 
 ---
 
@@ -957,9 +957,9 @@ await waitFor(() => {
 
 After setting up code-based routing testing, you might want to:
 
-- [How to Test File-Based Routing](./test-file-based-routing.md) - Specific patterns for file-based routing apps
-- [How to Set Up Basic Authentication](./setup-authentication.md) - Test authentication flows
-- [How to Debug Common Router Issues](./debug-router-issues.md) - Debug test failures
+- [How to Test File-Based Routing](../test-file-based-routing.md) - Specific patterns for file-based routing apps
+- [How to Set Up Basic Authentication](../setup-authentication.md) - Test authentication flows
+- [How to Debug Common Router Issues](../debug-router-issues.md) - Debug test failures
 
 <!-- TODO: Uncomment as guides are created
 - [How to Set Up Continuous Integration](./setup-ci.md)
@@ -968,7 +968,7 @@ After setting up code-based routing testing, you might want to:
 
 ## Related Resources
 
-- [Code-Based Routing Guide](../routing/code-based-routing.md) - Understanding code-based routing
+- [Code-Based Routing Guide](../../routing/code-based-routing.md) - Understanding code-based routing
 - [Vitest Documentation](https://vitest.dev/) - Testing framework
 - [Testing Library React](https://testing-library.com/docs/react-testing-library/intro/) - Component testing utilities
 - [Playwright Documentation](https://playwright.dev/) - E2E testing framework

--- a/docs/router/framework/react/how-to/share-search-params-across-routes.md
+++ b/docs/router/framework/react/how-to/share-search-params-across-routes.md
@@ -240,6 +240,6 @@ After implementing shared search parameters, you might want to:
 
 ## Related Resources
 
-- [Set Up Basic Search Parameters](./setup-basic-search-params.md) - Learn search parameter fundamentals
-- [Navigate with Search Parameters](./navigate-with-search-params.md) - Navigate while preserving search state
-- [Validate Search Parameters with Schemas](./validate-search-params.md) - Add type safety to shared parameters
+- [Set Up Basic Search Parameters](../setup-basic-search-params.md) - Learn search parameter fundamentals
+- [Navigate with Search Parameters](../navigate-with-search-params.md) - Navigate while preserving search state
+- [Validate Search Parameters with Schemas](../validate-search-params.md) - Add type safety to shared parameters

--- a/docs/router/framework/react/how-to/test-file-based-routing.md
+++ b/docs/router/framework/react/how-to/test-file-based-routing.md
@@ -940,13 +940,13 @@ beforeEach(() => {
 
 After setting up file-based route testing, you might want to:
 
-- [How to Set Up Testing with Code-Based Routing](./setup-testing.md) - Testing patterns for manually defined routes
-- [How to Debug Router Issues](./debug-router-issues.md) - Debug file-based routing issues
-- [File-Based Routing Guide](../routing/file-based-routing.md) - Learn more about file-based routing
+- [How to Set Up Testing with Code-Based Routing](../setup-testing.md) - Testing patterns for manually defined routes
+- [How to Debug Router Issues](../debug-router-issues.md) - Debug file-based routing issues
+- [File-Based Routing Guide](../../routing/file-based-routing.md) - Learn more about file-based routing
 
 ## Related Resources
 
-- [TanStack Router File-Based Routing](../routing/file-based-routing.md) - Complete file-based routing guide
-- [File Naming Conventions](../routing/file-naming-conventions.md) - Understanding file structure
+- [TanStack Router File-Based Routing](../../routing/file-based-routing.md) - Complete file-based routing guide
+- [File Naming Conventions](../../routing/file-naming-conventions.md) - Understanding file structure
 - [Testing Library](https://testing-library.com/) - Component testing utilities
 - [Vitest](https://vitest.dev/) - Testing framework documentation

--- a/docs/router/framework/react/how-to/use-environment-variables.md
+++ b/docs/router/framework/react/how-to/use-environment-variables.md
@@ -684,6 +684,6 @@ const getBooleanEnv = (value: string | undefined, defaultValue = false) => {
 
 ## Related Resources
 
-- [TanStack Router File-Based Routing](../routing/file-based-routing.md) - Learn about route configuration
+- [TanStack Router File-Based Routing](../../routing/file-based-routing.md) - Learn about route configuration
 - [Vite Environment Variables](https://vitejs.dev/guide/env-and-mode.html) - Official Vite documentation
 - [Webpack DefinePlugin](https://webpack.js.org/plugins/define-plugin/) - Webpack environment configuration

--- a/docs/router/framework/react/how-to/validate-search-params.md
+++ b/docs/router/framework/react/how-to/validate-search-params.md
@@ -4,7 +4,7 @@ title: Validate Search Parameters with Schemas
 
 Learn how to add robust schema validation to your search parameters using popular validation libraries like Zod, Valibot, and ArkType. This guide covers validation setup, error handling, type safety, and common validation patterns for production applications.
 
-**Prerequisites:** [Set Up Basic Search Parameters](./setup-basic-search-params.md) - Foundation concepts for reading and working with search params.
+**Prerequisites:** [Set Up Basic Search Parameters](../setup-basic-search-params.md) - Foundation concepts for reading and working with search params.
 
 ## Quick Start
 
@@ -500,7 +500,7 @@ describe('Search Validation Behavior', () => {
 })
 ```
 
-**For comprehensive route testing patterns, see:** [Set Up Testing](./setup-testing.md) and [Test File-Based Routing](./test-file-based-routing.md)
+**For comprehensive route testing patterns, see:** [Set Up Testing](../setup-testing.md) and [Test File-Based Routing](../test-file-based-routing.md)
 
 ## Common Problems
 
@@ -627,7 +627,7 @@ function SearchPage() {
 
 After setting up schema validation, you might want to:
 
-- [Work with Arrays, Objects, and Dates](./arrays-objects-dates-search-params.md) - Handle arrays, objects, dates, and nested data structures
+- [Work with Arrays, Objects, and Dates](../arrays-objects-dates-search-params.md) - Handle arrays, objects, dates, and nested data structures
 
 <!-- Uncomment when guides are available
 - [Share Search Parameters Across Routes](./share-search-params-across-routes.md) - Inherit and manage search params across route hierarchies


### PR DESCRIPTION
fixes #4877 and other links in how-to guids correctly