### PR TITLE
docs: visual spacing glitch between badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ A full‑stack framework built on Router, designed for server rendering, streami
 <br />
 
 <p align="center">
-  <a href="https://npmjs.com/package/@tanstack/react-router"><img src="https://img.shields.io/npm/dm/@tanstack/react-router.svg" alt="npm downloads" /></a> <a href="https://github.com/tanstack/router"><img src="https://img.shields.io/github/stars/tanstack/router.svg?style=social&label=Star" alt="GitHub stars" /></a> <a href="https://bundlephobia.com/result?p=@tanstack/react-router"><img src="https://badgen.net/bundlephobia/minzip/@tanstack/react-router" alt="Bundle size" /></a> <a href="#badge"><img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg"></a> <a href="https://bestofjs.org/projects/tanstack-router"><img alt="Best of JS" src="https://img.shields.io/endpoint?url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=TanStack%2Frouter%26since=daily" /></a> <a href="https://twitter.com/tan_stack"><img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/></a>
+  <a href="https://npmjs.com/package/@tanstack/react-router"><img src="https://img.shields.io/npm/dm/@tanstack/react-router.svg" alt="npm downloads" /></a> <a href="https://github.com/tanstack/router"><img src="https://img.shields.io/github/stars/tanstack/router.svg?style=social&label=Star" alt="GitHub stars" /></a> <a href="https://bundlephobia.com/result?p=@tanstack/react-router"><img src="https://badgen.net/bundlephobia/minzip/@tanstack/react-router" alt="Bundle size" /></a>
+</p>
+<p align="center">
+  <a href="#badge"><img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg"></a> <a href="https://bestofjs.org/projects/tanstack-router"><img alt="Best of JS" src="https://img.shields.io/endpoint?url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=TanStack%2Frouter%26since=daily" /></a> <a href="https://twitter.com/tan_stack"><img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/></a>
 </p>
 
 <div align="center">


### PR DESCRIPTION
Before:

<img width="1145" height="552" alt="image" src="https://github.com/user-attachments/assets/c8dd5166-8a8c-4e05-83a4-224c94d1e361" />

After:

<img width="1166" height="553" alt="image" src="https://github.com/user-attachments/assets/28ed5593-db71-48e1-b79e-a6bff4870c0f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified README presentation by consolidating badges and partner banners into two centered paragraph blocks.
  * Replaced multiple centered divs with cleaner inline markup for improved readability and easier maintenance.
  * Preserves existing content, links, and semantics; no changes to navigation or behavior.
  * Visual layout remains consistent for readers.
  * No code or API changes involved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->