### PR TITLE
fix: filter out routes from manifest that have neither preloads nor a…

### DIFF
--- a/packages/start-plugin-core/src/start-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/plugin.ts
@@ -244,6 +244,16 @@ export function startManifestPlugin(opts: {
 
           recurseRoute(routeTreeRoutes[rootRouteId]!)
 
+          // Filter out routes that have neither assets nor preloads
+          Object.keys(routeTreeRoutes).forEach((routeId) => {
+            const route = routeTreeRoutes[routeId]!
+            const hasAssets = route.assets && route.assets.length > 0
+            const hasPreloads = route.preloads && route.preloads.length > 0
+            if (!hasAssets && !hasPreloads) {
+              delete routeTreeRoutes[routeId]
+            }
+          })
+
           const startManifest = {
             routes: routeTreeRoutes,
             clientEntry: joinURL(

--- a/packages/start-server-core/src/router-manifest.ts
+++ b/packages/start-server-core/src/router-manifest.ts
@@ -1,6 +1,7 @@
 import { rootRouteId } from '@tanstack/router-core'
 import { VIRTUAL_MODULES } from './virtual-modules'
 import { loadVirtualModule } from './loadVirtualModule'
+import type { RouterManagedTag } from '@tanstack/router-core'
 
 /**
  * @description Returns the router manifest that should be sent to the client.
@@ -43,13 +44,17 @@ export async function getStartManifest() {
     routes: Object.fromEntries(
       Object.entries(startManifest.routes).map(([k, v]) => {
         const { preloads, assets } = v
-        return [
-          k,
-          {
-            preloads,
-            assets,
-          },
-        ]
+        const result = {} as {
+          preloads?: Array<string>
+          assets?: Array<RouterManagedTag>
+        }
+        if (preloads) {
+          result['preloads'] = preloads
+        }
+        if (assets) {
+          result['assets'] = assets
+        }
+        return [k, result]
       }),
     ),
   }


### PR DESCRIPTION
…ssets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized route tree pruning to remove routes without assets or preloads
  * Streamlined manifest to exclude empty or undefined route entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->