### PR TITLE
fix: add `StartInstance` re-export which is used as a return type from `createStart`

### DIFF
--- a/packages/start-client-core/src/index.tsx
+++ b/packages/start-client-core/src/index.tsx
@@ -79,7 +79,11 @@ export type * from './serverRoute'
 export type * from './startEntry'
 
 export { createStart } from './createStart'
-export type { AnyStartInstance, AnyStartInstanceOptions, StartInstance } from './createStart'
+export type {
+  AnyStartInstance,
+  AnyStartInstanceOptions,
+  StartInstance,
+} from './createStart'
 export type { Register } from '@tanstack/router-core'
 
 export { getRouterInstance } from './getRouterInstance'


### PR DESCRIPTION
Hello 👋

With strict `node_modules` structure, e.g. using `pnpm`, the fact that this type isn't exported is causing TS errors:

<img width="1164" height="166" alt="image" src="https://github.com/user-attachments/assets/de704984-5384-4090-943f-0bb91338146e" />

This PR just exports it, which fixes the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript developer experience by exposing an additional instance type for direct import, making typings more complete and reducing the need for workaround declarations.
  * No runtime or UI changes; fully backward compatible.
  * Existing imports continue to work, while projects can optionally adopt the new type to enhance code clarity and tooling (autocomplete, linting).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->