### PR TITLE
fix(router-devtools-core): bundle solid for smaller package

### DIFF
--- a/packages/router-devtools-core/package.json
+++ b/packages/router-devtools-core/package.json
@@ -64,10 +64,10 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "goober": "^2.1.16",
-    "solid-js": "^1.9.5",
     "vite": "^7.1.7"
   },
   "devDependencies": {
+    "solid-js": "^1.9.5",
     "vite-plugin-solid": "^2.11.8"
   },
   "peerDependencies": {

--- a/packages/router-devtools-core/vite.config.ts
+++ b/packages/router-devtools-core/vite.config.ts
@@ -7,10 +7,15 @@ const config = defineConfig({
   plugins: [solid()] as UserConfig['plugins'],
 })
 
-export default mergeConfig(
+const merged = mergeConfig(
   config,
   tanstackViteConfig({
     entry: './src/index.tsx',
     srcDir: './src',
   }),
 )
+
+merged.build.rollupOptions.output.manualChunks = false
+merged.build.rollupOptions.output.preserveModules = false
+
+export default merged

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7056,9 +7056,6 @@ importers:
       goober:
         specifier: ^2.1.16
         version: 2.1.16(csstype@3.1.3)
-      solid-js:
-        specifier: ^1.9.5
-        version: 1.9.5
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -7066,6 +7063,9 @@ importers:
         specifier: ^7.1.7
         version: 7.1.7(@types/node@22.10.2)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.0)
     devDependencies:
+      solid-js:
+        specifier: ^1.9.5
+        version: 1.9.5
       vite-plugin-solid:
         specifier: ^2.11.8
         version: 2.11.8(@testing-library/jest-dom@6.6.3)(solid-js@1.9.5)(vite@7.1.7(@types/node@22.10.2)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.0))


### PR DESCRIPTION
Trying https://github.com/TanStack/router/pull/5374 again

However, this time I followed the manual testing instructions detailed in https://github.com/TanStack/router/pull/5374#issuecomment-3378827140, so I'm fairly confident this version shouldn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted development dependencies to streamline tooling; no runtime impact.

- Build
  - Updated build configuration to produce a more consistent output and simplify packaging.
  - Improved stability of the build by refining how bundles are generated.
  - No changes to the public API or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->