### PR TITLE
Fix for vitest hooks issue

### DIFF
--- a/packages/react-start/src/plugin/vite.ts
+++ b/packages/react-start/src/plugin/vite.ts
@@ -57,7 +57,6 @@ export function tanstackStart(
                     '@tanstack/react-router-devtools',
                   ],
                   include: [
-                    'react',
                     'react/jsx-runtime',
                     'react/jsx-dev-runtime',
                     'react-dom',


### PR DESCRIPTION
Currently tests using vitest fail to run giving an error of: `TypeError: Cannot read properties of null (reading 'useState')`

```
TypeError: Cannot read properties of null (reading 'useState')
 ❯ exports.useState node_modules/react/cjs/react.development.js:1263:32
 ❯ StateButton src/components/StateButton.tsx:5:29
```

[Recreated in this example](https://github.com/RawToast/tanstack-vitest)

What's more revealing is the "rules of hooks" warnings above the test, which could indicate something being loaded twice:

```
stderr | src/components/__tests__/StateButton.test.tsx > StateButton > should increment
Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem.
```

These errors go away if the TanStack start plugin is removed from `vite.config.js` as mentioned here:
https://discord.com/channels/719702312431386674/1425117017140367421

I am no Vite plugin expert, but by simply removing the second `react` include line this issue was resolved for me. There may be a more elegant or correct solution than this, but hopefully this at least helps. I would have thought the `dedupe` lines above would've done the same task, so maybe this is not a bug here and could be a Vite issue instead 🤔

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration settings to streamline dependency optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->