### PR TITLE
Docs: Updating Vite plugin usage for Tanstack Start

### DIFF
--- a/docs/start/framework/react/spa-mode.md
+++ b/docs/start/framework/react/spa-mode.md
@@ -42,7 +42,7 @@ To configure SPA mode, there are a few options you can add to your Start plugin'
 // vite.config.ts
 export default defineConfig({
   plugins: [
-    TanStackStart({
+    tanstackStart({
       spa: {
         enabled: true,
       },
@@ -121,7 +121,7 @@ You can always override these options by providing your own prerender options:
 // vite.config.ts
 export default defineConfig({
   plugins: [
-    TanStackStart({
+    tanstackStart({
       spa: {
         prerender: {
           outputPath: '/custom-shell',


### PR DESCRIPTION
Simple docs update to help people who are using TanStack Start have the right usage for the vite plugin. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SPA mode guide for React to use the correct public API name in code examples (TanStackStart → tanstackStart).
  * Ensures examples reflect current API usage for easier copy-paste and fewer implementation errors.
  * Improves clarity and consistency across the SPA configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->