### PR TITLE
Docs(Relative Navigation): add extra context around the from location

### DIFF
--- a/docs/router/framework/react/guide/navigation.md
+++ b/docs/router/framework/react/guide/navigation.md
@@ -186,7 +186,7 @@ By default, all links are absolute unless a `from` route path is provided. This 
 Relative links can be combined with a `from` route path. If a from route path isn't provided, relative paths default to the current active location.
 
 > [!NOTE]
-> Keep in mind that when calling useNavigate as a method on the route, for example `Route.useNavigate`, then the `from` location is predefined to be the route its called on.
+> Keep in mind that when calling useNavigate as a method on the route, for example `Route.useNavigate`, then the `from` location is predefined to be the route it's called on.
 >
 > Another common pitfall is when using this in a pathless layout route, since the pathless layout route does not have an actual path, the `from` location is regarded as the parent of the pathless layout route. Hence relative routing will be resolved from this parent.
 


### PR DESCRIPTION
added some additional context regarding the determination of the from location specifically with regards to when it's called directly from the Route and when used in conjunction with pathless layout routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how relative navigation determines the "from" location when invoked on a specific route, improving predictability of route-scoped navigation.
  * Added a pitfall note for pathless layout routes: relative paths resolve from the parent of the pathless layout, which can change expected destinations.
  * Improved guidance to help debug relative routing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->