### PR TITLE
Fix `getResponse()`

### DIFF
--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -327,7 +327,7 @@ export function clearSession(config: Partial<SessionConfig>): Promise<void> {
 // not public API
 export function getResponse() {
   const event = getH3Event()
-  return event._res
+  return event.res
 }
 
 // not public API (yet)


### PR DESCRIPTION
It seems like the API is over-engineered with all these methods — `setResponseHeader`, `getResponseHeader`, `getResponseHeaders`, `removeResponseHeader`, `clearResponseHeaders` — and still doesn’t cover some cases.

For example:
- When I call two server functions in a row, each of them should be able to append a header with the same name. Currently, that isn’t possible.
- `getResponseHeader` does not use `getAll`, while `setResponseHeader` does support an array of values. This inconsistency makes things more confusing.
- The current `getResponseHeaders` implementation does not support returning multiple values for the same header.
- The current `getRequestHeaders` returns `Headers` but `getResponseHeaders` returns `Record<string, string>`.

Instead of maintaining all these methods, it would be simpler to just document how to manage response headers using the standard [Headers API](https://developer.mozilla.org/en-US/docs/Web/API/Headers):
```ts
const headers = getResponse().headers // or getResponseHeaders()
headers.set(name, value) // set
headers.append(name, value) // append
// etc.
```