### PR TITLE
Invalidate HMR after route clone in router plugin

### DIFF
--- a/packages/router-plugin/src/core/route-hmr-statement.ts
+++ b/packages/router-plugin/src/core/route-hmr-statement.ts
@@ -6,7 +6,7 @@ if (import.meta.hot) {
   import.meta.hot.accept((newModule) => {
     if (newModule && newModule.Route && typeof newModule.Route.clone === 'function') {
       newModule.Route.clone(Route)
-      import.meta.hot?.invalidate()
+      import.meta.hot.invalidate()
     }
    })
 }


### PR DESCRIPTION
Adds a call to import.meta.hot.invalidate() after cloning the Route during hot module replacement. This ensures the module is properly reloaded when routes are updated.

Fixes [#5698](https://github.com/TanStack/router/issues/5698)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hot module replacement behavior so route updates trigger proper module invalidation and a full page reload, ensuring updated routes are applied reliably during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->