### PR TITLE
fix(start-plugin-core): Properly declare start-client-core in dependencies

### DIFF
--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -70,6 +70,7 @@
     "@tanstack/router-plugin": "workspace:*",
     "@tanstack/router-utils": "workspace:*",
     "@tanstack/server-functions-plugin": "workspace:*",
+    "@tanstack/start-client-core": "workspace:*",
     "@tanstack/start-server-core": "workspace:*",
     "babel-dead-code-elimination": "^1.0.9",
     "cheerio": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7486,6 +7486,9 @@ importers:
       '@tanstack/server-functions-plugin':
         specifier: workspace:*
         version: link:../server-functions-plugin
+      '@tanstack/start-client-core':
+        specifier: workspace:*
+        version: link:../start-client-core
       '@tanstack/start-server-core':
         specifier: workspace:*
         version: link:../start-server-core


### PR DESCRIPTION
Fixes #5398 

fixes #5350

Under strict pnpm dependencies, if we require a package from a package, that package MUST be listed in its dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies by adding a new workspace package to the core plugin.
  * No user-facing changes or behavior adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->