### PR TITLE
docs: Correct capitalization of 'TypeScript' in documentation

### DIFF
--- a/docs/router/framework/react/guide/type-safety.md
+++ b/docs/router/framework/react/guide/type-safety.md
@@ -26,7 +26,7 @@ const parentRoute = createRoute({
 
 ## Exported Hooks, Components, and Utilities
 
-For the types of your router to work with top-level exports like `Link`, `useNavigate`, `useParams`, etc. they must permeate the type-script module boundary and be registered right into the library. To do this, we use declaration merging on the exported `Register` interface.
+For the types of your router to work with top-level exports like `Link`, `useNavigate`, `useParams`, etc. they must permeate the TypeScript module boundary and be registered right into the library. To do this, we use declaration merging on the exported `Register` interface.
 
 ```ts
 const router = createRouter({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed capitalization of "TypeScript" in the type-safety guide documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->