### PR TITLE
docs(solid-start): add framework flag to solid start cli commands

### DIFF
--- a/docs/start/framework/solid/getting-started.md
+++ b/docs/start/framework/solid/getting-started.md
@@ -7,7 +7,7 @@ title: Getting Started
 
 Choose one of the following options to start building a _new_ TanStack Start project:
 
-- [TanStack Start CLI] - Just run `npm create @tanstack/start@latest`. Local, fast, and optionally customizable
+- [TanStack Start CLI] - Just run `npm create @tanstack/start@latest -- --framework solid`. Local, fast, and optionally customizable
 - [TanStack Builder](#) (coming soon!) - A visual interface to configure new TanStack projects with a few clicks
 - [Quick Start Examples](../quick-start) Download or clone one of our official examples
 - [Build a project from scratch](../build-from-scratch) - A guide to building a TanStack Start project line-by-line, file-by-file.

--- a/docs/start/framework/solid/quick-start.md
+++ b/docs/start/framework/solid/quick-start.md
@@ -8,13 +8,13 @@ title: Quick Start
 The fastest way to get a Start project up and running is with the cli. Just run
 
 ```
-pnpm create @tanstack/start@latest
+pnpm create @tanstack/start@latest --framework solid
 ```
 
 or
 
 ```
-npm create @tanstack/start@latest
+npm create @tanstack/start@latest -- --framework solid
 ```
 
 depending on your package manage of choice. You'll be prompted to add things like Tailwind, eslint, and a ton of other options.


### PR DESCRIPTION
Update solid docs to include the `--framework solid` flag in the `create @tanstack/start` commands.
https://github.com/TanStack/create-tsrouter-app/blob/453a72f6c4b008f1cac3cf46b78e2f0b1a15ee8c/cli/ts-create-start/README.md?plain=1#L14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quick-start and getting-started guides for Solid framework projects.
  * CLI commands now include the `--framework solid` flag for npm and pnpm, enabling direct framework pre-selection during project initialization without additional interactive prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->