### PR TITLE
fix: run start compiler on imports from `@tanstack/start-client-core`

### DIFF
--- a/packages/start-plugin-core/src/start-compiler-plugin/compilers.ts
+++ b/packages/start-plugin-core/src/start-compiler-plugin/compilers.ts
@@ -52,12 +52,16 @@ export function compileStartOutputFactory(
     // find referenced identifiers *before* we transform anything
     const refIdents = doDce ? findReferencedIdentifiers(ast) : undefined
 
+    const validImportSources = [
+      `@tanstack/${framework}-start`,
+      '@tanstack/start-client-core',
+    ]
     babel.traverse(ast, {
       Program: {
         enter(programPath) {
           programPath.traverse({
             ImportDeclaration: (path) => {
-              if (path.node.source.value !== `@tanstack/${framework}-start`) {
+              if (!validImportSources.includes(path.node.source.value)) {
                 return
               }
 


### PR DESCRIPTION
this allows writing framework agnostic code that e.g. uses `createIsomorphicFn`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Broadened compiler import recognition to accept multiple valid import sources for tanstack start libraries.
  * Improves compatibility with varied import patterns and project configurations, reducing false negatives during import handling and giving developers more flexibility when managing imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->