### PR TITLE
Add core api jsdoc annotations

### DIFF
--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -35,6 +35,17 @@ import type { UseLoaderDepsRoute } from './useLoaderDeps'
 import type { UseLoaderDataRoute } from './useLoaderData'
 import type { UseRouteContextRoute } from './useRouteContext'
 
+/**
+ * Creates a file-based Route factory for a given path.
+ *
+ * Used by TanStack Router's file-based routing to associate a file with a
+ * route. The returned function accepts standard route options. In normal usage
+ * the `path` string is inserted and maintained by the `tsr` generator.
+ *
+ * @param path File path literal for the route (usually auto-generated).
+ * @returns A function that accepts Route options and returns a Route instance.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createFileRouteFunction
+ */
 export function createFileRoute<
   TFilePath extends keyof FileRoutesByPath,
   TParentRoute extends AnyRoute = FileRoutesByPath[TFilePath]['parentRoute'],

--- a/packages/react-router/src/route.tsx
+++ b/packages/react-router/src/route.tsx
@@ -307,6 +307,17 @@ export class Route<
   ) as unknown as LinkComponentRoute<TFullPath>
 }
 
+/**
+ * Creates a non-root Route instance for code-based routing.
+ *
+ * Use this to define a route that will be composed into a route tree
+ * (typically via a parent route's `addChildren`). If you're using file-based
+ * routing, prefer `createFileRoute`.
+ *
+ * @param options Route options (path, component, loader, context, etc.).
+ * @returns A Route instance to be attached to the route tree.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createRouteFunction
+ */
 export function createRoute<
   TRegister = unknown,
   TParentRoute extends RouteConstraints['TParentRoute'] = AnyRoute,
@@ -403,6 +414,15 @@ export type AnyRootRoute = RootRoute<
   any
 >
 
+/**
+ * Creates a root route factory that requires a router context type.
+ *
+ * Use when your root route expects `context` to be provided to `createRouter`.
+ * The returned function behaves like `createRootRoute` but enforces a context type.
+ *
+ * @returns A factory function to configure and return a root route.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createRootRouteWithContextFunction
+ */
 export function createRootRouteWithContext<TRouterContext extends {}>() {
   return <
     TRegister = Register,
@@ -563,6 +583,16 @@ export class RootRoute<
   ) as unknown as LinkComponentRoute<'/'>
 }
 
+/**
+ * Creates a root Route instance used to build your route tree.
+ *
+ * Typically paired with `createRouter({ routeTree })`. If you need to require
+ * a typed router context, use `createRootRouteWithContext` instead.
+ *
+ * @param options Root route options (component, error, pending, etc.).
+ * @returns A root route instance.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createRootRouteFunction
+ */
 export function createRootRoute<
   TRegister = Register,
   TSearchValidator = undefined,

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -77,6 +77,17 @@ declare module '@tanstack/router-core' {
   }
 }
 
+/**
+ * Creates a new Router instance for React.
+ *
+ * Pass the returned router to `RouterProvider` to enable routing.
+ * Notable options: `routeTree` (your route definitions) and `context`
+ * (required if the root route was created with `createRootRouteWithContext`).
+ *
+ * @param options Router options used to configure the router.
+ * @returns A Router instance to be provided to `RouterProvider`.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createRouterFunction
+ */
 export const createRouter: CreateRouterFn = (options) => {
   return new Router(options)
 }


### PR DESCRIPTION
Add JSDoc annotations to core public React Router APIs to improve developer experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-26bafc1a-a110-4ce0-9ee0-7fc59f5de966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26bafc1a-a110-4ce0-9ee0-7fc59f5de966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

