### PR TITLE
fix: ignore whitespace when detecting handler and createMiddleware calls

### DIFF
--- a/packages/start-plugin-core/src/create-server-fn-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/create-server-fn-plugin/plugin.ts
@@ -85,7 +85,7 @@ export function createServerFnPlugin(
           code: {
             // TODO apply this plugin with a different filter per environment so that .createMiddleware() calls are not scanned in server env
             // only scan files that mention `.handler(` | `.createMiddleware()`
-            include: [/\.handler\(/, /.createMiddleware\(\)/],
+            include: [/\.\s*handler\(/, /\.\s*createMiddleware\(\)/],
           },
         },
         async handler(code, id) {


### PR DESCRIPTION
fixes #5412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of server function handlers and middleware when there’s whitespace between an object and its method call, ensuring transforms apply reliably across different formatting styles.
  - Reduces edge cases where formatted code might be skipped by the transform, leading to more consistent behavior during development and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->