### PR TITLE
docs: filename comment change from src/start.tsx to src/router.tsx

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -137,7 +137,7 @@ from the default [preloading functionality](/router/latest/docs/framework/react/
 > You won't have a `routeTree.gen.ts` file yet. This file will be generated when you run TanStack Start for the first time.
 
 ```tsx
-// src/start.tsx
+// src/router.tsx
 import { createRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the React “Build from Scratch” guide to align the router setup example with current file naming, replacing an outdated reference.
  * Code snippets now point to the correct router entry point, keeping instructions consistent with the latest project structure.
  * No behavioral or API changes; this improves clarity and reduces setup confusion. Existing projects require no action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->