### PR TITLE
fix: update regex to include angle brackets in handler filter

### DIFF
--- a/packages/start-plugin-core/src/create-server-fn-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/create-server-fn-plugin/plugin.ts
@@ -85,7 +85,7 @@ export function createServerFnPlugin(
           code: {
             // TODO apply this plugin with a different filter per environment so that .createMiddleware() calls are not scanned in server env
             // only scan files that mention `.handler(` | `.createMiddleware()`
-            include: [/\.\s*handler\(/, /\.\s*createMiddleware\(\)/],
+            include: [/\.\s*handler[(<]/, /\.\s*createMiddleware\(\)/],
           },
         },
         async handler(code, id) {


### PR DESCRIPTION
# Summary

This resolves https://github.com/TanStack/router/issues/5496.

When a type argument is passed to the handler function, as shown below, the server-fn code transformation doesn't occur. 

This PR changes the behavior so that the server-fn is detected correctly even when a type argument is specified

```ts
const getNum = createServerFn({
  method: "GET",
}).handler<number>(() => 1);
```

I struggled with how to write the test. Could you give me some guidance if needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handler detection in the server plugin to recognize additional handler syntax variations, ensuring handlers are properly identified across different usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->