### PR TITLE
fix naming of solid-start example

### DIFF
--- a/docs/start/config.json
+++ b/docs/start/config.json
@@ -331,7 +331,7 @@
               "to": "framework/solid/examples/start-basic-cloudflare"
             },
             {
-              "label": "Cloudflare Vite Plugin",
+              "label": "Netlify Vite Plugin",
               "to": "framework/solid/examples/start-basic-netlify"
             }
           ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Solid framework example references to use Netlify Vite Plugin instead of Cloudflare Vite Plugin for start-basic examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->