### PR TITLE
docs(config): fix misleading link

### DIFF
--- a/docs/start/config.json
+++ b/docs/start/config.json
@@ -147,7 +147,7 @@
             },
             {
               "label": "Tailwind CSS Integration",
-              "to": "framework/solid/guide/tailwind-integration"
+              "to": "framework/react/guide/tailwind-integration"
             }
           ]
         },


### PR DESCRIPTION
Was reading the docs and stumbled upon a misleading link. Not a big deal itself but now the rest of the menu items were "solid" version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Tailwind CSS Integration guide location under React, updating navigation to framework/react/guide/tailwind-integration from an incorrect Solid path. Users can now find the React-specific Tailwind guide via the correct menu item and link, reducing confusion and broken navigation. This improves discoverability and ensures the docs sidebar reflects the correct framework categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->