### PR TITLE
fix(start-plugin-core): Remove framework specific packages from being required

### DIFF
--- a/packages/start-plugin-core/src/start-compiler-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-compiler-plugin/plugin.ts
@@ -75,7 +75,7 @@ export function startCompilerPlugin(
               ...resolveRuntimeFiles({
                 package: '@tanstack/start-server-core',
                 files: ['index.js', 'server-functions-handler.js'],
-              })
+              }),
             ]),
           ],
         },


### PR DESCRIPTION
Hopefully fixes #5398 part 2

@schiller-manuel thanks for merging #5408. I've now tested the new version, and now I have encountered the next issue: 

`packages/start-plugin-core/src/start-compiler-plugin/plugin.ts` also contains this snippet of code:
```
...resolveRuntimeFiles({
  package: `@tanstack/${framework}-start-client`,
  files: ['index.js'],
}),
```

I believe this is supposed to be either `react-start-client` or `solid-start-client`. Without declaring the dependency, we run into the error:

```
Error: Cannot find module '@tanstack/react-start-client/package.json'
```

Whichever one is needed must also be declared in dependencies, and it seems like incorrect design to me to add both to dependencies. I _think_ the best way to handle this is using `peerDependencies` with `peerDependenciesMeta` to declare them as optional. This way since `react-start` and `solid-start` already declare both `start-plugin-core` and their respect `-start-client` packages as dependencies, theoretically this should cleanly resolve the issue.

Do you have an opinion on this? c.c. @tannerlinsley 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - None

- Refactor
  - Streamlined build transformation by removing framework-specific client runtime resolution.
  - Fewer runtime files are excluded from inlining, improving build predictability and reducing unnecessary processing.
  - No changes to public APIs or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->