### PR TITLE
docs: change hydration target to document.body in custom client.tsx for Solid

### DIFF
--- a/docs/start/framework/solid/learn-the-basics.md
+++ b/docs/start/framework/solid/learn-the-basics.md
@@ -85,7 +85,7 @@ import { createRouter } from './router'
 
 const router = createRouter()
 
-hydrate(() => <StartClient router={router} />, document)
+hydrate(() => <StartClient router={router} />, document.body)
 ```
 
 This enables us to kick off client-side routing once the user's initial server request has fulfilled.


### PR DESCRIPTION
Fixes #5085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Solid framework “Learn the Basics” guide to correct the client hydration example, targeting the appropriate DOM root.
  * Clarifies which element to hydrate, aligning the snippet with current best practices and reducing confusion for readers.
  * Improves copy‑paste reliability of the example for newcomers following the setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->