### PR TITLE
docs(solid-start): fix ssr start-basic-solid-query

### DIFF
--- a/examples/solid/start-basic-solid-query/src/router.tsx
+++ b/examples/solid/start-basic-solid-query/src/router.tsx
@@ -6,7 +6,13 @@ import { DefaultCatchBoundary } from './components/DefaultCatchBoundary'
 import { NotFound } from './components/NotFound'
 
 export function getRouter() {
-  const queryClient = new QueryClient()
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        experimental_prefetchInRender: true,
+      },
+    },
+  })
 
   const router = createRouter({
     routeTree,


### PR DESCRIPTION
in case of ssr, solid needs the experimental_prefetchInRender flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved query prefetching behavior in the Solid Query example application with optimized default configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->