### PR TITLE
test(solid-router): un-skip link tests

### DIFF
--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -260,7 +260,7 @@ export function useLinkProps<
       propsSafeToSpread,
       {
         ref,
-        href: externalLink,
+        href: externalLink(),
       },
       Solid.splitProps(local, [
         'target',

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -675,8 +675,7 @@ describe('Link', () => {
     expect(pageZero).toBeInTheDocument()
   })
 
-  // TODO - THIS WORKS IN REACT
-  test.skip('when navigation to . from /posts while updating search from /', async () => {
+  test('when navigation to . from /posts while updating search from /', async () => {
     const RootComponent = () => {
       return (
         <>
@@ -774,12 +773,13 @@ describe('Link', () => {
 
     fireEvent.click(updateSearchLink)
 
+    const updatedPage = await screen.findByTestId('current-page')
+    const updatedFilter = await screen.findByTestId('current-filter')
+
     // Verify search was updated
     expect(window.location.pathname).toBe('/posts')
     expect(window.location.search).toBe('?page=2&filter=inactive')
 
-    const updatedPage = await screen.findByTestId('current-page')
-    const updatedFilter = await screen.findByTestId('current-filter')
     expect(updatedPage).toHaveTextContent('Page: 2')
     expect(updatedFilter).toHaveTextContent('Filter: inactive')
   })
@@ -1627,8 +1627,7 @@ describe('Link', () => {
     expect(window.location.pathname).toBe('/posts/id1')
   })
 
-  // TODO - THIS WORKS IN REACT
-  test.skip('when navigating from /posts/$postId to "/"', async () => {
+  test('when navigating from /posts/$postId to "/"', async () => {
     const rootRoute = createRootRoute({
       component: () => {
         return (
@@ -1745,8 +1744,9 @@ describe('Link', () => {
 
     fireEvent.click(homeLink)
 
-    expect(window.location.pathname).toBe('/')
     const homeHeading = await screen.findByTestId('home-heading')
+
+    expect(window.location.pathname).toBe('/')
     expect(homeHeading).toBeInTheDocument()
 
     expect(consoleWarnSpy).not.toHaveBeenCalled()
@@ -6346,8 +6346,7 @@ describe('when on /posts/$postId and navigating to ../ with default `from` /post
 })
 
 describe('rewrite', () => {
-  // TODO - THIS WORKS IN REACT
-  test.skip('renders hard link when rewrite points to different origin', async () => {
+  test('renders hard link when rewrite points to different origin', async () => {
     const rootRoute = createRootRoute()
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,


### PR DESCRIPTION
3 skipped link tests can be now be enabled. 2 due to timing, and 1 missed an accessor call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external links to correctly resolve to their intended URLs.

* **Tests**
  * Re-enabled previously skipped test scenarios for navigation and search parameter updates.
  * Enhanced tests with explicit waits to ensure UI updates are captured before assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->