### PR TITLE
docs: Add @types/node to build-from-scratch guide

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -66,7 +66,7 @@ Alternatively, you can also use `@vitejs/plugin-react-oxc` or `@vitejs/plugin-re
 and some TypeScript:
 
 ```shell
-npm i -D typescript @types/react @types/react-dom vite-tsconfig-paths
+npm i -D typescript @types/react @types/react-dom @types/node vite-tsconfig-paths
 ```
 
 ## Update Configuration Files
@@ -122,7 +122,6 @@ Once configuration is done, we'll have a file tree that looks like the following
 │   │   └── `__root.tsx`
 │   ├── `router.tsx`
 │   ├── `routeTree.gen.ts`
-├── `.gitignore`
 ├── `vite.config.ts`
 ├── `package.json`
 └── `tsconfig.json`


### PR DESCRIPTION
- Added `@types/node` to align with the subsequent `node:fs` usage
- Removed `.gitignore` from the file tree to keep it consistent with the steps provided (the guide does not instruct creating a `.gitignore` file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated setup instructions to include Node.js type definitions (@types/node) as a dev dependency, improving TypeScript compatibility in the React from-scratch guide.
  - Refreshed the example project file tree to omit .gitignore from the listing for clearer, less confusing output.
  - Aligned installation command examples with current recommendations to reduce setup friction and improve developer onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->