### PR TITLE
fix: set statusCode to 500 if error occurs

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2135,10 +2135,16 @@ export class RouterCore<
       await this.latestLoadPromise
     }
 
+    let newStatusCode: number | undefined = undefined
     if (this.hasNotFoundMatch()) {
+      newStatusCode = 404
+    } else if (this.__store.state.matches.some((d) => d.status === 'error')) {
+      newStatusCode = 500
+    }
+    if (newStatusCode !== undefined) {
       this.__store.setState((s) => ({
         ...s,
-        statusCode: 404,
+        statusCode: newStatusCode,
       }))
     }
   }


### PR DESCRIPTION
fixes #5535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `notFound` is now available as a public API export from router core.

* **Bug Fixes**
  * Improved status code computation to conditionally update based on not-found and error matches (404 or 500 respectively).

* **Tests**
  * Added comprehensive test coverage for status code behavior when loaders throw exceptions under synchronous and asynchronous conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->