### PR TITLE
fix: nitro v3 plugin link in the hosting docs

### DIFF
--- a/docs/start/framework/react/hosting.md
+++ b/docs/start/framework/react/hosting.md
@@ -119,7 +119,7 @@ Deploy your application using their one-click deployment process, and you're rea
 **⚠️ During TanStack Start 1.0 release candidate phase, we currently recommend using:**
 
 - [@tanstack/nitro-v2-vite-plugin (Temporary Compatibility Plugin)](https://www.npmjs.com/package/@tanstack/nitro-v2-vite-plugin) - A temporary compatibility plugin for using Nitro v2 as the underlying build tool for TanStack Start.
-- [Nitro v3's Vite Plugin (BETA)](https://www.npmjs.com/package/nitro-vite) - A **BETA** plugin for officially using Nitro v3 as the underlying build tool for TanStack Start.
+- [Nitro v3's Vite Plugin (BETA)](https://www.npmjs.com/package/nitro-nightly) - A **BETA** plugin for officially using Nitro v3 as the underlying build tool for TanStack Start.
 
 #### Using Nitro v2
 


### PR DESCRIPTION
The nitro v3 plugin link is incorrect, fix with correct one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vercel deployment guide to reference the correct Nitro v3 Vite plugin (now nitro-nightly), keeping the BETA status note.
  * Clarifies deployment steps for React users relying on Nitro v3, reducing confusion from outdated plugin naming.
  * Ensures alignment with current tooling to improve setup reliability and developer confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->