### PR TITLE
docs(start): Fix Cloudflare Workers hosting links

### DIFF
--- a/docs/start/framework/react/hosting.md
+++ b/docs/start/framework/react/hosting.md
@@ -35,7 +35,7 @@ When a TanStack Start application is being deployed, the `target` value in the T
 
 - [`netlify`](#netlify): Deploy to Netlify
 - [`vercel`](#vercel): Deploy to Vercel
-- [`cloudflare-pages`](#cloudflare-pages): Deploy to Cloudflare Pages
+- [`cloudflare-module`](#cloudflare-workers): Deploy to Cloudflare Workers
 - [`node-server`](#nodejs): Deploy to a Node.js server
 - [`bun`](#bun): Deploy to a Bun server
 - ... and more to come!


### PR DESCRIPTION
This updates the anchor links to the Cloudflare Workers (which has a target of `cloudflare-module`) hosting links that were updated as part of #4779