### PR TITLE
fix(router-core): await beforeLoad before rendering, even if preloaded

### DIFF
--- a/packages/react-router/tests/loaders.test.tsx
+++ b/packages/react-router/tests/loaders.test.tsx
@@ -731,7 +731,7 @@ test('clears pendingTimeout when match resolves', async () => {
 })
 
 
-test.only('reproducer #4998 - beforeLoad is awaited before rendering', async () => {
+test('reproducer #4998 - beforeLoad is awaited before rendering', async () => {
   const beforeLoad = vi.fn()
   const select = vi.fn()
   let resolved = 0


### PR DESCRIPTION
fix https://github.com/TanStack/router/issues/4998

---

WIP

at the time of writing, we're on [v1.131.27](https://github.com/TanStack/router/commit/83ab17331ba465617c9cab3beac7b7bd3f8a7665), and as far as I can tell it's been like this since at least [v1.128.2](https://github.com/TanStack/router/commit/80e76377b568145e991ffab1d3c500c3924932e4). I didn't look further in the past, because maybe it's been like this forever.