### PR TITLE
fix: fallback if origin is 'null'

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -969,7 +969,7 @@ export class RouterCore<
 
     this.origin = this.options.origin
     if (!this.origin) {
-      if (!this.isServer) {
+      if (!this.isServer && window?.origin && window.origin !== 'null') {
         this.origin = window.origin
       } else {
         // fallback for the server, can be overridden by calling router.update({origin}) on the server


### PR DESCRIPTION
fixes #5509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed router origin derivation to properly handle cases where the browser origin is null or unavailable, providing a fallback to localhost for improved compatibility across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->