### PR TITLE
refactor(router-core): Avoid creating empty objects when not necessary

### DIFF
--- a/packages/router-core/src/Matches.ts
+++ b/packages/router-core/src/Matches.ts
@@ -150,7 +150,7 @@ export interface RouteMatch<
   }
   loaderData?: TLoaderData
   /** @internal */
-  __routeContext: Record<string, unknown>
+  __routeContext?: Record<string, unknown>
   /** @internal */
   __beforeLoadContext?: Record<string, unknown>
   context: TAllContext

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -139,24 +139,27 @@ export async function hydrate(router: AnyRouter): Promise<any> {
       const route = router.looseRoutesById[match.routeId]!
 
       const parentMatch = router.state.matches[match.index - 1]
-      const parentContext = parentMatch?.context ?? router.options.context ?? {}
+      const parentContext = parentMatch?.context ?? router.options.context
 
       // `context()` was already executed by `matchRoutes`, however route context was not yet fully reconstructed
       // so run it again and merge route context
-      const contextFnContext: RouteContextOptions<any, any, any, any> = {
-        deps: match.loaderDeps,
-        params: match.params,
-        context: parentContext,
-        location: router.state.location,
-        navigate: (opts: any) =>
-          router.navigate({ ...opts, _fromLocation: router.state.location }),
-        buildLocation: router.buildLocation,
-        cause: match.cause,
-        abortController: match.abortController,
-        preload: false,
-        matches,
+      if (route.options.context) {
+        const contextFnContext: RouteContextOptions<any, any, any, any> = {
+          deps: match.loaderDeps,
+          params: match.params,
+          context: parentContext ?? {},
+          location: router.state.location,
+          navigate: (opts: any) =>
+            router.navigate({ ...opts, _fromLocation: router.state.location }),
+          buildLocation: router.buildLocation,
+          cause: match.cause,
+          abortController: match.abortController,
+          preload: false,
+          matches,
+        }
+        match.__routeContext =
+          route.options.context(contextFnContext) ?? undefined
       }
-      match.__routeContext = route.options.context?.(contextFnContext) ?? {}
 
       match.context = {
         ...parentContext,


### PR DESCRIPTION
`undefined` is allowed as the parameter of the `...` spread operator. It is not necessary to create an empty object `{}` as a fallback.

Creating objects incurs more work by the garbage collector, so minimizing how many are created if a performance improvement.