### PR TITLE
docs: fix invalid JSX on selective-ssr documentation page

### DIFF
--- a/docs/start/framework/react/selective-ssr.md
+++ b/docs/start/framework/react/selective-ssr.md
@@ -207,7 +207,7 @@ export const Route = createRootRoute({
   shellComponent: RootShell,
   component: RootComponent,
   errorComponent: () => <div>Error</div>,
-  notFoundComponent: () => <div>Not found</>,
+  notFoundComponent: () => <div>Not found</div>,
   ssr: false // or `defaultSsr: false` on the router
 })
 


### PR DESCRIPTION
Found and fixed an unclosed JSX tag. Nothing more

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a syntax error in a React example snippet within the selective SSR guide to prevent confusion when copying code.

* **Documentation**
  * Updated the selective SSR documentation to fix the example markup, ensuring the sample renders correctly and aligns with best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->