### PR TITLE
Correct NextJS link URL

### DIFF
--- a/docs/start/framework/react/getting-started.md
+++ b/docs/start/framework/react/getting-started.md
@@ -14,7 +14,7 @@ title: Getting Started
 
 Choose one of the following options to start building a _new_ TanStack Start project:
 
-- [TanStack Start CLI] - Just run `npm create @tanstack/start@latest`. Local, fast, and optionally customizable
+- [TanStack Start CLI](../quick-start) - Just run `npm create @tanstack/start@latest`. Local, fast, and optionally customizable
 - [TanStack Builder](#) (coming soon!) - A visual interface to configure new TanStack projects with a few clicks
 - [Quick Start Examples](../quick-start) Download or clone one of our official examples
 - [Build a project from scratch](../build-from-scratch) - A guide to building a TanStack Start project line-by-line, file-by-file.


### PR DESCRIPTION
Currently, the link from `getting-started` to `migrate-from-next-js` is broken. This PR corrects the relative path to the migration guide.

[Relevant page in prod deployment](https://tanstack.com/start/latest/docs/framework/react/getting-started)

<img width="682" height="505" alt="image" src="https://github.com/user-attachments/assets/bf348968-17d0-4728-8f80-04ea381c4713" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated link targets and explicit Markdown links in the React Getting Started guide for improved navigation.
  * Fixed Next.js migration link and formalized links to the TanStack Start CLI and "Build a project from scratch".
  * No other content changes; improves link accuracy and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->