### PR TITLE
fix(router-core): update cookie-es dependency to v2.0.0

### DIFF
--- a/packages/router-core/package.json
+++ b/packages/router-core/package.json
@@ -81,7 +81,7 @@
   "dependencies": {
     "@tanstack/history": "workspace:*",
     "@tanstack/store": "^0.7.0",
-    "cookie-es": "^1.2.2",
+    "cookie-es": "^2.0.0",
     "seroval": "^1.3.2",
     "seroval-plugins": "^1.3.2",
     "tiny-invariant": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6613,8 +6613,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       cookie-es:
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^2.0.0
+        version: 2.0.0
       seroval:
         specifier: ^1.3.2
         version: 1.3.2


### PR DESCRIPTION
## Description

When deploying applications that use `@tanstack/router-core` on AWS Amplify Hosting, the deployment fails with the following error:

```
H3Error: Cannot find package '/var/task/node_modules/cookie-es/index.js' 
imported from /var/task/node_modules/@tanstack/router-core/dist/esm/ssr/headers.js
```

## Root Cause

The `@tanstack/router-core` package imports `cookie-es` but was using an older version (`^1.2.2`) that may have compatibility issues in certain deployment environments.

## Solution

Updated `cookie-es` dependency from `^1.2.2` to `^2.0.0` in `@tanstack/router-core`'s package.json.

This aligns with other packages in the monorepo that are already using `cookie-es` v2.0.0.

Fixes #5137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded a cookie handling dependency to the latest major version within the routing module to improve stability, compatibility, and security posture.
  * No changes to public APIs or expected app behavior.

* **Documentation**
  * Not applicable.

* **Tests**
  * Not applicable.

* **Bug Fixes**
  * Not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->