### PR TITLE
test(react-start): fix query version in server-routes

### DIFF
--- a/e2e/react-start/server-routes/package.json
+++ b/e2e/react-start/server-routes/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@tanstack/react-query": "5.90.0",
+    "@tanstack/react-query": "^5.90.0",
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-router-devtools": "workspace:^",
     "@tanstack/react-router-ssr-query": "workspace:^",


### PR DESCRIPTION
this was pinned to react-query 5.90.0 which doesn't exist -> make it ^5.90.0

it "worked" anyway due to pnpm overrides from tanstack config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to allow broader compatibility with minor and patch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->