### PR TITLE
docs: Update router-context.md with context usage tips

### DIFF
--- a/docs/router/framework/react/guide/router-context.md
+++ b/docs/router/framework/react/guide/router-context.md
@@ -42,6 +42,9 @@ const router = createRouter({
 })
 ```
 
+> [!TIP]
+> `MyRouterContext` only needs to contain content that will be passed directly to `createRouter` below. All other context added in `beforeLoad` will be inferred.
+
 ## Passing the initial Router Context
 
 The router context is passed to the router at instantiation time. You can pass the initial router context to the router via the `context` option:


### PR DESCRIPTION
Clarify usage of MyRouterContent and initial Router Context.

This wasn't clear to me, and I was adding all the future context here. https://tkdodo.eu/blog/context-inheritance-in-tan-stack-router made me realise none of this was necessary.

To be honest I should have realised because the code was really ugly when I was trying to force it :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a tip in the router context guide clarifying that the typed router context only needs the properties provided when creating the router; additional context added during loading is automatically inferred.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->