### PR TITLE
docs: fix router commands in quick-start

### DIFF
--- a/docs/router/framework/react/quick-start.md
+++ b/docs/router/framework/react/quick-start.md
@@ -42,7 +42,7 @@ deno add npm:@tanstack/react-router
 
 [//]: # 'installCommand'
 
-Once installed, you can verify the installation by checking your `package.json` file for the `@tanstack/router` dependency.
+Once installed, you can verify the installation by checking your `package.json` file for the dependency.
 
 [//]: # 'packageJson'
 


### PR DESCRIPTION
As per https://github.com/TanStack/router/pull/5443#discussion_r2436662894 -> fixing the commands 

(Thanks for pointing it out @brett-lovelytics)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start installation instructions to use the correct package name across npm, pnpm, yarn, bun, and deno.
  * Clarified verification wording in the instructions to check for a dependency entry in package.json.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->