### PR TITLE
[Docs] Fix two dots in method call

### DIFF
--- a/docs/start/framework/react/static-server-functions.md
+++ b/docs/start/framework/react/static-server-functions.md
@@ -14,7 +14,7 @@ Static server functions are server functions that are executed at build time and
 import { createServerFn } from '@tanstack/react-start'
 import { staticFunctionMiddleware } from '@tanstack/start-static-server-functions'
 
-const myServerFn = createServerFn({ method: 'GET' })..middleware([staticFunctionMiddleware]).handler(async () => {
+const myServerFn = createServerFn({ method: 'GET' }).middleware([staticFunctionMiddleware]).handler(async () => {
   return 'Hello, world!'
 })
 ```


### PR DESCRIPTION
Tiny fix 😊

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected middleware chaining in the React static server functions example, replacing an erroneous double-dot with proper single-dot method chaining.
  * Example now compiles and accurately reflects the fluent API, improving clarity for readers.
  * No changes to public APIs or runtime behavior; this is a documentation fix to prevent developer confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->