### PR TITLE
alpha-docs(router): Small typo

### DIFF
--- a/docs/start/framework/react/server-functions.md
+++ b/docs/start/framework/react/server-functions.md
@@ -495,7 +495,7 @@ export const getServerTime = createServerFn({
 })
 ```
 
-This also allows fro streaming responses among other things:
+This also allows for streaming responses among other things:
 
 ```tsx
 import { createServerFn } from '@tanstack/react-start'


### PR DESCRIPTION
"fro" --> "for"