### PR TITLE
typo: Update path-params.md

### DIFF
--- a/docs/router/framework/react/guide/path-params.md
+++ b/docs/router/framework/react/guide/path-params.md
@@ -188,13 +188,13 @@ You can combine both prefixes and suffixes to create very specific routing patte
 
 ```tsx
 // src/routes/users/user-{$userId}person
-export const Route = createFileRoute('/users/user-{$userId}person')({
+export const Route = createFileRoute('/users/user-{$userId}.json')({
   component: UserComponent,
 })
 
 function UserComponent() {
   const { userId } = Route.useParams()
-  // userId will be the value between 'user-' and 'person'
+  // userId will be the value between 'user-' and '.json'
   return <div>User ID: {userId}</div>
 }
 ```


### PR DESCRIPTION
Making the 'Combining Prefixes and Suffixes' section clearer by making the text and code example suffix the same ('.json' all the way through, instead of '.json' vs 'person')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the React routing guide for path parameters with a revised example using a .json suffix.
  * Clarified how the userId parameter is captured in the example (between “user-” and “.json”).
  * No functional or behavioral changes to the product; this is a documentation-only improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->