### PR TITLE
fix: don't warn about stream closed in case a query does not have a promise

### DIFF
--- a/e2e/react-start/query-integration/src/routes/useQuery.tsx
+++ b/e2e/react-start/query-integration/src/routes/useQuery.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute('/useQuery')({
 })
 
 function RouteComponent() {
-  const query = useQuery(qOptions)
+  const query = useQuery({ ...qOptions, gcTime: 0 })
   return (
     <div>
       <div>

--- a/packages/router-ssr-query-core/src/index.ts
+++ b/packages/router-ssr-query-core/src/index.ts
@@ -80,14 +80,14 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
       if (sentQueries.has(event.query.queryHash)) {
         return
       }
+      // promise not yet set on the query, so we cannot stream it yet
+      if (!event.query.promise) {
+        return
+      }
       if (queryStream.isClosed()) {
         console.warn(
           `tried to stream query ${event.query.queryHash} after stream was already closed`,
         )
-        return
-      }
-      // promise not yet set on the query, so we cannot stream it yet
-      if (!event.query.promise) {
         return
       }
       sentQueries.add(event.query.queryHash)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query streaming reliability by adding an early guard to skip streaming when no active query promise exists and removing a duplicated check.
  * Stabilized client query behavior by ensuring query options include a gcTime constraint to preserve option behavior.

* **Tests**
  * Updated tests to reflect the adjusted query initialization and cache/streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->