### PR TITLE
(docs): update search params guide for zod 3.24.0+ with Standard Schema

### DIFF
--- a/docs/router/framework/react/guide/search-params.md
+++ b/docs/router/framework/react/guide/search-params.md
@@ -203,7 +203,27 @@ For validation libraries we recommend using adapters which infer the correct `in
 
 ### Zod
 
-An adapter is provided for [Zod](https://zod.dev/) which will pipe through the correct `input` type and `output` type
+> [!WARNING]
+> Router expects the zod 3.24.0+ package to be installed to use without an adapter.
+
+When using [Zod](https://zod.dev/) 3.24.0+ an adapter is not needed to ensure the correct `input` and `output` types are used for navigation and reading search params. This is because [Zod](https://zod.dev/) implements [Standard Schema](https://github.com/standard-schema/standard-schema)
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const productSearchSchema = z.object({
+  page: z.number().default(1).catch(1),
+  filter: z.string().default('').catch(''),
+  sort: z.enum(['newest', 'oldest', 'price']).default('newest').catch('newest'),
+})
+
+export const Route = createFileRoute('/shop/products/')({
+  validateSearch: productSearchSchema,
+})
+```
+
+For [Zod](https://zod.dev/) <3.24.0 an adapter is provided which will pipe through the correct `input` type and `output` type
 
 ```tsx
 import { createFileRoute } from '@tanstack/react-router'


### PR DESCRIPTION
Zod 3.24.0+ implements Standard Schema, therefore it can it be used without an adapter just as the Arktype, Valibot and Effect guides instruct. This docs change shows users how to use zod 3.24.0+ to validate search params without requiring the use of the @tanstack/zod-adapter package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised guidance on search parameter validation with a prominent warning about Zod 3.24.0+ compatibility.
  * Added adapterless examples for Zod 3.24.0+, including input/output typing and error handling.
  * Provided adapter-based workflow instructions for Zod versions below 3.24.0.
  * Expanded coverage for Standard Schema and alternative libraries (Valibot, ArkType, Effect/Schema) with comparable examples and notes.
  * Clarified behavior of validateSearch, onError handling, defaults/fallbacks, and typing implications.
  * Highlighted navigation/linking considerations when using adapters and how to enable or bypass them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->