### PR TITLE
test(solid-router): use default generated values in basic file based

### DIFF
--- a/e2e/solid-router/basic-file-based/src/routeTree.gen.ts
+++ b/e2e/solid-router/basic-file-based/src/routeTree.gen.ts
@@ -81,14 +81,14 @@ import { Route as NonNestedPrefixPrefixChar123bazChar125IndexRouteImport } from 
 import { Route as NonNestedPathBazIndexRouteImport } from './routes/non-nested/path/baz.index'
 import { Route as NonNestedNamedBazIndexRouteImport } from './routes/non-nested/named/$baz.index'
 import { Route as ParamsPsNonNestedFooBarRouteImport } from './routes/params-ps/non-nested/$foo_/$bar'
-import { Route as NonNestedSuffixChar123bazChar125suffixFooRouteImport } from './routes/non-nested/suffix/{$baz}suffix.foo'
 import { Route as NonNestedSuffixChar123bazChar125suffixBarRouteImport } from './routes/non-nested/suffix/{$baz}suffix_.bar'
-import { Route as NonNestedPrefixPrefixChar123bazChar125FooRouteImport } from './routes/non-nested/prefix/prefix{$baz}.foo'
+import { Route as NonNestedSuffixChar123bazChar125suffixFooRouteImport } from './routes/non-nested/suffix/{$baz}suffix.foo'
 import { Route as NonNestedPrefixPrefixChar123bazChar125BarRouteImport } from './routes/non-nested/prefix/prefix{$baz}_.bar'
-import { Route as NonNestedPathBazFooRouteImport } from './routes/non-nested/path/baz.foo'
+import { Route as NonNestedPrefixPrefixChar123bazChar125FooRouteImport } from './routes/non-nested/prefix/prefix{$baz}.foo'
 import { Route as NonNestedPathBazBarRouteImport } from './routes/non-nested/path/baz_.bar'
-import { Route as NonNestedNamedBazFooRouteImport } from './routes/non-nested/named/$baz.foo'
+import { Route as NonNestedPathBazFooRouteImport } from './routes/non-nested/path/baz.foo'
 import { Route as NonNestedNamedBazBarRouteImport } from './routes/non-nested/named/$baz_.bar'
+import { Route as NonNestedNamedBazFooRouteImport } from './routes/non-nested/named/$baz.foo'
 import { Route as ParamsPsNamedFooBarRouteRouteImport } from './routes/params-ps/named/$foo/$bar.route'
 import { Route as RelativeUseNavigatePathPathIndexRouteImport } from './routes/relative/useNavigate/path/$path/index'
 import { Route as RelativeUseNavigateNestedDeepIndexRouteImport } from './routes/relative/useNavigate/nested/deep/index'
@@ -324,7 +324,7 @@ const RedirectTargetViaBeforeLoadRoute =
     getParentRoute: () => RedirectTargetRoute,
   } as any)
 const PostsPostIdEditRoute = PostsPostIdEditRouteImport.update({
-  id: '/posts/$postId/edit',
+  id: '/posts_/$postId/edit',
   path: '/posts/$postId/edit',
   getParentRoute: () => rootRouteImport,
 } as any)
@@ -384,7 +384,7 @@ const groupLayoutInsidelayoutRoute = groupLayoutInsidelayoutRouteImport.update({
 } as any)
 const ParamsPsNonNestedFooRouteRoute =
   ParamsPsNonNestedFooRouteRouteImport.update({
-    id: '/$foo',
+    id: '/$foo_',
     path: '/$foo',
     getParentRoute: () => ParamsPsNonNestedRouteRoute,
   } as any)
@@ -476,17 +476,23 @@ const ParamsPsNonNestedFooBarRoute = ParamsPsNonNestedFooBarRouteImport.update({
   path: '/$bar',
   getParentRoute: () => ParamsPsNonNestedFooRouteRoute,
 } as any)
+const NonNestedSuffixChar123bazChar125suffixBarRoute =
+  NonNestedSuffixChar123bazChar125suffixBarRouteImport.update({
+    id: '/{$baz}suffix_/bar',
+    path: '/{$baz}suffix/bar',
+    getParentRoute: () => NonNestedSuffixRouteRoute,
+  } as any)
 const NonNestedSuffixChar123bazChar125suffixFooRoute =
   NonNestedSuffixChar123bazChar125suffixFooRouteImport.update({
     id: '/foo',
     path: '/foo',
     getParentRoute: () => NonNestedSuffixChar123bazChar125suffixRouteRoute,
   } as any)
-const NonNestedSuffixChar123bazChar125suffixBarRoute =
-  NonNestedSuffixChar123bazChar125suffixBarRouteImport.update({
-    id: '/{$baz}suffix/bar',
-    path: '/{$baz}suffix/bar',
-    getParentRoute: () => NonNestedSuffixRouteRoute,
+const NonNestedPrefixPrefixChar123bazChar125BarRoute =
+  NonNestedPrefixPrefixChar123bazChar125BarRouteImport.update({
+    id: '/prefix{$baz}_/bar',
+    path: '/prefix{$baz}/bar',
+    getParentRoute: () => NonNestedPrefixRouteRoute,
   } as any)
 const NonNestedPrefixPrefixChar123bazChar125FooRoute =
   NonNestedPrefixPrefixChar123bazChar125FooRouteImport.update({
@@ -494,31 +500,25 @@ const NonNestedPrefixPrefixChar123bazChar125FooRoute =
     path: '/foo',
     getParentRoute: () => NonNestedPrefixPrefixChar123bazChar125RouteRoute,
   } as any)
-const NonNestedPrefixPrefixChar123bazChar125BarRoute =
-  NonNestedPrefixPrefixChar123bazChar125BarRouteImport.update({
-    id: '/prefix{$baz}/bar',
-    path: '/prefix{$baz}/bar',
-    getParentRoute: () => NonNestedPrefixRouteRoute,
-  } as any)
+const NonNestedPathBazBarRoute = NonNestedPathBazBarRouteImport.update({
+  id: '/baz_/bar',
+  path: '/baz/bar',
+  getParentRoute: () => NonNestedPathRouteRoute,
+} as any)
 const NonNestedPathBazFooRoute = NonNestedPathBazFooRouteImport.update({
   id: '/foo',
   path: '/foo',
   getParentRoute: () => NonNestedPathBazRouteRoute,
 } as any)
-const NonNestedPathBazBarRoute = NonNestedPathBazBarRouteImport.update({
-  id: '/baz/bar',
-  path: '/baz/bar',
-  getParentRoute: () => NonNestedPathRouteRoute,
+const NonNestedNamedBazBarRoute = NonNestedNamedBazBarRouteImport.update({
+  id: '/$baz_/bar',
+  path: '/$baz/bar',
+  getParentRoute: () => NonNestedNamedRouteRoute,
 } as any)
 const NonNestedNamedBazFooRoute = NonNestedNamedBazFooRouteImport.update({
   id: '/foo',
   path: '/foo',
   getParentRoute: () => NonNestedNamedBazRouteRoute,
-} as any)
-const NonNestedNamedBazBarRoute = NonNestedNamedBazBarRouteImport.update({
-  id: '/$baz/bar',
-  path: '/$baz/bar',
-  getParentRoute: () => NonNestedNamedRouteRoute,
 } as any)
 const ParamsPsNamedFooBarRouteRoute =
   ParamsPsNamedFooBarRouteRouteImport.update({
@@ -616,14 +616,14 @@ export interface FileRoutesByFullPath {
   '/params-ps/wildcard': typeof ParamsPsWildcardIndexRoute
   '/redirect/$target/': typeof RedirectTargetIndexRoute
   '/params-ps/named/$foo/$bar': typeof ParamsPsNamedFooBarRouteRouteWithChildren
-  '/non-nested/named/$baz/bar': typeof NonNestedNamedBazBarRoute
   '/non-nested/named/$baz/foo': typeof NonNestedNamedBazFooRoute
-  '/non-nested/path/baz/bar': typeof NonNestedPathBazBarRoute
+  '/non-nested/named/$baz/bar': typeof NonNestedNamedBazBarRoute
   '/non-nested/path/baz/foo': typeof NonNestedPathBazFooRoute
-  '/non-nested/prefix/prefix{$baz}/bar': typeof NonNestedPrefixPrefixChar123bazChar125BarRoute
+  '/non-nested/path/baz/bar': typeof NonNestedPathBazBarRoute
   '/non-nested/prefix/prefix{$baz}/foo': typeof NonNestedPrefixPrefixChar123bazChar125FooRoute
-  '/non-nested/suffix/{$baz}suffix/bar': typeof NonNestedSuffixChar123bazChar125suffixBarRoute
+  '/non-nested/prefix/prefix{$baz}/bar': typeof NonNestedPrefixPrefixChar123bazChar125BarRoute
   '/non-nested/suffix/{$baz}suffix/foo': typeof NonNestedSuffixChar123bazChar125suffixFooRoute
+  '/non-nested/suffix/{$baz}suffix/bar': typeof NonNestedSuffixChar123bazChar125suffixBarRoute
   '/params-ps/non-nested/$foo/$bar': typeof ParamsPsNonNestedFooBarRoute
   '/non-nested/named/$baz/': typeof NonNestedNamedBazIndexRoute
   '/non-nested/path/baz/': typeof NonNestedPathBazIndexRoute
@@ -694,14 +694,14 @@ export interface FileRoutesByTo {
   '/params-ps/wildcard': typeof ParamsPsWildcardIndexRoute
   '/redirect/$target': typeof RedirectTargetIndexRoute
   '/params-ps/named/$foo/$bar': typeof ParamsPsNamedFooBarRouteRouteWithChildren
-  '/non-nested/named/$baz/bar': typeof NonNestedNamedBazBarRoute
   '/non-nested/named/$baz/foo': typeof NonNestedNamedBazFooRoute
-  '/non-nested/path/baz/bar': typeof NonNestedPathBazBarRoute
+  '/non-nested/named/$baz/bar': typeof NonNestedNamedBazBarRoute
   '/non-nested/path/baz/foo': typeof NonNestedPathBazFooRoute
-  '/non-nested/prefix/prefix{$baz}/bar': typeof NonNestedPrefixPrefixChar123bazChar125BarRoute
+  '/non-nested/path/baz/bar': typeof NonNestedPathBazBarRoute
   '/non-nested/prefix/prefix{$baz}/foo': typeof NonNestedPrefixPrefixChar123bazChar125FooRoute
-  '/non-nested/suffix/{$baz}suffix/bar': typeof NonNestedSuffixChar123bazChar125suffixBarRoute
+  '/non-nested/prefix/prefix{$baz}/bar': typeof NonNestedPrefixPrefixChar123bazChar125BarRoute
   '/non-nested/suffix/{$baz}suffix/foo': typeof NonNestedSuffixChar123bazChar125suffixFooRoute
+  '/non-nested/suffix/{$baz}suffix/bar': typeof NonNestedSuffixChar123bazChar125suffixBarRoute
   '/params-ps/non-nested/$foo/$bar': typeof ParamsPsNonNestedFooBarRoute
   '/non-nested/named/$baz': typeof NonNestedNamedBazIndexRoute
   '/non-nested/path/baz': typeof NonNestedPathBazIndexRoute
@@ -758,7 +758,7 @@ export interface FileRoutesById {
   '/non-nested/prefix/prefix{$baz}': typeof NonNestedPrefixPrefixChar123bazChar125RouteRouteWithChildren
   '/non-nested/suffix/{$baz}suffix': typeof NonNestedSuffixChar123bazChar125suffixRouteRouteWithChildren
   '/params-ps/named/$foo': typeof ParamsPsNamedFooRouteRouteWithChildren
-  '/params-ps/non-nested/$foo': typeof ParamsPsNonNestedFooRouteRouteWithChildren
+  '/params-ps/non-nested/$foo_': typeof ParamsPsNonNestedFooRouteRouteWithChildren
   '/(group)/_layout/insidelayout': typeof groupLayoutInsidelayoutRoute
   '/(group)/subfolder/inside': typeof groupSubfolderInsideRoute
   '/_layout/_layout-2/layout-a': typeof LayoutLayout2LayoutARoute
@@ -769,7 +769,7 @@ export interface FileRoutesById {
   '/params-ps/wildcard/prefix{$}': typeof ParamsPsWildcardPrefixChar123Char125Route
   '/params-ps/wildcard/{$}suffix': typeof ParamsPsWildcardChar123Char125suffixRoute
   '/params/single/$value': typeof ParamsSingleValueRoute
-  '/posts/$postId/edit': typeof PostsPostIdEditRoute
+  '/posts_/$postId/edit': typeof PostsPostIdEditRoute
   '/redirect/$target/via-beforeLoad': typeof RedirectTargetViaBeforeLoadRoute
   '/redirect/$target/via-loader': typeof RedirectTargetViaLoaderRoute
   '/redirect/preload/first': typeof RedirectPreloadFirstRoute
@@ -783,15 +783,15 @@ export interface FileRoutesById {
   '/params-ps/wildcard/': typeof ParamsPsWildcardIndexRoute
   '/redirect/$target/': typeof RedirectTargetIndexRoute
   '/params-ps/named/$foo/$bar': typeof ParamsPsNamedFooBarRouteRouteWithChildren
-  '/non-nested/named/$baz/bar': typeof NonNestedNamedBazBarRoute
   '/non-nested/named/$baz/foo': typeof NonNestedNamedBazFooRoute
-  '/non-nested/path/baz/bar': typeof NonNestedPathBazBarRoute
+  '/non-nested/named/$baz_/bar': typeof NonNestedNamedBazBarRoute
   '/non-nested/path/baz/foo': typeof NonNestedPathBazFooRoute
-  '/non-nested/prefix/prefix{$baz}/bar': typeof NonNestedPrefixPrefixChar123bazChar125BarRoute
+  '/non-nested/path/baz_/bar': typeof NonNestedPathBazBarRoute
   '/non-nested/prefix/prefix{$baz}/foo': typeof NonNestedPrefixPrefixChar123bazChar125FooRoute
-  '/non-nested/suffix/{$baz}suffix/bar': typeof NonNestedSuffixChar123bazChar125suffixBarRoute
+  '/non-nested/prefix/prefix{$baz}_/bar': typeof NonNestedPrefixPrefixChar123bazChar125BarRoute
   '/non-nested/suffix/{$baz}suffix/foo': typeof NonNestedSuffixChar123bazChar125suffixFooRoute
-  '/params-ps/non-nested/$foo/$bar': typeof ParamsPsNonNestedFooBarRoute
+  '/non-nested/suffix/{$baz}suffix_/bar': typeof NonNestedSuffixChar123bazChar125suffixBarRoute
+  '/params-ps/non-nested/$foo_/$bar': typeof ParamsPsNonNestedFooBarRoute
   '/non-nested/named/$baz/': typeof NonNestedNamedBazIndexRoute
   '/non-nested/path/baz/': typeof NonNestedPathBazIndexRoute
   '/non-nested/prefix/prefix{$baz}/': typeof NonNestedPrefixPrefixChar123bazChar125IndexRoute
@@ -870,14 +870,14 @@ export interface FileRouteTypes {
     | '/params-ps/wildcard'
     | '/redirect/$target/'
     | '/params-ps/named/$foo/$bar'
-    | '/non-nested/named/$baz/bar'
     | '/non-nested/named/$baz/foo'
-    | '/non-nested/path/baz/bar'
+    | '/non-nested/named/$baz/bar'
     | '/non-nested/path/baz/foo'
-    | '/non-nested/prefix/prefix{$baz}/bar'
+    | '/non-nested/path/baz/bar'
     | '/non-nested/prefix/prefix{$baz}/foo'
-    | '/non-nested/suffix/{$baz}suffix/bar'
+    | '/non-nested/prefix/prefix{$baz}/bar'
     | '/non-nested/suffix/{$baz}suffix/foo'
+    | '/non-nested/suffix/{$baz}suffix/bar'
     | '/params-ps/non-nested/$foo/$bar'
     | '/non-nested/named/$baz/'
     | '/non-nested/path/baz/'
@@ -948,14 +948,14 @@ export interface FileRouteTypes {
     | '/params-ps/wildcard'
     | '/redirect/$target'
     | '/params-ps/named/$foo/$bar'
-    | '/non-nested/named/$baz/bar'
     | '/non-nested/named/$baz/foo'
-    | '/non-nested/path/baz/bar'
+    | '/non-nested/named/$baz/bar'
     | '/non-nested/path/baz/foo'
-    | '/non-nested/prefix/prefix{$baz}/bar'
+    | '/non-nested/path/baz/bar'
     | '/non-nested/prefix/prefix{$baz}/foo'
-    | '/non-nested/suffix/{$baz}suffix/bar'
+    | '/non-nested/prefix/prefix{$baz}/bar'
     | '/non-nested/suffix/{$baz}suffix/foo'
+    | '/non-nested/suffix/{$baz}suffix/bar'
     | '/params-ps/non-nested/$foo/$bar'
     | '/non-nested/named/$baz'
     | '/non-nested/path/baz'
@@ -1011,7 +1011,7 @@ export interface FileRouteTypes {
     | '/non-nested/prefix/prefix{$baz}'
     | '/non-nested/suffix/{$baz}suffix'
     | '/params-ps/named/$foo'
-    | '/params-ps/non-nested/$foo'
+    | '/params-ps/non-nested/$foo_'
     | '/(group)/_layout/insidelayout'
     | '/(group)/subfolder/inside'
     | '/_layout/_layout-2/layout-a'
@@ -1022,7 +1022,7 @@ export interface FileRouteTypes {
     | '/params-ps/wildcard/prefix{$}'
     | '/params-ps/wildcard/{$}suffix'
     | '/params/single/$value'
-    | '/posts/$postId/edit'
+    | '/posts_/$postId/edit'
     | '/redirect/$target/via-beforeLoad'
     | '/redirect/$target/via-loader'
     | '/redirect/preload/first'
@@ -1036,15 +1036,15 @@ export interface FileRouteTypes {
     | '/params-ps/wildcard/'
     | '/redirect/$target/'
     | '/params-ps/named/$foo/$bar'
-    | '/non-nested/named/$baz/bar'
     | '/non-nested/named/$baz/foo'
-    | '/non-nested/path/baz/bar'
+    | '/non-nested/named/$baz_/bar'
     | '/non-nested/path/baz/foo'
-    | '/non-nested/prefix/prefix{$baz}/bar'
+    | '/non-nested/path/baz_/bar'
     | '/non-nested/prefix/prefix{$baz}/foo'
-    | '/non-nested/suffix/{$baz}suffix/bar'
+    | '/non-nested/prefix/prefix{$baz}_/bar'
     | '/non-nested/suffix/{$baz}suffix/foo'
-    | '/params-ps/non-nested/$foo/$bar'
+    | '/non-nested/suffix/{$baz}suffix_/bar'
+    | '/params-ps/non-nested/$foo_/$bar'
     | '/non-nested/named/$baz/'
     | '/non-nested/path/baz/'
     | '/non-nested/prefix/prefix{$baz}/'
@@ -1412,8 +1412,8 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof RedirectTargetViaBeforeLoadRouteImport
       parentRoute: typeof RedirectTargetRoute
     }
-    '/posts/$postId/edit': {
-      id: '/posts/$postId/edit'
+    '/posts_/$postId/edit': {
+      id: '/posts_/$postId/edit'
       path: '/posts/$postId/edit'
       fullPath: '/posts/$postId/edit'
       preLoaderRoute: typeof PostsPostIdEditRouteImport
@@ -1489,8 +1489,8 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof groupLayoutInsidelayoutRouteImport
       parentRoute: typeof groupLayoutRoute
     }
-    '/params-ps/non-nested/$foo': {
-      id: '/params-ps/non-nested/$foo'
+    '/params-ps/non-nested/$foo_': {
+      id: '/params-ps/non-nested/$foo_'
       path: '/$foo'
       fullPath: '/params-ps/non-nested/$foo'
       preLoaderRoute: typeof ParamsPsNonNestedFooRouteRouteImport
@@ -1601,12 +1601,19 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof NonNestedNamedBazIndexRouteImport
       parentRoute: typeof NonNestedNamedBazRouteRoute
     }
-    '/params-ps/non-nested/$foo/$bar': {
-      id: '/params-ps/non-nested/$foo/$bar'
+    '/params-ps/non-nested/$foo_/$bar': {
+      id: '/params-ps/non-nested/$foo_/$bar'
       path: '/$bar'
       fullPath: '/params-ps/non-nested/$foo/$bar'
       preLoaderRoute: typeof ParamsPsNonNestedFooBarRouteImport
       parentRoute: typeof ParamsPsNonNestedFooRouteRoute
+    }
+    '/non-nested/suffix/{$baz}suffix_/bar': {
+      id: '/non-nested/suffix/{$baz}suffix_/bar'
+      path: '/{$baz}suffix/bar'
+      fullPath: '/non-nested/suffix/{$baz}suffix/bar'
+      preLoaderRoute: typeof NonNestedSuffixChar123bazChar125suffixBarRouteImport
+      parentRoute: typeof NonNestedSuffixRouteRoute
     }
     '/non-nested/suffix/{$baz}suffix/foo': {
       id: '/non-nested/suffix/{$baz}suffix/foo'
@@ -1615,12 +1622,12 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof NonNestedSuffixChar123bazChar125suffixFooRouteImport
       parentRoute: typeof NonNestedSuffixChar123bazChar125suffixRouteRoute
     }
-    '/non-nested/suffix/{$baz}suffix/bar': {
-      id: '/non-nested/suffix/{$baz}suffix/bar'
-      path: '/{$baz}suffix/bar'
-      fullPath: '/non-nested/suffix/{$baz}suffix/bar'
-      preLoaderRoute: typeof NonNestedSuffixChar123bazChar125suffixBarRouteImport
-      parentRoute: typeof NonNestedSuffixRouteRoute
+    '/non-nested/prefix/prefix{$baz}_/bar': {
+      id: '/non-nested/prefix/prefix{$baz}_/bar'
+      path: '/prefix{$baz}/bar'
+      fullPath: '/non-nested/prefix/prefix{$baz}/bar'
+      preLoaderRoute: typeof NonNestedPrefixPrefixChar123bazChar125BarRouteImport
+      parentRoute: typeof NonNestedPrefixRouteRoute
     }
     '/non-nested/prefix/prefix{$baz}/foo': {
       id: '/non-nested/prefix/prefix{$baz}/foo'
@@ -1629,12 +1636,12 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof NonNestedPrefixPrefixChar123bazChar125FooRouteImport
       parentRoute: typeof NonNestedPrefixPrefixChar123bazChar125RouteRoute
     }
-    '/non-nested/prefix/prefix{$baz}/bar': {
-      id: '/non-nested/prefix/prefix{$baz}/bar'
-      path: '/prefix{$baz}/bar'
-      fullPath: '/non-nested/prefix/prefix{$baz}/bar'
-      preLoaderRoute: typeof NonNestedPrefixPrefixChar123bazChar125BarRouteImport
-      parentRoute: typeof NonNestedPrefixRouteRoute
+    '/non-nested/path/baz_/bar': {
+      id: '/non-nested/path/baz_/bar'
+      path: '/baz/bar'
+      fullPath: '/non-nested/path/baz/bar'
+      preLoaderRoute: typeof NonNestedPathBazBarRouteImport
+      parentRoute: typeof NonNestedPathRouteRoute
     }
     '/non-nested/path/baz/foo': {
       id: '/non-nested/path/baz/foo'
@@ -1643,12 +1650,12 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof NonNestedPathBazFooRouteImport
       parentRoute: typeof NonNestedPathBazRouteRoute
     }
-    '/non-nested/path/baz/bar': {
-      id: '/non-nested/path/baz/bar'
-      path: '/baz/bar'
-      fullPath: '/non-nested/path/baz/bar'
-      preLoaderRoute: typeof NonNestedPathBazBarRouteImport
-      parentRoute: typeof NonNestedPathRouteRoute
+    '/non-nested/named/$baz_/bar': {
+      id: '/non-nested/named/$baz_/bar'
+      path: '/$baz/bar'
+      fullPath: '/non-nested/named/$baz/bar'
+      preLoaderRoute: typeof NonNestedNamedBazBarRouteImport
+      parentRoute: typeof NonNestedNamedRouteRoute
     }
     '/non-nested/named/$baz/foo': {
       id: '/non-nested/named/$baz/foo'
@@ -1656,13 +1663,6 @@ declare module '@tanstack/solid-router' {
       fullPath: '/non-nested/named/$baz/foo'
       preLoaderRoute: typeof NonNestedNamedBazFooRouteImport
       parentRoute: typeof NonNestedNamedBazRouteRoute
-    }
-    '/non-nested/named/$baz/bar': {
-      id: '/non-nested/named/$baz/bar'
-      path: '/$baz/bar'
-      fullPath: '/non-nested/named/$baz/bar'
-      preLoaderRoute: typeof NonNestedNamedBazBarRouteImport
-      parentRoute: typeof NonNestedNamedRouteRoute
     }
     '/params-ps/named/$foo/$bar': {
       id: '/params-ps/named/$foo/$bar'

--- a/e2e/solid-router/basic-file-based/src/routes/non-nested/named/$baz_.bar.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/non-nested/named/$baz_.bar.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/solid-router'
 
-export const Route = createFileRoute('/non-nested/named/$baz/bar')({
+export const Route = createFileRoute('/non-nested/named/$baz_/bar')({
   component: RouteComponent,
 })
 

--- a/e2e/solid-router/basic-file-based/src/routes/non-nested/path/baz_.bar.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/non-nested/path/baz_.bar.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/solid-router'
 
-export const Route = createFileRoute('/non-nested/path/baz/bar')({
+export const Route = createFileRoute('/non-nested/path/baz_/bar')({
   component: RouteComponent,
 })
 

--- a/e2e/solid-router/basic-file-based/src/routes/non-nested/prefix/prefix{$baz}_.bar.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/non-nested/prefix/prefix{$baz}_.bar.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/solid-router'
 
-export const Route = createFileRoute('/non-nested/prefix/prefix{$baz}/bar')({
+export const Route = createFileRoute('/non-nested/prefix/prefix{$baz}_/bar')({
   component: RouteComponent,
 })
 

--- a/e2e/solid-router/basic-file-based/src/routes/non-nested/suffix/{$baz}suffix_.bar.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/non-nested/suffix/{$baz}suffix_.bar.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/solid-router'
 
-export const Route = createFileRoute('/non-nested/suffix/{$baz}suffix/bar')({
+export const Route = createFileRoute('/non-nested/suffix/{$baz}suffix_/bar')({
   component: RouteComponent,
 })
 

--- a/e2e/solid-router/basic-file-based/src/routes/params-ps/non-nested/$foo_/$bar.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/params-ps/non-nested/$foo_/$bar.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useParams } from '@tanstack/solid-router'
 import { useExperimentalNonNestedRoutes } from '../../../../../tests/utils/useExperimentalNonNestedRoutes'
 
-export const Route = createFileRoute('/params-ps/non-nested/$foo/$bar')({
+export const Route = createFileRoute('/params-ps/non-nested/$foo_/$bar')({
   component: RouteComponent,
 })
 

--- a/e2e/solid-router/basic-file-based/src/routes/params-ps/non-nested/$foo_/route.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/params-ps/non-nested/$foo_/route.tsx
@@ -1,3 +1,3 @@
 import { createFileRoute } from '@tanstack/solid-router'
 
-export const Route = createFileRoute('/params-ps/non-nested/$foo')()
+export const Route = createFileRoute('/params-ps/non-nested/$foo_')()

--- a/e2e/solid-router/basic-file-based/src/routes/posts_.$postId.edit.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/posts_.$postId.edit.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, getRouteApi, useParams } from '@tanstack/solid-router'
 import { useExperimentalNonNestedRoutes } from '../../tests/utils/useExperimentalNonNestedRoutes'
 
-export const Route = createFileRoute('/posts/$postId/edit')({
+export const Route = createFileRoute('/posts_/$postId/edit')({
   component: PostEditPage,
 })
 


### PR DESCRIPTION
this PR just commits the default generated non-nested paths to avoid any unnecessary diffs when running e2e tests on solid-router-basic-file-based

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated routing path identifiers across the router configuration to standardize naming conventions with trailing underscore segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->