### PR TITLE
docs: add note that prerendering is not yet supported on cf workers

### DIFF
--- a/docs/start/framework/react/guide/static-prerendering.md
+++ b/docs/start/framework/react/guide/static-prerendering.md
@@ -68,6 +68,7 @@ export default defineConfig({
   ],
 })
 ```
+Note: Prerendering on Cloudflare Workers is not yet supported, but is currently under development.
 
 ## Automatic Static Route Discovery
 

--- a/docs/start/framework/solid/guide/static-prerendering.md
+++ b/docs/start/framework/solid/guide/static-prerendering.md
@@ -68,6 +68,7 @@ export default defineConfig({
   ],
 })
 ```
+Note: Prerendering on Cloudflare Workers is not yet supported, but is currently under development.
 
 ## Automatic Static Route Discovery
 


### PR DESCRIPTION
- Why
As noted on Discord: “right now prerendering does not run using wrangler and hence fails when you reference cloudflare env during prerendering”.
- What changed
Documentation update: added a note in the Static Prerendering section.
- Scope/Impact
Docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated static-prerendering guides for React and Solid frameworks with informational notes clarifying that prerendering on Cloudflare Workers is not yet supported and currently under development. Notes have been added to inform developers of current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->