### PR TITLE
docs(beforeLoad & notFoundComponents): Add note regarding notFound error thrown from beforeLoad function

### DIFF
--- a/docs/router/framework/react/guide/not-found-errors.md
+++ b/docs/router/framework/react/guide/not-found-errors.md
@@ -161,11 +161,12 @@ export const Route = createFileRoute('/posts/$postId')({
   },
 })
 ```
+
 The not-found error above will be handled by the same route or nearest parent route that has either a `notFoundComponent` route option or the `defaultNotFoundComponent` router option configured.
 
 If neither the route nor any suitable parent route is found to handle the error, the root route will handle it using TanStack Router's **extremely basic (and purposefully undesirable)** default not-found component that simply renders `<div>Not Found</div>`. It's highly recommended to either attach at least one `notFoundComponent` to the root route or configure a router-wide `defaultNotFoundComponent` to handle not-found errors.
 
-> ⚠️ Throwing a notFound error in a beforeLoad method will always trigger the __root notFoundComponent. Since beforeLoad methods are run prior to the route loader methods, there is no guarantee that any required data for layouts have successfully loaded before the error is thrown.
+> ⚠️ Throwing a notFound error in a beforeLoad method will always trigger the \_\_root notFoundComponent. Since beforeLoad methods are run prior to the route loader methods, there is no guarantee that any required data for layouts have successfully loaded before the error is thrown.
 
 ## Specifying Which Routes Handle Not Found Errors
 


### PR DESCRIPTION
There have been a couple of issues, see #5498, #3321, #2139, etc., raised regarding this.

As per [this](https://discord.com/channels/719702312431386674/1325783958184792086) discussion in discord, it is not currently possible to throw notFound errors in beforeLoad methods and have the nearest notFoundComponent render as with normal loader methods; it will always return the notFoundComponent on the __root route.

This PR adds a note to the documentation regarding this behaviour.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated not-found error handling guide with clearer behavior explanations and edge cases
  * Added migration path for updating route configuration

* **New Features**
  * Root route now supports `notFoundComponent` configuration option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->