### PR TITLE
refactor(router-core): processRouteTree sorting uses constants for all score modifiers

### DIFF
--- a/packages/router-core/src/process-route-tree.ts
+++ b/packages/router-core/src/process-route-tree.ts
@@ -110,7 +110,10 @@ function sortRoutes<TRouteLike extends RouteLike>(
           nextSegment.value !== '/'
         ) {
           hasStaticAfter = true
-          return handleParam(segment, baseScore + STATIC_AFTER_DYNAMIC_BONUS_SCORE)
+          return handleParam(
+            segment,
+            baseScore + STATIC_AFTER_DYNAMIC_BONUS_SCORE,
+          )
         }
       }
 


### PR DESCRIPTION
Just to make it easier to tweak the values and understand the scales / functions, we extract all score modifiers to constants w/ descriptive names.

This PR is a no-op, no logic was modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved route matching accuracy by prioritizing routes with static segments that appear after dynamic parameters.
  - More predictable matching in complex paths; reduces unexpected selections.
  - Wildcard routes handled more consistently.

- Refactor
  - Updated internal route scoring to consider deeper static segments without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->