### PR TITLE
Add jsdoc annotations to public api

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -544,6 +544,11 @@ export function createBrowserHistory(opts?: {
   return history
 }
 
+/**
+ * Create a hash-based history implementation.
+ * Useful for static hosts or environments without server URL rewriting.
+ * @link https://tanstack.com/router/latest/docs/framework/react/guide/history-types
+ */
 export function createHashHistory(opts?: { window?: any }): RouterHistory {
   const win =
     opts?.window ??
@@ -565,6 +570,11 @@ export function createHashHistory(opts?: { window?: any }): RouterHistory {
   })
 }
 
+/**
+ * Create an in-memory history implementation.
+ * Ideal for server rendering, tests, and non-DOM environments.
+ * @link https://tanstack.com/router/latest/docs/framework/react/guide/history-types
+ */
 export function createMemoryHistory(
   opts: {
     initialEntries: Array<string>

--- a/packages/react-router/src/ClientOnly.tsx
+++ b/packages/react-router/src/ClientOnly.tsx
@@ -28,6 +28,11 @@ export interface ClientOnlyProps {
  * )
  * ```
  */
+/**
+ * Render children only after client hydration; otherwise render `fallback`.
+ * Useful for components that require browser-only APIs.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/clientOnlyComponent
+ */
 export function ClientOnly({ children, fallback = null }: ClientOnlyProps) {
   return useHydrated() ? (
     <React.Fragment>{children}</React.Fragment>
@@ -54,6 +59,9 @@ export function ClientOnly({ children, fallback = null }: ClientOnlyProps) {
  * )
  * ```
  * @returns True if the JS has been hydrated already, false otherwise.
+ */
+/**
+ * Return a boolean indicating whether client hydration has occurred.
  */
 function useHydrated(): boolean {
   return React.useSyncExternalStore(

--- a/packages/react-router/src/HeadContent.tsx
+++ b/packages/react-router/src/HeadContent.tsx
@@ -4,6 +4,10 @@ import { useRouter } from './useRouter'
 import { useRouterState } from './useRouterState'
 import type { RouterManagedTag } from '@tanstack/router-core'
 
+/**
+ * Build the list of head/link/meta/script tags to render for active matches.
+ * Used internally by `HeadContent`.
+ */
 export const useTags = () => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce
@@ -186,6 +190,11 @@ export const useTags = () => {
 /**
  * @description The `HeadContent` component is used to render meta tags, links, and scripts for the current route.
  * It should be rendered in the `<head>` of your document.
+ */
+/**
+ * Render route-managed head tags (title, meta, links, styles, head scripts).
+ * Place inside the document head of your app shell.
+ * @link https://tanstack.com/router/latest/docs/framework/react/guide/document-head-management
  */
 export function HeadContent() {
   const tags = useTags()

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -45,6 +45,10 @@ declare module '@tanstack/router-core' {
  * Internal component that renders the router's active match tree with
  * suspense, error, and not-found boundaries. Rendered by `RouterProvider`.
  */
+/**
+ * Internal component that renders the router's active match tree with
+ * suspense, error, and not-found boundaries. Rendered by `RouterProvider`.
+ */
 export function Matches() {
   const router = useRouter()
   const rootRoute: AnyRoute = router.routesById[rootRouteId]
@@ -259,6 +263,10 @@ export function useMatches<
  *
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useMatchesHook
  */
+/**
+ * Read the full array of active route matches or select a derived subset
+ * from the parent boundary up to (but not including) the current match.
+ */
 export function useParentMatches<
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
@@ -281,6 +289,10 @@ export function useParentMatches<
   } as any)
 }
 
+/**
+ * Read the array of active route matches that are children of the current
+ * match (or selected parent) in the match tree.
+ */
 /**
  * Read the array of active route matches that are children of the current
  * match (or selected parent) in the match tree.

--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -11,6 +11,10 @@ import type {
  * Low-level provider that places the router into React context and optionally
  * updates router options from props. Most apps should use `RouterProvider`.
  */
+/**
+ * Low-level provider that places the router into React context and optionally
+ * updates router options from props. Most apps should use `RouterProvider`.
+ */
 export function RouterContextProvider<
   TRouter extends AnyRouter = RegisteredRouter,
   TDehydrated extends Record<string, any> = Record<string, any>,
@@ -56,6 +60,11 @@ export function RouterContextProvider<
  * instance after creation.
  *
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createRouterFunction
+ */
+/**
+ * Top-level component that renders the active route matches and provides the
+ * router to the React tree via context. Accepts the same options as
+ * `createRouter` via props to update the router instance.
  */
 export function RouterProvider<
   TRouter extends AnyRouter = RegisteredRouter,

--- a/packages/react-router/src/ScriptOnce.tsx
+++ b/packages/react-router/src/ScriptOnce.tsx
@@ -1,5 +1,9 @@
 import { useRouter } from './useRouter'
 
+/**
+ * Server-only helper to emit a script tag exactly once during SSR.
+ * Appends an internal marker to signal hydration completion.
+ */
 export function ScriptOnce({ children }: { children: string }) {
   const router = useRouter()
   if (!router.isServer) {

--- a/packages/react-router/src/Scripts.tsx
+++ b/packages/react-router/src/Scripts.tsx
@@ -7,6 +7,10 @@ import type { RouterManagedTag } from '@tanstack/router-core'
  * Render body script tags collected from route matches and SSR manifests.
  * Should be placed near the end of the document body.
  */
+/**
+ * Render body script tags collected from route matches and SSR manifests.
+ * Should be placed near the end of the document body.
+ */
 export const Scripts = () => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce

--- a/packages/react-router/src/awaited.tsx
+++ b/packages/react-router/src/awaited.tsx
@@ -8,6 +8,7 @@ export type AwaitOptions<T> = {
 }
 
 /** Suspend until a deferred promise resolves/rejects and return its data. */
+/** Suspend until a deferred promise resolves or rejects and return its data. */
 export function useAwaited<T>({
   promise: _promise,
 }: AwaitOptions<T>): [T, DeferredPromise<T>] {
@@ -24,6 +25,10 @@ export function useAwaited<T>({
   return [promise[TSR_DEFERRED_PROMISE].data, promise]
 }
 
+/**
+ * Component that suspends on a deferred promise and renders its child with
+ * the resolved value. Optionally provides a Suspense fallback.
+ */
 /**
  * Component that suspends on a deferred promise and renders its child with
  * the resolved value. Optionally provides a Suspense fallback.

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -57,6 +57,13 @@ import type { UseRouteContextRoute } from './useRouteContext'
  * @returns A function that accepts Route options and returns a Route instance.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createFileRouteFunction
  */
+/**
+ * Creates a file-based Route factory for a given path.
+ * Used by file-based routing to associate a file with a route. The returned
+ * function accepts standard route options; the path is typically auto-managed
+ * by the generator.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createFileRouteFunction
+ */
 export function createFileRoute<
   TFilePath extends keyof FileRoutesByPath,
   TParentRoute extends AnyRoute = FileRoutesByPath[TFilePath]['parentRoute'],
@@ -84,6 +91,10 @@ export function createFileRoute<
 /** 
   @deprecated It's no longer recommended to use the `FileRoute` class directly.
   Instead, use `createFileRoute('/path/to/file')(options)` to create a file route.
+*/
+/**
+  @deprecated It's no longer recommended to use the `FileRoute` class directly.
+  Instead, use `createFileRoute('/path')(options)` to create a file route.
 */
 export class FileRoute<
   TFilePath extends keyof FileRoutesByPath,
@@ -183,6 +194,10 @@ export class FileRoute<
   @deprecated It's recommended not to split loaders into separate files.
   Instead, place the loader function in the the main route file, inside the
   `createFileRoute('/path/to/file)(options)` options.
+*/
+/**
+  @deprecated It's recommended not to split loaders into separate files.
+  Instead, place the loader function in the main route file via `createFileRoute`.
 */
 export function FileRouteLoader<
   TFilePath extends keyof FileRoutesByPath,
@@ -308,6 +323,10 @@ export class LazyRoute<TRoute extends AnyRoute> {
  * @returns A function that accepts lazy route options and returns a `LazyRoute`.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createLazyRouteFunction
  */
+/**
+ * Create a lazily-configurable code-based route stub by ID.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createLazyRouteFunction
+ */
 export function createLazyRoute<
   TRouter extends AnyRouter = RegisteredRouter,
   TId extends string = string,
@@ -341,6 +360,10 @@ export function createLazyRoute<
  *
  * @param id File path literal for the route file.
  * @returns A function that accepts lazy route options and returns a `LazyRoute`.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createLazyFileRouteFunction
+ */
+/**
+ * Create a lazily-configurable file-based route stub by file path.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createLazyFileRouteFunction
  */
 export function createLazyFileRoute<

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -615,6 +615,21 @@ export type LinkOptionsFn<TComp> = <
   options: LinkOptionsFnOptions<TOptions, TComp, TRouter>,
 ) => TOptions
 
+/**
+ * Validate and reuse navigation options for `Link`, `navigate` or `redirect`.
+ * Accepts a literal options object and returns it typed for later spreading.
+ * @example
+ * const opts = linkOptions({ to: '/dashboard', search: { tab: 'home' } })
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/linkOptions
+ */
 export const linkOptions: LinkOptionsFn<'a'> = (options) => {
   return options as any
 }
+
+/**
+ * Type-check a literal object for use with `Link`, `navigate` or `redirect`.
+ * Use to validate and reuse navigation options across your app.
+ * @example
+ * const opts = linkOptions({ to: '/dashboard', search: { tab: 'home' } })
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/linkOptions
+ */

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -88,6 +88,11 @@ declare module '@tanstack/router-core' {
  * @returns A Router instance to be provided to `RouterProvider`.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createRouterFunction
  */
+/**
+ * Create a new React router instance from `RouterOptions`.
+ * Pass the resulting router to `RouterProvider`.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createRouterFunction
+ */
 export const createRouter: CreateRouterFn = (options) => {
   return new Router(options)
 }

--- a/packages/react-router/src/useLoaderData.tsx
+++ b/packages/react-router/src/useLoaderData.tsx
@@ -65,6 +65,10 @@ export type UseLoaderDataRoute<out TId> = <
  * @returns The loader data (or selected value) for the matched route.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useLoaderDataHook
  */
+/**
+ * Read and select the current route's loader data with type‑safety.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useLoaderDataHook
+ */
 export function useLoaderData<
   TRouter extends AnyRouter = RegisteredRouter,
   const TFrom extends string | undefined = undefined,

--- a/packages/react-router/src/useLoaderDeps.tsx
+++ b/packages/react-router/src/useLoaderDeps.tsx
@@ -51,6 +51,10 @@ export type UseLoaderDepsRoute<out TId> = <
  * @returns The loader deps (or selected value) for the matched route.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useLoaderDepsHook
  */
+/**
+ * Read and select the current route's loader dependencies object.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useLoaderDepsHook
+ */
 export function useLoaderDeps<
   TRouter extends AnyRouter = RegisteredRouter,
   const TFrom extends string | undefined = undefined,

--- a/packages/react-router/src/useLocation.tsx
+++ b/packages/react-router/src/useLocation.tsx
@@ -37,6 +37,11 @@ export type UseLocationResult<
  * @returns The current location (or selected value).
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useLocationHook
  */
+/**
+ * Read the current location from the router state with optional selection.
+ * Useful for subscribing to just the pieces of location you care about.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useLocationHook
+ */
 export function useLocation<
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,

--- a/packages/react-router/src/useMatch.tsx
+++ b/packages/react-router/src/useMatch.tsx
@@ -77,14 +77,6 @@ export type UseMatchResult<
 
 /**
  * Read and select the nearest or targeted route match.
- *
- * Options:
- * - `from`/`strict`: Target a specific route ID and control union vs. exact typing
- * - `select`: Project the match object to a derived value
- * - `shouldThrow`: Throw if the match is not found in strict contexts
- * - `structuralSharing`: Enable structural sharing for stable references
- *
- * @returns The active match (or selected value).
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useMatchHook
  */
 export function useMatch<

--- a/packages/react-router/src/useParams.tsx
+++ b/packages/react-router/src/useParams.tsx
@@ -73,6 +73,10 @@ export type UseParamsRoute<out TFrom> = <
  * @returns The params object (or selected value) for the matched route.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useParamsHook
  */
+/**
+ * Access the current route's path parameters with type-safety.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useParamsHook
+ */
 export function useParams<
   TRouter extends AnyRouter = RegisteredRouter,
   const TFrom extends string | undefined = undefined,

--- a/packages/react-router/src/useRouter.tsx
+++ b/packages/react-router/src/useRouter.tsx
@@ -13,6 +13,11 @@ import type { AnyRouter, RegisteredRouter } from '@tanstack/router-core'
  * @returns The registered router instance.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useRouterHook
  */
+/**
+ * Access the current TanStack Router instance from React context.
+ * Must be used within a `RouterProvider`.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useRouterHook
+ */
 export function useRouter<TRouter extends AnyRouter = RegisteredRouter>(opts?: {
   warn?: boolean
 }): TRouter {

--- a/packages/react-router/src/useRouterState.tsx
+++ b/packages/react-router/src/useRouterState.tsx
@@ -40,6 +40,11 @@ export type UseRouterStateResult<
  * @returns The selected router state (or the full state by default).
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useRouterStateHook
  */
+/**
+ * Subscribe to the router's state store with optional selection and
+ * structural sharing for render optimization.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useRouterStateHook
+ */
 export function useRouterState<
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,

--- a/packages/react-router/src/useSearch.tsx
+++ b/packages/react-router/src/useSearch.tsx
@@ -73,6 +73,10 @@ export type UseSearchRoute<out TFrom> = <
  * @returns The search object (or selected value) for the matched route.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useSearchHook
  */
+/**
+ * Read and select the current route's search parameters with type-safety.
+ * @link https://tanstack.com/router/latest/docs/framework/react/api/router/useSearchHook
+ */
 export function useSearch<
   TRouter extends AnyRouter = RegisteredRouter,
   const TFrom extends string | undefined = undefined,

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -23,6 +23,7 @@ export interface Segment {
 }
 
 /** Join path segments, cleaning duplicate slashes between parts. */
+/** Join path segments, cleaning duplicate slashes between parts. */
 export function joinPaths(paths: Array<string | undefined>) {
   return cleanPath(
     paths
@@ -34,21 +35,25 @@ export function joinPaths(paths: Array<string | undefined>) {
 }
 
 /** Remove repeated slashes from a path string. */
+/** Remove repeated slashes from a path string. */
 export function cleanPath(path: string) {
   // remove double slashes
   return path.replace(/\/{2,}/g, '/')
 }
 
 /** Trim leading slashes (except preserving root '/'). */
+/** Trim leading slashes (except preserving root '/'). */
 export function trimPathLeft(path: string) {
   return path === '/' ? path : path.replace(/^\/{1,}/, '')
 }
 
 /** Trim trailing slashes (except preserving root '/'). */
+/** Trim trailing slashes (except preserving root '/'). */
 export function trimPathRight(path: string) {
   return path === '/' ? path : path.replace(/\/{1,}$/, '')
 }
 
+/** Trim both leading and trailing slashes. */
 /** Trim both leading and trailing slashes. */
 export function trimPath(path: string) {
   return trimPathRight(trimPathLeft(path))
@@ -66,6 +71,10 @@ export function removeTrailingSlash(value: string, basepath: string): string {
 // see the usage in the isActive under useLinkProps
 // /sample/path1 = /sample/path1/
 // /sample/path1/some <> /sample/path1
+/**
+ * Compare two pathnames for exact equality after normalizing trailing slashes
+ * relative to the provided `basepath`.
+ */
 /**
  * Compare two pathnames for exact equality after normalizing trailing slashes
  * relative to the provided `basepath`.
@@ -226,6 +235,10 @@ export const parseRoutePathSegments = (
   cache?: ParsePathnameCache,
 ): ReadonlyArray<Segment> => parsePathname(pathname, cache, false)
 
+/**
+ * Parse a pathname into an array of typed segments used by the router's
+ * matcher. Results are optionally cached via an LRU cache.
+ */
 /**
  * Parse a pathname into an array of typed segments used by the router's
  * matcher. Results are optionally cached via an LRU cache.
@@ -409,6 +422,10 @@ type InterPolatePathResult = {
  * - Supports `{-$optional}` segments, `{prefix{$id}suffix}` and `{$}` wildcards
  * - Optionally leaves placeholders or wildcards in place
  */
+/**
+ * Interpolate params and wildcards into a route path template.
+ * Encodes safely and supports optional params and custom decode char maps.
+ */
 export function interpolatePath({
   path,
   params,
@@ -539,6 +556,10 @@ function encodePathParam(value: string, decodeCharMap?: Map<string, string>) {
  * Match a pathname against a route destination and return extracted params
  * or `undefined`. Uses the same parsing as the router for consistency.
  */
+/**
+ * Match a pathname against a route destination and return extracted params
+ * or `undefined`. Uses the same parsing as the router for consistency.
+ */
 export function matchPathname(
   currentPathname: string,
   matchLocation: Pick<MatchLocation, 'to' | 'fuzzy' | 'caseSensitive'>,
@@ -554,6 +575,7 @@ export function matchPathname(
   return pathParams ?? {}
 }
 
+/** Low-level matcher that compares two path strings and extracts params. */
 /** Low-level matcher that compares two path strings and extracts params. */
 export function matchByPath(
   from: string,

--- a/packages/router-core/src/qss.ts
+++ b/packages/router-core/src/qss.ts
@@ -47,6 +47,7 @@ export function encode(
  * // Example input: toValue("123")
  * // Expected output: 123
  */
+/** Convert a string into a primitive boolean/number when possible. */
 function toValue(str: unknown) {
   if (!str) return ''
 

--- a/packages/router-core/src/rewrite.ts
+++ b/packages/router-core/src/rewrite.ts
@@ -2,6 +2,7 @@ import { joinPaths, trimPath } from './path'
 import type { LocationRewrite } from './router'
 
 /** Compose multiple rewrite pairs into a single in/out rewrite. */
+/** Compose multiple rewrite pairs into a single in/out rewrite. */
 export function composeRewrites(rewrites: Array<LocationRewrite>) {
   return {
     input: ({ url }) => {
@@ -19,6 +20,7 @@ export function composeRewrites(rewrites: Array<LocationRewrite>) {
   } satisfies LocationRewrite
 }
 
+/** Create a rewrite pair that strips/adds a basepath on input/output. */
 /** Create a rewrite pair that strips/adds a basepath on input/output. */
 export function rewriteBasepath(opts: {
   basepath: string
@@ -57,6 +59,7 @@ export function rewriteBasepath(opts: {
 }
 
 /** Execute a location input rewrite if provided. */
+/** Execute a location input rewrite if provided. */
 export function executeRewriteInput(
   rewrite: LocationRewrite | undefined,
   url: URL,
@@ -72,6 +75,7 @@ export function executeRewriteInput(
   return url
 }
 
+/** Execute a location output rewrite if provided. */
 /** Execute a location output rewrite if provided. */
 export function executeRewriteOutput(
   rewrite: LocationRewrite | undefined,

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -35,6 +35,7 @@ function getSafeSessionStorage() {
 
 /** SessionStorage key used to persist scroll restoration state. */
 /** SessionStorage key used to store scroll positions across navigations. */
+/** SessionStorage key used to store scroll positions across navigations. */
 export const storageKey = 'tsr-scroll-restoration-v1_3'
 
 const throttle = (fn: (...args: Array<any>) => void, wait: number) => {
@@ -74,6 +75,7 @@ function createScrollRestorationCache(): ScrollRestorationCache | null {
 
 /** In-memory handle to the persisted scroll restoration cache. */
 /** In-memory handle to the persisted scroll restoration cache. */
+/** In-memory handle to the persisted scroll restoration cache. */
 export const scrollRestorationCache = createScrollRestorationCache()
 
 /**
@@ -83,6 +85,9 @@ export const scrollRestorationCache = createScrollRestorationCache()
  * The `location.href` is used as a fallback to support the use case where the location state is not available like the initial render.
  */
 
+/**
+ * Default scroll restoration cache key: location state key or full href.
+ */
 /**
  * Default scroll restoration cache key: location state key or full href.
  */
@@ -112,6 +117,9 @@ let ignoreScroll = false
 // unless they are passed in as arguments. Why? Because we need to be able to
 // toString() it into a script tag to execute as early as possible in the browser
 // during SSR. Additionally, we also call it from within the router lifecycle
+/**
+ * Restore scroll positions for window/elements based on cached entries.
+ */
 /**
  * Restore scroll positions for window/elements based on cached entries.
  */
@@ -214,6 +222,7 @@ export function restoreScroll({
   ignoreScroll = false
 }
 
+/** Setup global listeners and hooks to support scroll restoration. */
 /** Setup global listeners and hooks to support scroll restoration. */
 export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
   if (!scrollRestorationCache && !router.isServer) {
@@ -387,6 +396,11 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
  *
  * Provides hash scrolling for programmatic navigation when default browser handling is prevented.
  * @param router The router instance containing current location and state
+ */
+/**
+ * @private
+ * Handles hash-based scrolling after navigation completes.
+ * To be used in framework-specific Transitioners.
  */
 export function handleHashScroll(router: AnyRouter) {
   if (typeof document !== 'undefined' && (document as any).querySelector) {

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -3,7 +3,9 @@ import type { AnySchema } from './validators'
 
 /** Default `parseSearch` that strips leading '?' and JSON-parses values. */
 /** Default `parseSearch` that strips leading '?' and JSON-parses values. */
+/** Default `parseSearch` that strips leading '?' and JSON-parses values. */
 export const defaultParseSearch = parseSearchWith(JSON.parse)
+/** Default `stringifySearch` using JSON.stringify for complex values. */
 export const defaultStringifySearch = stringifySearchWith(
   JSON.stringify,
   JSON.parse,

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -184,6 +184,10 @@ export type LooseAsyncReturnType<T> = T extends (
     : TReturn
   : never
 
+/**
+ * Return the last element of an array.
+ * Intended for non-empty arrays used within router internals.
+ */
 export function last<T>(arr: Array<T>) {
   return arr[arr.length - 1]
 }
@@ -192,6 +196,10 @@ function isFunction(d: any): d is Function {
   return typeof d === 'function'
 }
 
+/**
+ * Apply a value-or-updater to a previous value.
+ * Accepts either a literal value or a function of the previous value.
+ */
 export function functionalUpdate<TPrevious, TResult = TPrevious>(
   updater: Updater<TPrevious, TResult> | NonNullableUpdater<TPrevious, TResult>,
   previous: TPrevious,
@@ -311,10 +319,17 @@ function hasObjectPrototype(o: any) {
   return Object.prototype.toString.call(o) === '[object Object]'
 }
 
+/**
+ * Check if a value is a "plain" array (no extra enumerable keys).
+ */
 export function isPlainArray(value: unknown): value is Array<unknown> {
   return Array.isArray(value) && value.length === Object.keys(value).length
 }
 
+/**
+ * Perform a deep equality check with options for partial comparison and
+ * ignoring `undefined` values. Optimized for router state comparisons.
+ */
 export function deepEqual(
   a: any,
   b: any,
@@ -407,6 +422,10 @@ export type ControlledPromise<T> = Promise<T> & {
   value?: T
 }
 
+/**
+ * Create a promise with exposed resolve/reject and status fields.
+ * Useful for coordinating async router lifecycle operations.
+ */
 export function createControlledPromise<T>(onResolve?: (value: T) => void) {
   let resolveLoadPromise!: (value: T) => void
   let rejectLoadPromise!: (value: any) => void
@@ -433,6 +452,10 @@ export function createControlledPromise<T>(onResolve?: (value: T) => void) {
   return controlledPromise
 }
 
+/**
+ * Heuristically detect dynamic import "module not found" errors
+ * across major browsers for lazy route component handling.
+ */
 export function isModuleNotFoundError(error: any): boolean {
   // chrome: "Failed to fetch dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
   // firefox: "error loading dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"


### PR DESCRIPTION
Add JSDoc annotations to multiple public APIs across core and React packages for improved code self-documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-01b16cea-ff1f-4c79-b05a-0ab20e72005a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-01b16cea-ff1f-4c79-b05a-0ab20e72005a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

