### PR TITLE
chore(examples): Always build before deploy in cloudflare workers examples

### DIFF
--- a/docs/start/framework/react/guide/hosting.md
+++ b/docs/start/framework/react/guide/hosting.md
@@ -86,16 +86,16 @@ export default defineConfig({
     "start": "node .output/server/index.mjs",
     // ============ 👇 add these lines ============
     "preview": "vite preview",
-    "deploy": "wrangler deploy",
+    "deploy": "npm run build && wrangler deploy",
     "cf-typegen": "wrangler types"
   }
 }
 ```
 
-5. Build and deploy
+5. Deploy
 
 ```bash
-pnpm run build && pnpm run deploy
+pnpm run deploy
 ```
 
 Deploy your application to Cloudflare Workers using their one-click deployment process, and you're ready to go!

--- a/docs/start/framework/solid/guide/hosting.md
+++ b/docs/start/framework/solid/guide/hosting.md
@@ -97,15 +97,15 @@ pnpm add wrangler -D
     "build": "vite build && tsc --noEmit",
     "start": "node .output/server/index.mjs",
     // ============ 👇 add this line ============
-    "deploy": "wrangler deploy"
+    "deploy": "npm run build && wrangler deploy"
   }
 }
 ```
 
-6. Build and deploy
+6. Deploy
 
 ```bash
-pnpm run build && pnpm run deploy
+pnpm run deploy
 ```
 
 Deploy your application to Cloudflare Workers using their one-click deployment process, and you're ready to go!

--- a/examples/react/start-basic-cloudflare/package.json
+++ b/examples/react/start-basic-cloudflare/package.json
@@ -7,7 +7,7 @@
     "dev": "vite dev",
     "build": "vite build && tsc --noEmit",
     "preview": "vite preview",
-    "deploy": "wrangler deploy",
+    "deploy": "npm run build && wrangler deploy",
     "cf-typegen": "wrangler types",
     "postinstall": "npm run cf-typegen"
   },


### PR DESCRIPTION
I got momentarily stuck due to not reading the hosting docs on the fact that you needed to build before deploying the cloudflare examples. I can't figure out a reason why you would want to _not_ build before deploying, so added it to the script to reduce similar friction for people like myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hosting guides for React and Solid frameworks to reflect streamlined deployment workflow.

* **Chores**
  * Updated deploy scripts to automatically execute build before deployment, simplifying the overall deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->