### PR TITLE
doc(hosting): add nitro@nightly opt-in

### DIFF
--- a/docs/start/framework/react/hosting.md
+++ b/docs/start/framework/react/hosting.md
@@ -159,6 +159,19 @@ export default defineConfig({
 })
 ```
 
+You should opt-in to the nightly release channel by updating your `package.json`:
+
+```text
+{
+  "devDependencies": {
+--    "nitropack": "^2.0.0"
+++    "nitropack": "npm:nitropack-nightly@latest"
+  }
+}
+```
+
+Reference: [nitro.build@nightly](https://nitro.build/guide/nightly)
+
 Deploy your application to Vercel using their one-click deployment process, and you're ready to go!
 
 ### Node.js / Railway / Docker


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React + Vercel hosting guide to explicitly recommend opting into the Nitro nightly channel for Nitro v3 deployments.
  * Instructs updating package.json to use nitropack-nightly@latest under devDependencies and includes a link to the nightly docs.
  * Clarifies expected package version resolution during deployment.
  * No changes to app behavior, code logic, or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->