### PR TITLE
Add Firebase App Hosting to hosting.md

### DIFF
--- a/docs/start/framework/react/hosting.md
+++ b/docs/start/framework/react/hosting.md
@@ -161,6 +161,10 @@ export default defineConfig({
 
 Deploy your application to Vercel using their one-click deployment process, and you're ready to go!
 
+### Firebase App Hosting
+
+[Firebase App Hosting](https://firebase.google.com/docs/app-hosting) is compatible with TanStack Start [without any additional configuration needed](https://firebase.blog/posts/2025/06/app-hosting-frameworks#nitro-analog-nuxt-solidstart-tanstack-start).
+
 ### Node.js / Railway / Docker
 
 TanStack Start builds to a `node` server by default. Use the `node` command to start your application from the server from the build output files.


### PR DESCRIPTION
[Firebase App Hosting](https://firebase.google.com/docs/app-hosting)'s integration with Nitro as a [zero-config provider](https://nitro.build/deploy#zero-config-providers) means that there isn't any work to do to deploy TanStack Start sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Firebase App Hosting” to the hosting options, noting full compatibility with TanStack Start without extra configuration.
  * Included a direct link to Firebase App Hosting for easy setup and deployment.
  * Improved hosting guidance to help users quickly choose and deploy with Firebase as an officially supported option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->