### PR TITLE
typo: Update path-params.md

### DIFF
--- a/docs/router/framework/react/guide/path-params.md
+++ b/docs/router/framework/react/guide/path-params.md
@@ -187,14 +187,14 @@ function FileComponent() {
 You can combine both prefixes and suffixes to create very specific routing patterns. For example, if you want to match a URL that starts with `user-` and ends with `.json`, you can define it like this:
 
 ```tsx
-// src/routes/users/user-{$userId}person
-export const Route = createFileRoute('/users/user-{$userId}person')({
+// src/routes/users/user-{$userId}.json
+export const Route = createFileRoute('/users/user-{$userId}.json')({
   component: UserComponent,
 })
 
 function UserComponent() {
   const { userId } = Route.useParams()
-  // userId will be the value between 'user-' and 'person'
+  // userId will be the value between 'user-' and '.json'
   return <div>User ID: {userId}</div>
 }
 ```


### PR DESCRIPTION
Making the 'Combining Prefixes and Suffixes' section clearer by making the text and code example suffix the same ('.json' all the way through, instead of '.json' vs 'person')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Path Params guide example to use a .json suffix in combined prefix/suffix routes.
  * Route example changed from '/users/user-{$userId}person' to '/users/user-{$userId}.json'.
  * Clarifies that the captured userId ends before '.json'.
  * Improves clarity for defining dynamic segments with surrounding static text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->