### PR TITLE
Update custom entry point in docs for `1.132.0`

### DIFF
--- a/docs/start/framework/react/client-entry-point.md
+++ b/docs/start/framework/react/client-entry-point.md
@@ -22,7 +22,7 @@ const router = createRouter()
 hydrateRoot(
   document,
   <StrictMode>
-    <StartClient router={router} />
+    <StartClient />
   </StrictMode>,
 )
 ```
@@ -48,7 +48,7 @@ hydrateRoot(
   document,
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <StartClient router={router} />
+      <StartClient />
     </QueryClientProvider>
   </StrictMode>,
 )
@@ -72,7 +72,7 @@ hydrateRoot(
   document,
   <StrictMode>
     <ErrorBoundary>
-      <StartClient router={router} />
+      <StartClient />
     </ErrorBoundary>
   </StrictMode>,
 )
@@ -94,7 +94,7 @@ const router = createRouter()
 const App = (
   <>
     {import.meta.env.DEV && <div>Development Mode</div>}
-    <StartClient router={router} />
+    <StartClient />
   </>
 )
 


### PR DESCRIPTION
Updated import path for `StartClient` in client entry point documentation to account for changes in `1.132.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the React client entry guide to use the recommended client import for StartClient.
  * Refreshed code examples to remove usage of the router prop and show the updated client usage.
  * Clarified examples for consistency with current runtime behavior and recommended patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->