### PR TITLE
chore: upgraded start-basic to Tailwind CSS 4

### DIFF
--- a/examples/react/start-basic/package.json
+++ b/examples/react/start-basic/package.json
@@ -18,13 +18,12 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.1.11",
     "@types/node": "^22.5.4",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.6.0",
-    "autoprefixer": "^10.4.20",
-    "postcss": "^8.5.1",
-    "tailwindcss": "^3.4.17",
+    "tailwindcss": "^4.1.11",
     "typescript": "^5.7.2",
     "vite": "^6.3.5",
     "vite-tsconfig-paths": "^5.1.4"

--- a/examples/react/start-basic/postcss.config.mjs
+++ b/examples/react/start-basic/postcss.config.mjs
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/examples/react/start-basic/src/styles/app.css
+++ b/examples/react/start-basic/src/styles/app.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 @layer base {
   html {

--- a/examples/react/start-basic/tailwind.config.mjs
+++ b/examples/react/start-basic/tailwind.config.mjs
@@ -1,4 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: ['./src/**/*.{js,jsx,ts,tsx}'],
-}

--- a/examples/react/start-basic/vite.config.ts
+++ b/examples/react/start-basic/vite.config.ts
@@ -1,3 +1,4 @@
+import tailwindcss from '@tailwindcss/vite'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import { defineConfig } from 'vite'
 import tsConfigPaths from 'vite-tsconfig-paths'
@@ -13,5 +14,6 @@ export default defineConfig({
     }),
     tanstackStart({ customViteReactPlugin: true }),
     viteReact(),
+    tailwindcss(),
   ],
 })


### PR DESCRIPTION
We've just started testing Tanstack Start and began with the start-basic example. The first thing we did was upgrade to Tailwind CSS 4 - which is in this commit and PR. Probably just a drop in the bucket but hope this helps. Feel free to ignore if you have other plans.