### PR TITLE
refactor: export devtools options type

### DIFF
--- a/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
+++ b/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
@@ -5,7 +5,7 @@ import type { ButtonHTMLAttributes, HTMLAttributes } from 'react'
 import type { AnyRouter } from '@tanstack/react-router'
 import type React from 'react'
 
-interface DevtoolsOptions {
+export interface TanStackRouterDevtoolsOptions {
   /**
    * Set this true if you want the dev tools to default to being open
    */
@@ -44,7 +44,7 @@ interface DevtoolsOptions {
 }
 
 export function TanStackRouterDevtools(
-  props: DevtoolsOptions,
+  props: TanStackRouterDevtoolsOptions,
 ): React.ReactElement | null {
   const {
     initialIsOpen,

--- a/packages/react-router-devtools/src/TanStackRouterDevtoolsPanel.tsx
+++ b/packages/react-router-devtools/src/TanStackRouterDevtoolsPanel.tsx
@@ -3,7 +3,7 @@ import { TanStackRouterDevtoolsPanelCore } from '@tanstack/router-devtools-core'
 import React, { useEffect, useRef, useState } from 'react'
 import type { AnyRouter } from '@tanstack/react-router'
 
-export interface DevtoolsPanelOptions {
+export interface TanStackRouterDevtoolsPanelOptions {
   /**
    * The standard React style object used to style a component with inline styles
    */
@@ -34,9 +34,9 @@ export interface DevtoolsPanelOptions {
   shadowDOMTarget?: ShadowRoot
 }
 
-export const TanStackRouterDevtoolsPanel: React.FC<DevtoolsPanelOptions> = (
-  props,
-): React.ReactElement | null => {
+export const TanStackRouterDevtoolsPanel: React.FC<
+  TanStackRouterDevtoolsPanelOptions
+> = (props): React.ReactElement | null => {
   const { router: propsRouter, ...rest } = props
   const hookRouter = useRouter({ warn: false })
   const activeRouter = propsRouter ?? hookRouter

--- a/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
+++ b/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
@@ -4,7 +4,7 @@ import { ShadowDomTargetContext } from './context'
 import type { AnyRouter } from '@tanstack/router-core'
 import type { Signal } from 'solid-js'
 
-interface DevtoolsOptions {
+export interface TanStackRouterDevtoolsCoreOptions {
   /**
    * Set this true if you want the dev tools to default to being open
    */
@@ -49,7 +49,7 @@ interface DevtoolsOptions {
   shadowDOMTarget?: ShadowRoot
 }
 
-class TanStackRouterDevtoolsCore {
+export class TanStackRouterDevtoolsCore {
   #router: Signal<AnyRouter>
   #routerState: Signal<any>
   #position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
@@ -65,7 +65,7 @@ class TanStackRouterDevtoolsCore {
   #Component: any
   #dispose?: () => void
 
-  constructor(config: DevtoolsOptions) {
+  constructor(config: TanStackRouterDevtoolsCoreOptions) {
     this.#router = createSignal(config.router)
     this.#routerState = createSignal(config.routerState)
     this.#position = config.position ?? 'bottom-left'
@@ -141,7 +141,7 @@ class TanStackRouterDevtoolsCore {
     this.#routerState[1](routerState)
   }
 
-  setOptions(options: Partial<DevtoolsOptions>) {
+  setOptions(options: Partial<TanStackRouterDevtoolsCoreOptions>) {
     if (options.position !== undefined) {
       this.#position = options.position
     }
@@ -159,5 +159,3 @@ class TanStackRouterDevtoolsCore {
     }
   }
 }
-
-export { TanStackRouterDevtoolsCore }

--- a/packages/router-devtools-core/src/TanStackRouterDevtoolsPanelCore.tsx
+++ b/packages/router-devtools-core/src/TanStackRouterDevtoolsPanelCore.tsx
@@ -4,7 +4,7 @@ import { DevtoolsOnCloseContext, ShadowDomTargetContext } from './context'
 import type { JSX } from 'solid-js'
 import type { AnyRouter } from '@tanstack/router-core'
 
-interface TanStackRouterDevtoolsPanelCoreOptions {
+export interface TanStackRouterDevtoolsPanelCoreOptions {
   /**
    * The standard React style object used to style a component with inline styles
    */
@@ -37,7 +37,7 @@ interface TanStackRouterDevtoolsPanelCoreOptions {
   shadowDOMTarget?: ShadowRoot
 }
 
-class TanStackRouterDevtoolsPanelCore {
+export class TanStackRouterDevtoolsPanelCore {
   #router: any
   #routerState: any
   #style: any
@@ -158,5 +158,3 @@ class TanStackRouterDevtoolsPanelCore {
     }
   }
 }
-
-export { TanStackRouterDevtoolsPanelCore }

--- a/packages/solid-router-devtools/src/TanStackRouterDevtools.tsx
+++ b/packages/solid-router-devtools/src/TanStackRouterDevtools.tsx
@@ -4,7 +4,7 @@ import { createEffect, createSignal, onCleanup, onMount } from 'solid-js'
 import type { AnyRouter } from '@tanstack/solid-router'
 import type { Component, JSX } from 'solid-js'
 
-interface DevtoolsOptions {
+export interface TanStackRouterDevtoolsOptions {
   /**
    * Set this true if you want the dev tools to default to being open
    */
@@ -42,9 +42,9 @@ interface DevtoolsOptions {
   shadowDOMTarget?: ShadowRoot
 }
 
-export const TanStackRouterDevtools: Component<DevtoolsOptions> = (
-  props,
-): JSX.Element | null => {
+export const TanStackRouterDevtools: Component<
+  TanStackRouterDevtoolsOptions
+> = (props): JSX.Element | null => {
   const activeRouter = props.router ?? useRouter()
   const activeRouterState = useRouterState({ router: activeRouter })
 

--- a/packages/solid-router-devtools/src/TanStackRouterDevtoolsPanel.tsx
+++ b/packages/solid-router-devtools/src/TanStackRouterDevtoolsPanel.tsx
@@ -4,7 +4,7 @@ import { createEffect, createSignal, onCleanup, onMount } from 'solid-js'
 import type { AnyRouter } from '@tanstack/solid-router'
 import type { Component, JSX } from 'solid-js'
 
-export interface DevtoolsPanelOptions {
+export interface TanStackRouterDevtoolsPanelOptions {
   /**
    * The standard React style object used to style a component with inline styles
    */
@@ -35,9 +35,9 @@ export interface DevtoolsPanelOptions {
   shadowDOMTarget?: ShadowRoot
 }
 
-export const TanStackRouterDevtoolsPanel: Component<DevtoolsPanelOptions> = (
-  props,
-): JSX.Element | null => {
+export const TanStackRouterDevtoolsPanel: Component<
+  TanStackRouterDevtoolsPanelOptions
+> = (props): JSX.Element | null => {
   const activeRouter = props.router ?? useRouter()
   const activeRouterState = useRouterState({ router: activeRouter })
 


### PR DESCRIPTION
When working with the TanStack Router Devtools, I was getting errors because the `DevtoolsOptions` type wasn't being exported from the main package. This isn't a problem when using the devtools directly from imports, but it does cause issues when trying to use the options to integrate tightly with my application.

```
Exported variable 'AppDevOptions' has or is using name 'DevtoolsOptions' from external module "/tmp/app/node_modules/@tanstack/react-router-devtools/dist/esm/TanStackRouterDevtools" but cannot be named. (ts4023)
```
In this instance, `AppDevOptions` is the type from my application.

I tried inferring the type, as well as creating a new type from the arguments, but it gives the same error:
```ts
import {TanStackRouterDevtools} from '@tanstack/react-router-devtools'

type DevtoolsOptions = Parameters<TanStackRouterDevtools>[0]
```

> [!NOTE]
> Despite what CodeRabbit says, these aren't actually breaking changes since the types were never exported in the first place. This is a minor change at best.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Public option type names were renamed — update imports and prop types accordingly.
  * Several devtools classes/components are now exported differently — adjust import syntax.

* **New Features**
  * New exported option interfaces and expanded public exports for core and panel devtools, offering richer typing and more configurable options for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->