### PR TITLE
Add core api jsdoc annotations

### DIFF
--- a/packages/router-core/src/not-found.ts
+++ b/packages/router-core/src/not-found.ts
@@ -18,12 +18,24 @@ export type NotFoundError = {
   headers?: HeadersInit
 }
 
+/**
+ * Create a not-found error object recognized by TanStack Router.
+ *
+ * Throw this from loaders/actions to trigger the nearest `notFoundComponent`.
+ * Use `routeId` to target a specific route's not-found boundary. If `throw`
+ * is true, the error is thrown instead of returned.
+ *
+ * @param options Optional settings including `routeId`, `headers`, and `throw`.
+ * @returns A not-found error object that can be thrown or returned.
+ * @link https://tanstack.com/router/latest/docs/router/framework/react/api/router/notFoundFunction
+ */
 export function notFound(options: NotFoundError = {}) {
   ;(options as any).isNotFound = true
   if (options.throw) throw options
   return options
 }
 
+/** Determine if a value is a TanStack Router not-found error. */
 export function isNotFound(obj: any): obj is NotFoundError {
   return !!obj?.isNotFound
 }

--- a/packages/router-core/src/redirect.ts
+++ b/packages/router-core/src/redirect.ts
@@ -54,6 +54,20 @@ export type ResolvedRedirect<
   TMaskTo extends string = '',
 > = Redirect<TRouter, TFrom, TTo, TMaskFrom, TMaskTo>
 
+/**
+ * Create a redirect Response understood by TanStack Router.
+ *
+ * Use inside loaders/actions/server functions. If `throw: true` is provided,
+ * the redirect Response is thrown instead of returned. When an absolute `href`
+ * is passed and `reloadDocument` is not set, a full-document navigation is
+ * inferred.
+ *
+ * @param opts Options for the redirect, including `href`, `statusCode`,
+ * `headers`, and standard navigation options (e.g. `to`, `params`, `search`,
+ * `reloadDocument`).
+ * @returns A Response augmented with router navigation options.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/redirectFunction
+ */
 export function redirect<
   TRouter extends AnyRouter = RegisteredRouter,
   const TTo extends string | undefined = '.',

--- a/packages/router-core/src/searchMiddleware.ts
+++ b/packages/router-core/src/searchMiddleware.ts
@@ -3,6 +3,13 @@ import type { NoInfer, PickOptional } from './utils'
 import type { SearchMiddleware } from './route'
 import type { IsRequiredParams } from './link'
 
+/**
+ * Search middleware to retain specified search params across links.
+ *
+ * If `keys` is `true`, all existing params are retained. Otherwise, missing
+ * keys from the current search are merged into the next value produced by
+ * subsequent middlewares.
+ */
 export function retainSearchParams<TSearchSchema extends object>(
   keys: Array<keyof TSearchSchema> | true,
 ): SearchMiddleware<TSearchSchema> {
@@ -21,6 +28,13 @@ export function retainSearchParams<TSearchSchema extends object>(
   }
 }
 
+/**
+ * Search middleware to remove optional search params from links.
+ *
+ * Accepts either a list of keys or an object map of default values. Keys with
+ * values matching the provided defaults are removed from the final search.
+ * Passing `true` removes all params.
+ */
 export function stripSearchParams<
   TSearchSchema,
   TOptionalProps = PickOptional<NoInfer<TSearchSchema>>,

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -7,6 +7,16 @@ export const defaultStringifySearch = stringifySearchWith(
   JSON.parse,
 )
 
+/**
+ * Build a `parseSearch` function using a provided JSON-like parser.
+ *
+ * The returned function strips a leading `?`, decodes values, and attempts to
+ * JSON-parse string values using the given `parser`.
+ *
+ * @param parser Function to parse a string value (e.g. `JSON.parse`).
+ * @returns A `parseSearch` function compatible with `Router` options.
+ * @link https://tanstack.com/router/latest/docs/router/framework/react/guide/custom-search-param-serialization
+ */
 export function parseSearchWith(parser: (str: string) => any) {
   return (searchStr: string): AnySchema => {
     if (searchStr[0] === '?') {
@@ -31,6 +41,18 @@ export function parseSearchWith(parser: (str: string) => any) {
   }
 }
 
+/**
+ * Build a `stringifySearch` function using a provided serializer.
+ *
+ * Non-primitive values are serialized with `stringify`. If a `parser` is
+ * supplied, string values that are parseable are re-serialized to ensure
+ * symmetry with `parseSearch`.
+ *
+ * @param stringify Function to serialize a value (e.g. `JSON.stringify`).
+ * @param parser Optional parser to detect parseable strings.
+ * @returns A `stringifySearch` function compatible with `Router` options.
+ * @link https://tanstack.com/router/latest/docs/router/framework/react/guide/custom-search-param-serialization
+ */
 export function stringifySearchWith(
   stringify: (search: any) => string,
   parser?: (str: string) => any,


### PR DESCRIPTION
Add JSDoc annotations to key `@tanstack/router-core` public APIs to enhance developer documentation and clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-30278c06-4d69-4d60-b4a0-27fc7259ec2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30278c06-4d69-4d60-b4a0-27fc7259ec2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

