### PR TITLE
docs: Update migrate-from-next-js.md

### DIFF
--- a/docs/start/framework/react/migrate-from-next-js.md
+++ b/docs/start/framework/react/migrate-from-next-js.md
@@ -129,7 +129,7 @@ import {
   HeadContent,
   Scripts,
 } from "@tanstack/react-router"
-import "./globals.css"
+import appCss from "./globals.css?url"
 
 - export const metadata: Metadata = { // [!code --]
 -   title: "Create Next App", // [!code --]
@@ -144,6 +144,12 @@ export const Route = createRootRoute({
         content: "width=device-width, initial-scale=1",
       },
       { title: "TanStack Start Starter" }
+    ],
+    links: [
+      {
+        rel: 'stylesheet',
+        href: appCss,
+      },
     ],
   }),
   component: RootLayout,


### PR DESCRIPTION
Fix how `__root.tsx` should be modified when migrating from Nextjs so that it loads css files. 

I had a issue when I've tried to migrate from Nextjs to Tanstack Start where my css file was not being loaded which caused my app to briefly show un-styled content.
This modification fixed it so I thought it would be cool to share it with other people who will most likely face this issue when migration from nextjs