### PR TITLE
feat(devtools-core): add history tab

### DIFF
--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -601,8 +601,8 @@ export const BaseTanStackRouterDevtoolsPanel =
                       </For>
                       {hasHistoryOverflowed() ? (
                         <li class={styles().historyOverflowContainer}>
-                          History panel is only keeping the last {HISTORY_LIMIT}{' '}
-                          navigations
+                          This panel displays the most recent {HISTORY_LIMIT}{' '}
+                          navigations.
                         </li>
                       ) : null}
                     </ul>

--- a/packages/router-devtools-core/src/useStyles.tsx
+++ b/packages/router-devtools-core/src/useStyles.tsx
@@ -412,6 +412,7 @@ const stylesFactory = (shadowDOMTarget?: ShadowRoot) => {
     `,
     historyOverflowContainer: css`
       padding: ${size[1]} ${size[2]};
+      font-size: ${tokens.font.size.xs};
     `,
     maskedBadgeContainer: css`
       flex: 1;


### PR DESCRIPTION
Adds a history panel to the devtools, super useful to be able to track down redirects.

If you don't think it should land, I'm totally ok by building it in userland too.

Ideally, I'd also want to, when I click on a history item, have a side panel that shows the matches for this given pathname, but that's a bigger change that I rather wait until I'm given confirmation it's wanted.

Demo: https://discord.com/channels/719702312431386674/1425569815304863844/1425607969680130058

<img width="1263" height="519" alt="image" src="https://github.com/user-attachments/assets/aa23dd8c-0d36-4c64-b855-75047072cd61" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabbed DevTools panel (Routes, Matches, History) with active tab persisted and history capped at 15 entries; history shows time-since indicators and quick navigation.

* **Refactor**
  * Replaced single toggle with unified tabbed layout and consolidated content switching; matches render as a navigable, selectable list with age indicators.

* **Style**
  * Added scrollable history container and overflow spacing for clearer history display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->