### PR TITLE
fix: override h3 in nitro-v2-plugin to h3@v2

### DIFF
--- a/packages/nitro-v2-vite-plugin/package.json
+++ b/packages/nitro-v2-vite-plugin/package.json
@@ -63,6 +63,12 @@
     "pathe": "^2.0.3",
     "h3-v1": "npm:h3@^1.15.4"
   },
+  "overrides": {
+    "h3": "2.0.0-beta.5"
+  },
+  "resolutions": {
+    "h3": "2.0.0-beta.5"
+  },
   "peerDependencies": {
     "vite": ">=7.0.0"
   }


### PR DESCRIPTION
this fixes an install issue with bun where, without using isolated installs, only a single version of h3 was installed (in this case, v1)

we still install v1 of h3 as the `h3-v1` alias and redirect nitropack to that via the resolveId rollup plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned a transitive dependency (h3) to a specific version to ensure consistent installs across environments and prevent unexpected upstream changes.
  * Improves build determinism and installation reliability without altering features or behavior.
  * No changes to user-facing APIs, configuration, or runtime functionality; this is a stability-focused maintenance update for development and packaging workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->