### PR TITLE
test(start): fix search-params tests

### DIFF
--- a/e2e/react-start/basic/tests/search-params.spec.ts
+++ b/e2e/react-start/basic/tests/search-params.spec.ts
@@ -19,7 +19,7 @@ function expectRedirect(response: Response | null, endsWith: string) {
 function expectNoRedirect(response: Response | null) {
   expect(response).not.toBeNull()
   const request = response!.request()
-  expect(request.redirectedFrom()?.redirectedTo() === request).toBeTruthy()
+  expect(request.redirectedFrom()).toBeNull()
 }
 
 test.describe('/search-params/loader-throws-redirect', () => {

--- a/e2e/solid-start/basic/tests/search-params.spec.ts
+++ b/e2e/solid-start/basic/tests/search-params.spec.ts
@@ -18,7 +18,7 @@ function expectRedirect(response: Response | null, endsWith: string) {
 function expectNoRedirect(response: Response | null) {
   expect(response).not.toBeNull()
   const request = response!.request()
-  expect(request.redirectedFrom()?.redirectedTo() === request).toBeTruthy()
+  expect(request.redirectedFrom()).toBeNull()
 }
 
 test.describe('/search-params/loader-throws-redirect', () => {


### PR DESCRIPTION
@schiller-manuel , i found that these tests had `toBeTruthy` that weren't called, and they break if they are enabled, which is demonstrated here:
- https://github.com/TanStack/router/pull/5656

I think they should just be checking `expect(request.redirectedFrom()).toBeNull()`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified redirect verification assertions in end-to-end tests across framework implementations to improve test clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->