### PR TITLE
docs(start): update nitro v3 instructions for `nitro` alpha package

### DIFF
--- a/docs/start/framework/react/guide/hosting.md
+++ b/docs/start/framework/react/guide/hosting.md
@@ -145,7 +145,7 @@ Deploy your application using their one-click deployment process, and you're rea
 **⚠️ During TanStack Start 1.0 release candidate phase, we currently recommend using:**
 
 - [@tanstack/nitro-v2-vite-plugin (Temporary Compatibility Plugin)](https://www.npmjs.com/package/@tanstack/nitro-v2-vite-plugin) - A temporary compatibility plugin for using Nitro v2 as the underlying build tool for TanStack Start.
-- [Nitro v3's Vite Plugin (BETA)](https://www.npmjs.com/package/nitro-nightly) - A **BETA** plugin for officially using Nitro v3 as the underlying build tool for TanStack Start.
+- [Nitro v3's Vite Plugin (ALPHA)](https://www.npmjs.com/package/nitro) - An **ALPHA** plugin for officially using Nitro v3 as the underlying build tool for TanStack Start.
 
 #### Using Nitro v2
 
@@ -169,15 +169,9 @@ export default defineConfig({
 })
 ```
 
-#### Using Nitro v3 (BETA)
+#### Using Nitro v3 (ALPHA)
 
-**⚠️ The `nitro` vite plugin is an official **BETA** plugin from the Nitro team for using Nitro v3 as the underlying build tool for TanStack Start. It is still in development and is receiving regular updates.**
-
-This package needs to be installed as follows:
-
-```
- "nitro": "npm:nitro-nightly",
-```
+**⚠️ The [`nitro`](https://www.npmjs.com/package/nitro) vite plugin is an official **ALPHA** plugin from the Nitro team for using Nitro v3 as the underlying build tool for TanStack Start. It is still in development and is receiving regular updates.**
 
 ```tsx
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'

--- a/docs/start/framework/solid/guide/hosting.md
+++ b/docs/start/framework/solid/guide/hosting.md
@@ -153,7 +153,7 @@ Deploy your application using their one-click deployment process, and you're rea
 **⚠️ During TanStack Start 1.0 release candidate phase, we currently recommend using:**
 
 - [@tanstack/nitro-v2-vite-plugin (Temporary Compatibility Plugin)](https://www.npmjs.com/package/@tanstack/nitro-v2-vite-plugin) - A temporary compatibility plugin for using Nitro v2 as the underlying build tool for TanStack Start.
-- [Nitro v3's Vite Plugin (BETA)](https://www.npmjs.com/package/nitro-nightly) - A **BETA** plugin for officially using Nitro v3 as the underlying build tool for TanStack Start.
+- [Nitro v3's Vite Plugin (ALPHA)](https://www.npmjs.com/package/nitro) - An **ALPHA** plugin for officially using Nitro v3 as the underlying build tool for TanStack Start.
 
 #### Using Nitro v2
 
@@ -177,15 +177,9 @@ export default defineConfig({
 })
 ```
 
-#### Using Nitro v3 (BETA)
+#### Using Nitro v3 (ALPHA)
 
-**⚠️ The `nitro` vite plugin is an official **BETA** plugin from the Nitro team for using Nitro v3 as the underlying build tool for TanStack Start. It is still in development and is receiving regular updates.**
-
-This package needs to be installed as follows:
-
-```
- "nitro": "npm:nitro-nightly",
-```
+**⚠️ The [`nitro`](https://www.npmjs.com/package/nitro) vite plugin is an official **ALPHA** plugin from the Nitro team for using Nitro v3 as the underlying build tool for TanStack Start. It is still in development and is receiving regular updates.**
 
 ```tsx
 import { tanstackStart } from '@tanstack/solid-start/plugin/vite'


### PR DESCRIPTION
Nitro v3 Alpha was just recently published, and now under the [`nitro`](https://www.npmjs.com/package/nitro) npm package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hosting guides to reflect Nitro v3 ALPHA status instead of BETA.
  * Removed nightly installation instructions and references to nitro-nightly.
  * Revised examples to import from nitro and nitro/vite, with updated plugin invocation syntax.
  * Adjusted section headings and code snippets to match ALPHA guidance.
  * Applied changes across React and Solid framework guides for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->