### PR TITLE
test(react-router): add more variants to store-updates test

### DIFF
--- a/packages/react-router/tests/store-updates-during-navigation.test.tsx
+++ b/packages/react-router/tests/store-updates-during-navigation.test.tsx
@@ -47,11 +47,13 @@ function setup({
   const rootRoute = createRootRoute({
     component: function RootComponent() {
       useRouterState({ select })
-      return <>
-        <Link to="/">Back</Link>
-        <Link to="/posts">Posts</Link>
-        <Outlet />
-      </>
+      return (
+        <>
+          <Link to="/">Back</Link>
+          <Link to="/posts">Posts</Link>
+          <Outlet />
+        </>
+      )
     },
   })
   const indexRoute = createRoute({
@@ -96,7 +98,9 @@ function setup({
 async function back() {
   const link = await waitFor(() => screen.getByRole('link', { name: 'Back' }))
   fireEvent.click(link)
-  const title = await waitFor(() => screen.getByRole('heading', { name: /Index/ }))
+  const title = await waitFor(() =>
+    screen.getByRole('heading', { name: /Index/ }),
+  )
   expect(title).toBeInTheDocument()
 }
 


### PR DESCRIPTION
Add a few more setup configurations to measure the number of `__store` updates:
- with caching (`staleTime > 0`)
- when preloading multiple times the same route (simulates hovering a list of links to the same page w/ different params)
