### PR TITLE
fix: Move initial route generation into `configResolved`

### DIFF
--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -66,23 +66,11 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
         event,
       })
     },
-    async buildStart() {
-      await generate()
-    },
     vite: {
-      configResolved() {
+      async configResolved() {
         initConfigAndGenerator()
-      },
-      applyToEnvironment(environment) {
-        if (userConfig.plugin?.vite?.environmentName) {
-          return userConfig.plugin.vite.environmentName === environment.name
-        }
-        return true
-      },
-      async buildStart() {
         await generate()
       },
-      sharedDuringBuild: true,
     },
     rspack(compiler) {
       initConfigAndGenerator()


### PR DESCRIPTION
This ensures that routes are generated before dependency optimisation when using Vite. An up-to-date `routeTree.gen.ts` is required so that the optimiser can crawl the user's code for dependencies.

Note: I think it is safe to remove the shared `buildStart` as the other bundlers already call `generate()` in `beforeRun` but this needs confirming.