### PR TITLE
fix: opt into SSR type level serializability check

### DIFF
--- a/e2e/react-start/basic-auth/src/routeTree.gen.ts
+++ b/e2e/react-start/basic-auth/src/routeTree.gen.ts
@@ -219,6 +219,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/basic-react-query/src/routeTree.gen.ts
+++ b/e2e/react-start/basic-react-query/src/routeTree.gen.ts
@@ -412,6 +412,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/basic-tsr-config/src/routeTree.gen.ts
+++ b/e2e/react-start/basic-tsr-config/src/routeTree.gen.ts
@@ -62,6 +62,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/basic/src/routeTree.gen.ts
+++ b/e2e/react-start/basic/src/routeTree.gen.ts
@@ -1589,6 +1589,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/custom-basepath/src/routeTree.gen.ts
+++ b/e2e/react-start/custom-basepath/src/routeTree.gen.ts
@@ -319,6 +319,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/query-integration/src/routeTree.gen.ts
+++ b/e2e/react-start/query-integration/src/routeTree.gen.ts
@@ -125,6 +125,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/scroll-restoration/src/routeTree.gen.ts
+++ b/e2e/react-start/scroll-restoration/src/routeTree.gen.ts
@@ -121,6 +121,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/selective-ssr/src/routeTree.gen.ts
+++ b/e2e/react-start/selective-ssr/src/routeTree.gen.ts
@@ -106,6 +106,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/serialization-adapters/src/routeTree.gen.ts
+++ b/e2e/react-start/serialization-adapters/src/routeTree.gen.ts
@@ -126,6 +126,7 @@ import type { getRouter } from './router.tsx'
 import type { startInstance } from './start.tsx'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
     config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }

--- a/e2e/react-start/server-functions/src/routeTree.gen.ts
+++ b/e2e/react-start/server-functions/src/routeTree.gen.ts
@@ -488,6 +488,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/server-routes/src/routeTree.gen.ts
+++ b/e2e/react-start/server-routes/src/routeTree.gen.ts
@@ -106,6 +106,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/spa-mode/src/routeTree.gen.ts
+++ b/e2e/react-start/spa-mode/src/routeTree.gen.ts
@@ -106,6 +106,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/virtual-routes/src/routeTree.gen.ts
+++ b/e2e/react-start/virtual-routes/src/routeTree.gen.ts
@@ -320,6 +320,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/react-start/website/src/routeTree.gen.ts
+++ b/e2e/react-start/website/src/routeTree.gen.ts
@@ -307,6 +307,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/solid-start/basic-tsr-config/src/app/routeTree.gen.ts
+++ b/e2e/solid-start/basic-tsr-config/src/app/routeTree.gen.ts
@@ -62,6 +62,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/solid-start/basic/src/routeTree.gen.ts
+++ b/e2e/solid-start/basic/src/routeTree.gen.ts
@@ -863,6 +863,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/solid-start/custom-basepath/src/routeTree.gen.ts
+++ b/e2e/solid-start/custom-basepath/src/routeTree.gen.ts
@@ -298,6 +298,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/solid-start/scroll-restoration/src/routeTree.gen.ts
+++ b/e2e/solid-start/scroll-restoration/src/routeTree.gen.ts
@@ -121,6 +121,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/solid-start/selective-ssr/src/routeTree.gen.ts
+++ b/e2e/solid-start/selective-ssr/src/routeTree.gen.ts
@@ -106,6 +106,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/solid-start/server-functions/src/routeTree.gen.ts
+++ b/e2e/solid-start/server-functions/src/routeTree.gen.ts
@@ -360,6 +360,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/solid-start/server-routes/src/routeTree.gen.ts
+++ b/e2e/solid-start/server-routes/src/routeTree.gen.ts
@@ -106,6 +106,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/solid-start/spa-mode/src/routeTree.gen.ts
+++ b/e2e/solid-start/spa-mode/src/routeTree.gen.ts
@@ -106,6 +106,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/e2e/solid-start/website/src/routeTree.gen.ts
+++ b/e2e/solid-start/website/src/routeTree.gen.ts
@@ -284,6 +284,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-bare/src/routeTree.gen.ts
+++ b/examples/react/start-bare/src/routeTree.gen.ts
@@ -80,6 +80,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-basic-auth/src/routeTree.gen.ts
+++ b/examples/react/start-basic-auth/src/routeTree.gen.ts
@@ -218,6 +218,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-basic-react-query/src/routeTree.gen.ts
+++ b/examples/react/start-basic-react-query/src/routeTree.gen.ts
@@ -424,6 +424,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-basic-static/src/routeTree.gen.ts
+++ b/examples/react/start-basic-static/src/routeTree.gen.ts
@@ -368,6 +368,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-basic/src/routeTree.gen.ts
+++ b/examples/react/start-basic/src/routeTree.gen.ts
@@ -441,6 +441,7 @@ import type { getRouter } from './router.tsx'
 import type { startInstance } from './start.tsx'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
     config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }

--- a/examples/react/start-convex-trellaux/src/routeTree.gen.ts
+++ b/examples/react/start-convex-trellaux/src/routeTree.gen.ts
@@ -80,6 +80,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-counter/src/routeTree.gen.ts
+++ b/examples/react/start-counter/src/routeTree.gen.ts
@@ -62,6 +62,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-large/src/routeTree.gen.ts
+++ b/examples/react/start-large/src/routeTree.gen.ts
@@ -233,6 +233,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-material-ui/src/routeTree.gen.ts
+++ b/examples/react/start-material-ui/src/routeTree.gen.ts
@@ -80,6 +80,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-supabase-basic/src/routeTree.gen.ts
+++ b/examples/react/start-supabase-basic/src/routeTree.gen.ts
@@ -219,6 +219,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-tailwind-v4/src/routeTree.gen.ts
+++ b/examples/react/start-tailwind-v4/src/routeTree.gen.ts
@@ -62,6 +62,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-trellaux/src/routeTree.gen.ts
+++ b/examples/react/start-trellaux/src/routeTree.gen.ts
@@ -80,6 +80,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/react/start-workos/src/routeTree.gen.ts
+++ b/examples/react/start-workos/src/routeTree.gen.ts
@@ -147,6 +147,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/solid/start-bare/src/routeTree.gen.ts
+++ b/examples/solid/start-bare/src/routeTree.gen.ts
@@ -80,6 +80,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/solid/start-basic-static/src/routeTree.gen.ts
+++ b/examples/solid/start-basic-static/src/routeTree.gen.ts
@@ -368,6 +368,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/examples/solid/start-basic/src/routeTree.gen.ts
+++ b/examples/solid/start-basic/src/routeTree.gen.ts
@@ -420,6 +420,7 @@ import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/solid-start'
 declare module '@tanstack/solid-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -101,6 +101,12 @@ export interface Register {
   // ssr
 }
 
+export type RegisteredSsr<TRegister = Register> = TRegister extends {
+  ssr: infer TSSR
+}
+  ? TSSR
+  : false
+
 export type RegisteredRouter<TRegister = Register> = TRegister extends {
   router: infer TRouter
 }

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -1,7 +1,11 @@
 import { createPlugin } from 'seroval'
 import { GLOBAL_TSR } from '../constants'
 import type { Plugin, SerovalNode } from 'seroval'
-import type { RegisteredConfigType, SSROption } from '../../router'
+import type {
+  RegisteredConfigType,
+  RegisteredSsr,
+  SSROption,
+} from '../../router'
 import type { LooseReturnType } from '../../utils'
 import type { AnyRoute, ResolveAllSSR } from '../../route'
 
@@ -194,16 +198,17 @@ export type ValidateSerializableLifecycleResult<
   TParentRoute extends AnyRoute,
   TSSR,
   TFn,
-> = false extends (TRegister extends { ssr: infer TSSR } ? TSSR : never)
-  ? any
-  : ValidateSerializableLifecycleResultSSR<
-        TRegister,
-        TParentRoute,
-        TSSR,
-        TFn
-      > extends infer TInput
-    ? TInput
-    : never
+> =
+  false extends RegisteredSsr<TRegister>
+    ? any
+    : ValidateSerializableLifecycleResultSSR<
+          TRegister,
+          TParentRoute,
+          TSSR,
+          TFn
+        > extends infer TInput
+      ? TInput
+      : never
 
 export type ValidateSerializableLifecycleResultSSR<
   TRegister,

--- a/packages/start-plugin-core/src/start-router-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-router-plugin/plugin.ts
@@ -71,6 +71,7 @@ function moduleDeclaration({
   result.push(
     `declare module '@tanstack/${corePluginOpts.framework}-start' {
   interface Register {
+    ssr: true
     router: Awaited<ReturnType<typeof getRouter>>`,
   )
   if (startFilePath) {


### PR DESCRIPTION
default `false` was not working for plain router

fixes #5222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized SSR registration across React Start and Solid Start by introducing a unified SSR flag in public typings.
  - Added a shared SSR type in the router core and updated internal serializers to use it.
  - No runtime behavior changes; improvements are type-level only.

- Chores
  - Regenerated route trees in examples and end-to-end setups to include the SSR flag, ensuring consistent SSR-aware type checking across projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->