### PR TITLE
refactor(router-core): scroll-restoration minor performance cleanup

### DIFF
--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -87,7 +87,9 @@ export function getCssSelector(el: any): string {
   const path = []
   let parent: HTMLElement
   while ((parent = el.parentNode)) {
-    path.push(`${el.tagName}:nth-child(${Array.prototype.indexOf.call(parent.children, el) + 1})`)
+    path.push(
+      `${el.tagName}:nth-child(${Array.prototype.indexOf.call(parent.children, el) + 1})`,
+    )
     el = parent
   }
   return `${path.reverse().join(' > ')}`.toLowerCase()


### PR DESCRIPTION
Some minor performance improvements in `scroll-restoration.ts`
- in `getCssSelector`: 
  - we can obtain `indexOf` without creating an empty array through `Array.prototype.indexOf`
  - using `.unshift` in a loop is always bad for performance. To build arrays in reverse, use `.push()` in the loop, and `.reverse()` at the end.
- in `restoreScroll`: 
  - we can early exit without creating an IIFE by using a [labeled statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label)
  - we can avoid creating an array of elements to iterate over since we already have an array
- in `onScroll`: 
  - we can avoid accessing the same key twice by using the `||=` operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - More reliable scroll restoration after navigation and refresh.
  - Improved handling of URL hash anchors for accurate in-page scrolling.
  - Consistent scroll-to-top behavior across configured elements.
  - Avoids runtime errors when session storage is unavailable or data is invalid.
- Refactor
  - Streamlined scroll handling and state initialization for improved stability and minor performance gains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->