### PR TITLE
docs: add guide for New Relic integration

### DIFF
--- a/docs/start/framework/react/guide/observability.md
+++ b/docs/start/framework/react/guide/observability.md
@@ -555,29 +555,28 @@ If you want to add monitoring for server functions and server routes, you will n
 
 ```ts
 // newrelic-middleware.ts
-import newrelic from 'newrelic';
-import { createMiddleware } from "@tanstack/react-start";
+import newrelic from 'newrelic'
+import { createMiddleware } from '@tanstack/react-start'
 
-export const nrTransactionMiddleware = createMiddleware().server(async ({ 
-    request, 
-    next 
-}) => {
-    const reqPath = new URL(request.url).pathname;
-    newrelic.setControllerName(reqPath, request.method ?? 'GET');
-    return await next();
-});
+export const nrTransactionMiddleware = createMiddleware().server(
+  async ({ request, next }) => {
+    const reqPath = new URL(request.url).pathname
+    newrelic.setControllerName(reqPath, request.method ?? 'GET')
+    return await next()
+  },
+)
 ```
 
 ```ts
 // start.ts
-import { createStart } from "@tanstack/react-start";
-import { nrTransactionMiddleware } from "./newrelic-middleware";
+import { createStart } from '@tanstack/react-start'
+import { nrTransactionMiddleware } from './newrelic-middleware'
 
 export const startInstance = createStart(() => {
-    return {
-        requestMiddleware: [nrTransactionMiddleware],
-    };
-});
+  return {
+    requestMiddleware: [nrTransactionMiddleware],
+  }
+})
 ```
 
 #### SPA & Browser
@@ -589,20 +588,20 @@ After you set it up, you will have to add the integration script that New Relic 
 ```tsx
 // __root.tsx
 export const Route = createRootRoute({
-    head: () => ({
-      scripts: [
-          {
-              id: "new-relic",
-              
-              // either copy/paste your New Relic integration script here
-              children: `...`,
+  head: () => ({
+    scripts: [
+      {
+        id: 'new-relic',
 
-              // or you can create it in your public folder and then reference it here
-              src: "/newrelic.js",
-          },
-      ],
-    }),
-});
+        // either copy/paste your New Relic integration script here
+        children: `...`,
+
+        // or you can create it in your public folder and then reference it here
+        src: '/newrelic.js',
+      },
+    ],
+  }),
+})
 ```
 
 ### OpenTelemetry Integration (Experimental)


### PR DESCRIPTION
Given that Sentry is still not ready for RC, New Relic is pretty much the next best thing.

Added a quick guide on how to have it setup for monitoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded observability docs with a full New Relic integration guide, including quick-start configuration, server and client integration steps, middleware and route setup examples for collecting traces and custom attributes, and CLI guidance to run the agent. New Relic content is presented alongside existing OpenTelemetry and other external observability tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->