### PR TITLE
Fix Bun server static routes from using the wrong path separator on Windows

### DIFF
--- a/examples/react/start-bun/server.ts
+++ b/examples/react/start-bun/server.ts
@@ -63,7 +63,7 @@
  *   bun run server.ts
  */
 
-import path from "node:path"
+import path from 'node:path'
 
 // Configuration
 const SERVER_PORT = Number(process.env.PORT ?? 3000)


### PR DESCRIPTION
The issue on Windows:
- `filepath` will resolve to something like `dist/client\assets\index-CYVUvHau.js`, which is fine (Windows accepts either path separator and Bun will read the file just fine).
- However, `route` will resolve into `/assets\index-CYVUvHau.js`, where the windows path separator `\` won't match how the route will be requested over HTTP (`/assets/index-CYVUvHau.js`). So any static route with a path separator in it will fail to work.

To fix it, this change does 2 things:
1. Fixes the `route` generation by normalizing all path separators into the expected POSIX `/`.
2. Uses `path.join()` to create `filepath`. Not strictly necessary, but more correct (and we're importing `node:path` anyway for the first fix).

This should have no effect on any platform that already uses `/` as a path separator (though it _is_ a little noisier).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Fixed inconsistent route generation across operating systems by normalizing file and URL paths, improving reliability on Windows, macOS, and Linux.

- Refactor
  - Standardized path construction to a more robust approach, reducing edge cases and improving maintainability. No behavior or API changes expected.

- Chores
  - Updated internal imports to use built-in modules. No configuration changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->