### PR TITLE
fix: type error when passing number to `Link.params`

### DIFF
--- a/packages/router-core/src/link.ts
+++ b/packages/router-core/src/link.ts
@@ -574,7 +574,16 @@ export interface MakeRequiredPathParams<
   in out TFrom,
   in out TTo,
 > {
-  params: MakeRequiredParamsReducer<TRouter, 'PATH', TFrom, TTo> & {}
+  params: MakeRequiredParamsReducer<
+    TRouter,
+    'PATH',
+    TFrom,
+    TTo
+  > extends infer Params
+    ? {
+        [K in keyof Params]: Params[K] | number
+      } & {}
+    : never
 }
 
 export interface MakeRequiredSearchParams<


### PR DESCRIPTION
fixes #5559

for some reason the type error isn't reproducible in `TanStack/router` repo. to check that the changes work:
1. create an external repo (e.g vite tanstack router template)
2. build packages with the changes
3. [locally install router packages](https://pnpm.io/cli/add#install-from-local-file-system)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Routes now accept numeric values for path segments in addition to string values, improving flexibility when constructing navigation links throughout your application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->