### PR TITLE
fix: allow to express dependencies between serialization adapters

### DIFF
--- a/e2e/react-start/serialization-adapters/src/data.tsx
+++ b/e2e/react-start/serialization-adapters/src/data.tsx
@@ -88,6 +88,38 @@ export function makeData() {
     },
   }
 }
+export class NestedOuter {
+  constructor(public inner: NestedInner) {}
+  whisper() {
+    return this.inner.value.toLowerCase()
+  }
+}
+
+export class NestedInner {
+  constructor(public value: string) {}
+  shout() {
+    return this.value.toUpperCase()
+  }
+}
+
+export const nestedInnerAdapter = createSerializationAdapter({
+  key: 'nestedInner',
+  test: (value): value is NestedInner => value instanceof NestedInner,
+  toSerializable: (inner) => inner.value,
+  fromSerializable: (value) => new NestedInner(value),
+})
+
+export const nestedOuterAdapter = createSerializationAdapter({
+  key: 'nestedOuter',
+  extends: [nestedInnerAdapter],
+  test: (value) => value instanceof NestedOuter,
+  toSerializable: (outer) => outer.inner,
+  fromSerializable: (value) => new NestedOuter(value),
+})
+
+export function makeNested() {
+  return new NestedOuter(new NestedInner('Hello World'))
+}
 
 export function RenderData({
   id,

--- a/e2e/react-start/serialization-adapters/src/routeTree.gen.ts
+++ b/e2e/react-start/serialization-adapters/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SsrStreamRouteImport } from './routes/ssr/stream'
+import { Route as SsrNestedRouteImport } from './routes/ssr/nested'
 import { Route as SsrDataOnlyRouteImport } from './routes/ssr/data-only'
 import { Route as ServerFunctionCustomErrorRouteImport } from './routes/server-function/custom-error'
 
@@ -22,6 +23,11 @@ const IndexRoute = IndexRouteImport.update({
 const SsrStreamRoute = SsrStreamRouteImport.update({
   id: '/ssr/stream',
   path: '/ssr/stream',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SsrNestedRoute = SsrNestedRouteImport.update({
+  id: '/ssr/nested',
+  path: '/ssr/nested',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SsrDataOnlyRoute = SsrDataOnlyRouteImport.update({
@@ -40,12 +46,14 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/server-function/custom-error': typeof ServerFunctionCustomErrorRoute
   '/ssr/data-only': typeof SsrDataOnlyRoute
+  '/ssr/nested': typeof SsrNestedRoute
   '/ssr/stream': typeof SsrStreamRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/server-function/custom-error': typeof ServerFunctionCustomErrorRoute
   '/ssr/data-only': typeof SsrDataOnlyRoute
+  '/ssr/nested': typeof SsrNestedRoute
   '/ssr/stream': typeof SsrStreamRoute
 }
 export interface FileRoutesById {
@@ -53,6 +61,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/server-function/custom-error': typeof ServerFunctionCustomErrorRoute
   '/ssr/data-only': typeof SsrDataOnlyRoute
+  '/ssr/nested': typeof SsrNestedRoute
   '/ssr/stream': typeof SsrStreamRoute
 }
 export interface FileRouteTypes {
@@ -61,14 +70,21 @@ export interface FileRouteTypes {
     | '/'
     | '/server-function/custom-error'
     | '/ssr/data-only'
+    | '/ssr/nested'
     | '/ssr/stream'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/server-function/custom-error' | '/ssr/data-only' | '/ssr/stream'
+  to:
+    | '/'
+    | '/server-function/custom-error'
+    | '/ssr/data-only'
+    | '/ssr/nested'
+    | '/ssr/stream'
   id:
     | '__root__'
     | '/'
     | '/server-function/custom-error'
     | '/ssr/data-only'
+    | '/ssr/nested'
     | '/ssr/stream'
   fileRoutesById: FileRoutesById
 }
@@ -76,6 +92,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ServerFunctionCustomErrorRoute: typeof ServerFunctionCustomErrorRoute
   SsrDataOnlyRoute: typeof SsrDataOnlyRoute
+  SsrNestedRoute: typeof SsrNestedRoute
   SsrStreamRoute: typeof SsrStreamRoute
 }
 
@@ -93,6 +110,13 @@ declare module '@tanstack/react-router' {
       path: '/ssr/stream'
       fullPath: '/ssr/stream'
       preLoaderRoute: typeof SsrStreamRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ssr/nested': {
+      id: '/ssr/nested'
+      path: '/ssr/nested'
+      fullPath: '/ssr/nested'
+      preLoaderRoute: typeof SsrNestedRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/ssr/data-only': {
@@ -116,6 +140,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ServerFunctionCustomErrorRoute: ServerFunctionCustomErrorRoute,
   SsrDataOnlyRoute: SsrDataOnlyRoute,
+  SsrNestedRoute: SsrNestedRoute,
   SsrStreamRoute: SsrStreamRoute,
 }
 export const routeTree = rootRouteImport

--- a/e2e/react-start/serialization-adapters/src/routes/ssr/nested.tsx
+++ b/e2e/react-start/serialization-adapters/src/routes/ssr/nested.tsx
@@ -1,0 +1,56 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { makeNested } from '~/data'
+
+export const Route = createFileRoute('/ssr/nested')({
+  beforeLoad: () => {
+    return { nested: makeNested() }
+  },
+  loader: ({ context }) => {
+    return context
+  },
+  component: () => {
+    const loaderData = Route.useLoaderData()
+
+    const localData = makeNested()
+    const expectedShoutState = localData.inner.shout()
+    const expectedWhisperState = localData.whisper()
+    const shoutState = loaderData.nested.inner.shout()
+    const whisperState = loaderData.nested.whisper()
+
+    return (
+      <div data-testid="data-only-container">
+        <h2 data-testid="data-only-heading">data-only</h2>
+        <div data-testid="shout-container">
+          <h3>shout</h3>
+          <div>
+            expected:{' '}
+            <div data-testid="shout-expected-state">
+              {JSON.stringify(expectedShoutState)}
+            </div>
+          </div>
+          <div>
+            actual:{' '}
+            <div data-testid="shout-actual-state">
+              {JSON.stringify(shoutState)}
+            </div>
+          </div>
+        </div>
+        <div data-testid="whisper-container">
+          <h3>whisper</h3>
+          <div>
+            expected:{' '}
+            <div data-testid="whisper-expected-state">
+              {JSON.stringify(expectedWhisperState)}
+            </div>
+          </div>
+          <div>
+            actual:{' '}
+            <div data-testid="whisper-actual-state">
+              {JSON.stringify(whisperState)}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  },
+})

--- a/e2e/react-start/serialization-adapters/src/start.tsx
+++ b/e2e/react-start/serialization-adapters/src/start.tsx
@@ -1,10 +1,16 @@
 import { createStart } from '@tanstack/react-start'
-import { carAdapter, fooAdapter } from './data'
+import { carAdapter, fooAdapter, nestedOuterAdapter } from './data'
 import { customErrorAdapter } from './CustomError'
 
 export const startInstance = createStart(() => {
   return {
     defaultSsr: true,
-    serializationAdapters: [fooAdapter, carAdapter, customErrorAdapter],
+    serializationAdapters: [
+      fooAdapter,
+      carAdapter,
+      customErrorAdapter,
+      // only register nestedOuterAdapter here, nestedInnerAdapter is registered as an "extends" of nestedOuterAdapter
+      nestedOuterAdapter,
+    ],
   }
 })

--- a/e2e/react-start/serialization-adapters/tests/app.spec.ts
+++ b/e2e/react-start/serialization-adapters/tests/app.spec.ts
@@ -49,6 +49,27 @@ test.describe('SSR serialization adapters', () => {
     await awaitPageLoaded(page)
     await checkData(page, 'stream')
   })
+
+  test('nested', async ({ page }) => {
+    await page.goto('/ssr/nested')
+    await awaitPageLoaded(page)
+
+    const expectedShout = await page
+      .getByTestId(`shout-expected-state`)
+      .textContent()
+    expect(expectedShout).not.toBeNull()
+    await expect(page.getByTestId(`shout-actual-state`)).toContainText(
+      expectedShout!,
+    )
+
+    const expectedWhisper = await page
+      .getByTestId(`whisper-expected-state`)
+      .textContent()
+    expect(expectedWhisper).not.toBeNull()
+    await expect(page.getByTestId(`whisper-actual-state`)).toContainText(
+      expectedWhisper!,
+    )
+  })
 })
 
 test.describe('server functions serialization adapters', () => {

--- a/packages/start-client-core/src/createMiddleware.ts
+++ b/packages/start-client-core/src/createMiddleware.ts
@@ -292,11 +292,8 @@ export type AssignAllServerRequestContext<
 > = Assign<
   // Fetch Request Context
   GlobalFetchRequestContext,
-  // AnyContext,
   Assign<
-    GlobalServerRequestContext<TRegister>, // TODO: This enabled global middleware
-    // type inference, but creates a circular types issue. No idea how to fix this.
-    // AnyContext,
+    GlobalServerRequestContext<TRegister>,
     __AssignAllServerRequestContext<TMiddlewares, TSendContext, TServerContext>
   >
 >

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -13,7 +13,7 @@ import {
 } from '@tanstack/router-core'
 import { attachRouterServerSsrUtils } from '@tanstack/router-core/ssr/server'
 import { runWithStartContext } from '@tanstack/start-storage-context'
-import { getResponseHeaders, requestHandler } from './request-response'
+import { requestHandler } from './request-response'
 import { getStartManifest } from './router-manifest'
 import { handleServerAction } from './server-functions-handler'
 
@@ -40,7 +40,6 @@ type TODO = any
 
 function getStartResponseHeaders(opts: { router: AnyRouter }) {
   const headers = mergeHeaders(
-    getResponseHeaders() as Headers,
     {
       'Content-Type': 'text/html; charset=utf-8',
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new SSR route at /ssr/nested.
  - Enhanced state serialization to support nested/extended adapters for accurate SSR hydration.

- Refactor
  - Improved adapter handling to avoid duplicates and ensure reliable nested serialization.

- Chores
  - Simplified server response headers for more predictable output.

- Tests
  - Added end-to-end tests validating nested state (shout/whisper) is preserved across SSR/CSR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->