### PR TITLE
fix: inherit build target

### DIFF
--- a/packages/nitro-v2-vite-plugin/src/index.ts
+++ b/packages/nitro-v2-vite-plugin/src/index.ts
@@ -107,6 +107,12 @@ export function nitroV2Plugin(nitroConfig?: NitroConfig): Array<PluginOption> {
                   },
                 ],
                 ...nitroConfig,
+                esbuild: {
+                  options: {
+                    target: server.config.build.target || undefined,
+                    ...nitroConfig?.esbuild?.options,
+                  },
+                },
                 renderer: virtualEntry,
                 rollupConfig: {
                   ...nitroConfig?.rollupConfig,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the Nitro v2 Vite plugin to improve server-side rendering build configuration, ensuring proper application of server build targets and merging of existing esbuild options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->