### PR TITLE
test(solid-start): fix basic-solid-query nav tests

### DIFF
--- a/e2e/solid-start/basic-solid-query/src/routeTree.gen.ts
+++ b/e2e/solid-start/basic-solid-query/src/routeTree.gen.ts
@@ -13,14 +13,18 @@ import { Route as UsersRouteImport } from './routes/users'
 import { Route as SuspenseTransitionRouteImport } from './routes/suspense-transition'
 import { Route as PostsRouteImport } from './routes/posts'
 import { Route as DeferredRouteImport } from './routes/deferred'
+import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as UsersIndexRouteImport } from './routes/users.index'
 import { Route as PostsIndexRouteImport } from './routes/posts.index'
 import { Route as UsersUserIdRouteImport } from './routes/users.$userId'
 import { Route as PostsPostIdRouteImport } from './routes/posts.$postId'
 import { Route as ApiUsersRouteImport } from './routes/api.users'
+import { Route as LayoutLayout2RouteImport } from './routes/_layout/_layout-2'
 import { Route as PostsPostIdDeepRouteImport } from './routes/posts_.$postId.deep'
 import { Route as ApiUsersIdRouteImport } from './routes/api/users.$id'
+import { Route as LayoutLayout2LayoutBRouteImport } from './routes/_layout/_layout-2/layout-b'
+import { Route as LayoutLayout2LayoutARouteImport } from './routes/_layout/_layout-2/layout-a'
 
 const UsersRoute = UsersRouteImport.update({
   id: '/users',
@@ -40,6 +44,10 @@ const PostsRoute = PostsRouteImport.update({
 const DeferredRoute = DeferredRouteImport.update({
   id: '/deferred',
   path: '/deferred',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LayoutRoute = LayoutRouteImport.update({
+  id: '/_layout',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -72,6 +80,10 @@ const ApiUsersRoute = ApiUsersRouteImport.update({
   path: '/api/users',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LayoutLayout2Route = LayoutLayout2RouteImport.update({
+  id: '/_layout-2',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const PostsPostIdDeepRoute = PostsPostIdDeepRouteImport.update({
   id: '/posts_/$postId/deep',
   path: '/posts/$postId/deep',
@@ -81,6 +93,16 @@ const ApiUsersIdRoute = ApiUsersIdRouteImport.update({
   id: '/$id',
   path: '/$id',
   getParentRoute: () => ApiUsersRoute,
+} as any)
+const LayoutLayout2LayoutBRoute = LayoutLayout2LayoutBRouteImport.update({
+  id: '/layout-b',
+  path: '/layout-b',
+  getParentRoute: () => LayoutLayout2Route,
+} as any)
+const LayoutLayout2LayoutARoute = LayoutLayout2LayoutARouteImport.update({
+  id: '/layout-a',
+  path: '/layout-a',
+  getParentRoute: () => LayoutLayout2Route,
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -94,6 +116,8 @@ export interface FileRoutesByFullPath {
   '/users/$userId': typeof UsersUserIdRoute
   '/posts/': typeof PostsIndexRoute
   '/users/': typeof UsersIndexRoute
+  '/layout-a': typeof LayoutLayout2LayoutARoute
+  '/layout-b': typeof LayoutLayout2LayoutBRoute
   '/api/users/$id': typeof ApiUsersIdRoute
   '/posts/$postId/deep': typeof PostsPostIdDeepRoute
 }
@@ -106,21 +130,27 @@ export interface FileRoutesByTo {
   '/users/$userId': typeof UsersUserIdRoute
   '/posts': typeof PostsIndexRoute
   '/users': typeof UsersIndexRoute
+  '/layout-a': typeof LayoutLayout2LayoutARoute
+  '/layout-b': typeof LayoutLayout2LayoutBRoute
   '/api/users/$id': typeof ApiUsersIdRoute
   '/posts/$postId/deep': typeof PostsPostIdDeepRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/_layout': typeof LayoutRouteWithChildren
   '/deferred': typeof DeferredRoute
   '/posts': typeof PostsRouteWithChildren
   '/suspense-transition': typeof SuspenseTransitionRoute
   '/users': typeof UsersRouteWithChildren
+  '/_layout/_layout-2': typeof LayoutLayout2RouteWithChildren
   '/api/users': typeof ApiUsersRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
   '/users/$userId': typeof UsersUserIdRoute
   '/posts/': typeof PostsIndexRoute
   '/users/': typeof UsersIndexRoute
+  '/_layout/_layout-2/layout-a': typeof LayoutLayout2LayoutARoute
+  '/_layout/_layout-2/layout-b': typeof LayoutLayout2LayoutBRoute
   '/api/users/$id': typeof ApiUsersIdRoute
   '/posts_/$postId/deep': typeof PostsPostIdDeepRoute
 }
@@ -137,6 +167,8 @@ export interface FileRouteTypes {
     | '/users/$userId'
     | '/posts/'
     | '/users/'
+    | '/layout-a'
+    | '/layout-b'
     | '/api/users/$id'
     | '/posts/$postId/deep'
   fileRoutesByTo: FileRoutesByTo
@@ -149,26 +181,33 @@ export interface FileRouteTypes {
     | '/users/$userId'
     | '/posts'
     | '/users'
+    | '/layout-a'
+    | '/layout-b'
     | '/api/users/$id'
     | '/posts/$postId/deep'
   id:
     | '__root__'
     | '/'
+    | '/_layout'
     | '/deferred'
     | '/posts'
     | '/suspense-transition'
     | '/users'
+    | '/_layout/_layout-2'
     | '/api/users'
     | '/posts/$postId'
     | '/users/$userId'
     | '/posts/'
     | '/users/'
+    | '/_layout/_layout-2/layout-a'
+    | '/_layout/_layout-2/layout-b'
     | '/api/users/$id'
     | '/posts_/$postId/deep'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  LayoutRoute: typeof LayoutRouteWithChildren
   DeferredRoute: typeof DeferredRoute
   PostsRoute: typeof PostsRouteWithChildren
   SuspenseTransitionRoute: typeof SuspenseTransitionRoute
@@ -205,6 +244,13 @@ declare module '@tanstack/solid-router' {
       path: '/deferred'
       fullPath: '/deferred'
       preLoaderRoute: typeof DeferredRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_layout': {
+      id: '/_layout'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof LayoutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -249,6 +295,13 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof ApiUsersRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_layout/_layout-2': {
+      id: '/_layout/_layout-2'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof LayoutLayout2RouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/posts_/$postId/deep': {
       id: '/posts_/$postId/deep'
       path: '/posts/$postId/deep'
@@ -263,8 +316,47 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof ApiUsersIdRouteImport
       parentRoute: typeof ApiUsersRoute
     }
+    '/_layout/_layout-2/layout-b': {
+      id: '/_layout/_layout-2/layout-b'
+      path: '/layout-b'
+      fullPath: '/layout-b'
+      preLoaderRoute: typeof LayoutLayout2LayoutBRouteImport
+      parentRoute: typeof LayoutLayout2Route
+    }
+    '/_layout/_layout-2/layout-a': {
+      id: '/_layout/_layout-2/layout-a'
+      path: '/layout-a'
+      fullPath: '/layout-a'
+      preLoaderRoute: typeof LayoutLayout2LayoutARouteImport
+      parentRoute: typeof LayoutLayout2Route
+    }
   }
 }
+
+interface LayoutLayout2RouteChildren {
+  LayoutLayout2LayoutARoute: typeof LayoutLayout2LayoutARoute
+  LayoutLayout2LayoutBRoute: typeof LayoutLayout2LayoutBRoute
+}
+
+const LayoutLayout2RouteChildren: LayoutLayout2RouteChildren = {
+  LayoutLayout2LayoutARoute: LayoutLayout2LayoutARoute,
+  LayoutLayout2LayoutBRoute: LayoutLayout2LayoutBRoute,
+}
+
+const LayoutLayout2RouteWithChildren = LayoutLayout2Route._addFileChildren(
+  LayoutLayout2RouteChildren,
+)
+
+interface LayoutRouteChildren {
+  LayoutLayout2Route: typeof LayoutLayout2RouteWithChildren
+}
+
+const LayoutRouteChildren: LayoutRouteChildren = {
+  LayoutLayout2Route: LayoutLayout2RouteWithChildren,
+}
+
+const LayoutRouteWithChildren =
+  LayoutRoute._addFileChildren(LayoutRouteChildren)
 
 interface PostsRouteChildren {
   PostsPostIdRoute: typeof PostsPostIdRoute
@@ -304,6 +396,7 @@ const ApiUsersRouteWithChildren = ApiUsersRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  LayoutRoute: LayoutRouteWithChildren,
   DeferredRoute: DeferredRoute,
   PostsRoute: PostsRouteWithChildren,
   SuspenseTransitionRoute: SuspenseTransitionRoute,

--- a/e2e/solid-start/basic-solid-query/src/routes/__root.tsx
+++ b/e2e/solid-start/basic-solid-query/src/routes/__root.tsx
@@ -109,12 +109,26 @@ function RootDocument(props: { children?: any }) {
             Users
           </Link>{' '}
           <Link
+            to="/layout-a"
+            activeProps={{
+              class: 'font-bold',
+            }}
+          >
+            Layout
+          </Link>{' '}
+          <Link
             to="/deferred"
             activeProps={{
               class: 'font-bold',
             }}
           >
             Deferred
+          </Link>{' '}
+          <Link
+            // @ts-expect-error
+            to="/this-route-does-not-exist"
+          >
+            This Route Does Not Exist
           </Link>
         </div>
         <hr />

--- a/e2e/solid-start/basic-solid-query/src/routes/_layout.tsx
+++ b/e2e/solid-start/basic-solid-query/src/routes/_layout.tsx
@@ -1,0 +1,16 @@
+import { Outlet, createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute('/_layout')({
+  component: LayoutComponent,
+})
+
+function LayoutComponent() {
+  return (
+    <div class="p-2">
+      <div>I'm a layout</div>
+      <div>
+        <Outlet />
+      </div>
+    </div>
+  )
+}

--- a/e2e/solid-start/basic-solid-query/src/routes/_layout/_layout-2.tsx
+++ b/e2e/solid-start/basic-solid-query/src/routes/_layout/_layout-2.tsx
@@ -1,0 +1,34 @@
+import { Link, Outlet, createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute('/_layout/_layout-2')({
+  component: LayoutComponent,
+})
+
+function LayoutComponent() {
+  return (
+    <div>
+      <div>I'm a nested layout</div>
+      <div class="flex gap-2">
+        <Link
+          to="/layout-a"
+          activeProps={{
+            class: 'font-bold',
+          }}
+        >
+          Layout A
+        </Link>
+        <Link
+          to="/layout-b"
+          activeProps={{
+            class: 'font-bold',
+          }}
+        >
+          Layout B
+        </Link>
+      </div>
+      <div>
+        <Outlet />
+      </div>
+    </div>
+  )
+}

--- a/e2e/solid-start/basic-solid-query/src/routes/_layout/_layout-2/layout-a.tsx
+++ b/e2e/solid-start/basic-solid-query/src/routes/_layout/_layout-2/layout-a.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/solid-router'
+export const Route = createFileRoute('/_layout/_layout-2/layout-a')({
+  component: LayoutAComponent,
+})
+
+function LayoutAComponent() {
+  return <div>I'm A!</div>
+}

--- a/e2e/solid-start/basic-solid-query/src/routes/_layout/_layout-2/layout-b.tsx
+++ b/e2e/solid-start/basic-solid-query/src/routes/_layout/_layout-2/layout-b.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/solid-router'
+export const Route = createFileRoute('/_layout/_layout-2/layout-b')({
+  component: LayoutBComponent,
+})
+
+function LayoutBComponent() {
+  return <div>I'm B!</div>
+}

--- a/e2e/solid-start/basic-solid-query/tests/app.spec.ts
+++ b/e2e/solid-start/basic-solid-query/tests/app.spec.ts
@@ -17,7 +17,7 @@ test('Navigating to user', async ({ page }) => {
   await expect(page.getByRole('heading')).toContainText('Leanne Graham')
 })
 
-test.skip('Navigating nested layouts', async ({ page }) => {
+test('Navigating nested layouts', async ({ page }) => {
   await page.goto('/')
 
   await page.getByRole('link', { name: 'Layout', exact: true }).click()
@@ -27,7 +27,7 @@ test.skip('Navigating nested layouts', async ({ page }) => {
   await expect(page.locator('body')).toContainText("I'm B!")
 })
 
-test.skip('Navigating to a not-found route', async ({ page }) => {
+test('Navigating to a not-found route', async ({ page }) => {
   await page.goto('/')
 
   await page.getByRole('link', { name: 'This Route Does Not Exist' }).click()


### PR DESCRIPTION
enabled for basic-solid-query the tests:

- 'Navigating to a not-found route'
- 'Navigating nested layouts'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nested layout routing structure with multiple navigable routes.
  * Introduced new navigation links to organized layout sections.

* **Tests**
  * Enabled tests for nested layout navigation and not-found route handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->