### PR TITLE
fix: Backslash incorrectly decoded (#3962)

### DIFF
--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -348,12 +348,7 @@ function baseParsePathname(
       // Handle regular pathname segment
       return {
         type: SEGMENT_TYPE_PATHNAME,
-        value: partToMatch.includes('%25')
-          ? partToMatch
-              .split('%25')
-              .map((segment) => decodeURI(segment))
-              .join('%25')
-          : decodeURI(partToMatch),
+        value: partToMatch,
       }
     }),
   )

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -816,6 +816,14 @@ describe('parsePathname', () => {
           { type: SEGMENT_TYPE_WILDCARD, value: '$' },
         ],
       },
+      {
+        name: 'should preserve backslashes in path parameters',
+        to: '/foo%5Cbar',
+        expected: [
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'foo%5Cbar' },
+        ],
+      },
     ] satisfies ParsePathnameTestScheme)('$name', ({ to, expected }) => {
       const result = parsePathname(to)
       expect(result).toEqual(expected)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pathname parsing now preserves percent-encoded sequences (e.g., encoded backslashes) within path segments instead of decoding them, preventing unintended changes to parameters.

* **Tests**
  * Added coverage to verify encoded characters in path parameters remain intact during parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->