### PR TITLE
fix: enable dead code elimination in split-route to remove unused imports

### DIFF
--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/arrow-function@errorComponent.tsx
@@ -1,2 +1,1 @@
 import * as React from 'react';
-import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/arrow-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/arrow-function@notFoundComponent.tsx
@@ -1,2 +1,1 @@
 import * as React from 'react';
-import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/boolean-null-literals@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/boolean-null-literals@component.tsx
@@ -1,4 +1,3 @@
 // Test errorComponent with false literal
-import { Route } from "boolean-null-literals.tsx";
 const SplitComponent = () => <div>Test Component</div>;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/boolean-null-literals@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/boolean-null-literals@errorComponent.tsx
@@ -1,2 +1,0 @@
-// Test errorComponent with false literal
-import { Route } from "boolean-null-literals.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/boolean-null-literals@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/boolean-null-literals@notFoundComponent.tsx
@@ -1,2 +1,0 @@
-// Test errorComponent with false literal
-import { Route } from "boolean-null-literals.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/chinese@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/chinese@component.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Route } from "chinese.tsx";
 function HomeComponent() {
   return <div className="p-2">
       <Demo title="标题很好看，谁说不是呢？" />

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/chinese@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/chinese@errorComponent.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/chinese@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/chinese@notFoundComponent.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-arrow-function@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-arrow-function@component.tsx
@@ -16,5 +16,4 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-arrow-function.tsx";
 export { App as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-arrow-function@errorComponent.tsx
@@ -16,4 +16,3 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-arrow-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-arrow-function@notFoundComponent.tsx
@@ -16,4 +16,3 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-function@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-function@component.tsx
@@ -16,5 +16,4 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-function.tsx";
 export { App as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-function@errorComponent.tsx
@@ -16,4 +16,3 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/circular-reference-function@notFoundComponent.tsx
@@ -16,4 +16,3 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/conditional-properties@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/conditional-properties@component.tsx
@@ -1,6 +1,5 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { FalseComponent } from '@modules/false-component';
-import { Route } from "conditional-properties.tsx";
 const SplitComponent = isEnabled ? TrueImport.Component : FalseComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/conditional-properties@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/conditional-properties@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/conditional-properties@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/conditional-properties@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/destructured-react-memo-imported-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/destructured-react-memo-imported-component@component.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react';
-import { Route } from "destructured-react-memo-imported-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/destructured-react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/destructured-react-memo-imported-component@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/destructured-react-memo-imported-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/destructured-react-memo-imported-component@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/explicit-undefined-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/explicit-undefined-component@component.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "explicit-undefined-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/explicit-undefined-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/explicit-undefined-component@errorComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "explicit-undefined-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/explicit-undefined-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/explicit-undefined-component@notFoundComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "explicit-undefined-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@component.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component-and-normal-notFound.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@errorComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component-and-normal-notFound.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@notFoundComponent.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Route } from "export-default-component-and-normal-notFound.tsx";
 function NotFoundComponent() {
   return <div>Not Found</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@component.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@errorComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@notFoundComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/function-declaration@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/function-declaration@errorComponent.tsx
@@ -1,2 +1,1 @@
 import * as React from 'react';
-import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/function-declaration@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/function-declaration@notFoundComponent.tsx
@@ -1,2 +1,1 @@
 import * as React from 'react';
-import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/importAttribute@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/importAttribute@component.tsx
@@ -1,4 +1,3 @@
 import { test } from './test' with { type: 'macro' };
-import { Route } from "importAttribute.tsx";
 const SplitComponent = () => test;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/importAttribute@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/importAttribute@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/importAttribute@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/importAttribute@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component-destructured-loader@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component-destructured-loader@component.tsx
@@ -1,4 +1,3 @@
 import importedComponent from '../../shared/imported';
-import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component-destructured-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component-destructured-loader@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component-destructured-loader@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component-destructured-loader@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component@component.tsx
@@ -1,4 +1,3 @@
 import ImportedDefaultComponent from '../../shared/imported';
-import { Route } from "imported-default-component.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-default-component@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-errorComponent@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-errorComponent@component.tsx
@@ -1,4 +1,3 @@
 import ImportedDefaultComponent from '../../shared/imported';
-import { Route } from "imported-errorComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-errorComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-errorComponent@errorComponent.tsx
@@ -1,4 +1,3 @@
 import { importedErrorComponent } from '../../shared/imported';
-import { Route } from "imported-errorComponent.tsx";
 const SplitErrorComponent = importedErrorComponent;
 export { SplitErrorComponent as errorComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-errorComponent@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-errorComponent@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-errorComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-notFoundComponent@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-notFoundComponent@component.tsx
@@ -1,4 +1,3 @@
 import ImportedDefaultComponent from '../../shared/imported';
-import { Route } from "imported-notFoundComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-notFoundComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-notFoundComponent@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-notFoundComponent@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-notFoundComponent@notFoundComponent.tsx
@@ -1,4 +1,3 @@
 import { importedNotFoundComponent } from '../../shared/imported';
-import { Route } from "imported-notFoundComponent.tsx";
 const SplitNotFoundComponent = importedNotFoundComponent;
 export { SplitNotFoundComponent as notFoundComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-pendingComponent@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-pendingComponent@component.tsx
@@ -1,4 +1,3 @@
 import ImportedDefaultComponent from '../../shared/imported';
-import { Route } from "imported-pendingComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-pendingComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-pendingComponent@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-pendingComponent@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported-pendingComponent@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported@component.tsx
@@ -1,4 +1,3 @@
 import { importedComponent } from '../../shared';
-import { Route } from "imported.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/imported@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/inline@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/inline@errorComponent.tsx
@@ -1,4 +1,3 @@
 import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
-import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/inline@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/inline@notFoundComponent.tsx
@@ -1,4 +1,3 @@
 import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
-import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/random-number@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/random-number@errorComponent.tsx
@@ -10,12 +10,9 @@ import agGridImage from '~/images/ag-grid.png';
 import nozzleImage from '~/images/nozzle.png';
 import bytesImage from '~/images/bytes.svg';
 import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
-import { textColors } from "random-number.tsx";
-import { gradients } from "random-number.tsx";
 const courses = [{
   name: 'The Official TanStack React Query Course',
   cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
   href: 'https://query.gg/?s=tanstack',
   description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
 }];
-import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/random-number@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/random-number@notFoundComponent.tsx
@@ -10,12 +10,9 @@ import agGridImage from '~/images/ag-grid.png';
 import nozzleImage from '~/images/nozzle.png';
 import bytesImage from '~/images/bytes.svg';
 import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
-import { textColors } from "random-number.tsx";
-import { gradients } from "random-number.tsx";
 const courses = [{
   name: 'The Official TanStack React Query Course',
   cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
   href: 'https://query.gg/?s=tanstack',
   description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
 }];
-import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-component@component.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Route } from "react-memo-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-component@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-component@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-imported-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-imported-component@component.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
 import { importedComponent } from '../../shared/imported';
-import { Route } from "react-memo-imported-component.tsx";
 const SplitComponent = React.memo(importedComponent);
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-imported-component@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-imported-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/react-memo-imported-component@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@component.tsx
@@ -1,5 +1,3 @@
 import * as React from 'react';
-import { Route } from "retain-export-component.tsx";
-import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
 const SIDEBAR_MINI_WIDTH = '80px';
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@errorComponent.tsx
@@ -1,5 +1,3 @@
 import * as React from 'react';
-import { Route } from "retain-export-component.tsx";
-import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
 const SIDEBAR_MINI_WIDTH = '80px';
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@notFoundComponent.tsx
@@ -1,5 +1,3 @@
 import * as React from 'react';
-import { Route } from "retain-export-component.tsx";
-import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
 const SIDEBAR_MINI_WIDTH = '80px';
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@component.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-const.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@errorComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-const.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@notFoundComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-const.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@component.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-function.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@errorComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-function.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@notFoundComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-function.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@component.tsx
@@ -18,9 +18,6 @@ function Layout() {
       <Outlet />
     </main>;
 }
-import { Route } from "retain-exports-loader.tsx";
 const HEADER_HEIGHT = '63px';
-import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
 const ASIDE_WIDTH = '250px';
 export { Layout as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@errorComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-loader.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@notFoundComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-loader.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/undefined-literals@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/undefined-literals@component.tsx
@@ -1,1 +1,0 @@
-import { Route } from "undefined-literals.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/undefined-literals@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/undefined-literals@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "undefined-literals.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/undefined-literals@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/undefined-literals@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "undefined-literals.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@component.tsx
@@ -1,3 +1,2 @@
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
-import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@errorComponent.tsx
@@ -1,3 +1,2 @@
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
-import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@notFoundComponent.tsx
@@ -1,3 +1,2 @@
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
-import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/using@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/using@component.tsx
@@ -1,1 +1,0 @@
-import { Route } from "using.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/using@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/using@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "using.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/using@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/using@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "using.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/arrow-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/arrow-function@loader.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
 import { fetchPosts } from '../posts';
-import { Route } from "arrow-function.tsx";
 const SplitLoader = fetchPosts;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/boolean-null-literals@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/boolean-null-literals@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
 // Test errorComponent with false literal
-import { Route } from "boolean-null-literals.tsx";
 const SplitComponent = () => <div>Test Component</div>;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/boolean-null-literals@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/boolean-null-literals@loader.tsx
@@ -1,5 +1,4 @@
 // Test errorComponent with false literal
-import { Route } from "boolean-null-literals.tsx";
 const SplitLoader = async () => ({
   data: 'test'
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/chinese@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/chinese@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Route } from "chinese.tsx";
 function HomeComponent() {
   return <div className="p-2">
       <Demo title="标题很好看，谁说不是呢？" />

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/chinese@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/chinese@loader.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/circular-reference-arrow-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/circular-reference-arrow-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -16,5 +16,4 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-arrow-function.tsx";
 export { App as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/circular-reference-arrow-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/circular-reference-arrow-function@loader.tsx
@@ -16,4 +16,3 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/circular-reference-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/circular-reference-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -16,5 +16,4 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-function.tsx";
 export { App as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/circular-reference-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/circular-reference-function@loader.tsx
@@ -16,4 +16,3 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/conditional-properties@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/conditional-properties@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,5 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { FalseComponent } from '@modules/false-component';
-import { Route } from "conditional-properties.tsx";
 const SplitComponent = isEnabled ? TrueImport.Component : FalseComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/conditional-properties@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/conditional-properties@loader.tsx
@@ -1,6 +1,5 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { falseLoader } from '@modules/false-component';
-import { Route } from "conditional-properties.tsx";
 const SplitLoader = isEnabled ? TrueImport.loader : falseLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/destructured-react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/destructured-react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react';
-import { Route } from "destructured-react-memo-imported-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/destructured-react-memo-imported-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/destructured-react-memo-imported-component@loader.tsx
@@ -1,4 +1,3 @@
 import { importedLoader } from '../../shared/imported';
-import { Route } from "destructured-react-memo-imported-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/explicit-undefined-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/explicit-undefined-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "explicit-undefined-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/explicit-undefined-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/explicit-undefined-component@loader.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "explicit-undefined-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component-and-normal-notFound@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component-and-normal-notFound@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Route } from "export-default-component-and-normal-notFound.tsx";
 function NotFoundComponent() {
   return <div>Not Found</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component-and-normal-notFound@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component-and-normal-notFound@loader.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component-and-normal-notFound.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component@loader.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/function-declaration@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/function-declaration@loader.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
 import { fetchPosts } from '../posts';
-import { Route } from "function-declaration.tsx";
 const SplitLoader = fetchPosts;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/importAttribute@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/importAttribute@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
 import { test } from './test' with { type: 'macro' };
-import { Route } from "importAttribute.tsx";
 const SplitComponent = () => test;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/importAttribute@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/importAttribute@loader.tsx
@@ -1,1 +1,0 @@
-import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-default-component-destructured-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-default-component-destructured-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
 import importedComponent from '../../shared/imported';
-import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-default-component-destructured-loader@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-default-component-destructured-loader@loader.tsx
@@ -1,4 +1,3 @@
 import { importedLoader } from '../../shared/imported';
-import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-default-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-default-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
 import ImportedDefaultComponent from '../../shared/imported';
-import { Route } from "imported-default-component.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-default-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-default-component@loader.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-errorComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-errorComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import ImportedDefaultComponent, { importedErrorComponent } from '../../shared/imported';
-import { Route } from "imported-errorComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitErrorComponent = importedErrorComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-errorComponent@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-errorComponent@loader.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-errorComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-notFoundComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-notFoundComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import ImportedDefaultComponent, { importedNotFoundComponent } from '../../shared/imported';
-import { Route } from "imported-notFoundComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitNotFoundComponent = importedNotFoundComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-notFoundComponent@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-notFoundComponent@loader.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-pendingComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-pendingComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import ImportedDefaultComponent, { importedPendingComponent } from '../../shared/imported';
-import { Route } from "imported-pendingComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitPendingComponent = importedPendingComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-pendingComponent@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported-pendingComponent@loader.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
 import { importedComponent } from '../../shared';
-import { Route } from "imported.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/imported@loader.tsx
@@ -1,4 +1,3 @@
 import { importedLoader } from '../../shared';
-import { Route } from "imported.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/inline@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/inline@loader.tsx
@@ -1,4 +1,3 @@
 import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
-import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/random-number@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/random-number@loader.tsx
@@ -11,15 +11,12 @@ import agGridImage from '~/images/ag-grid.png';
 import nozzleImage from '~/images/nozzle.png';
 import bytesImage from '~/images/bytes.svg';
 import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
-import { textColors } from "random-number.tsx";
-import { gradients } from "random-number.tsx";
 const courses = [{
   name: 'The Official TanStack React Query Course',
   cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
   href: 'https://query.gg/?s=tanstack',
   description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
 }];
-import { Route } from "random-number.tsx";
 const SplitLoader = () => {
   return {
     randomNumber: Math.random(),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/react-memo-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/react-memo-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Route } from "react-memo-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/react-memo-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/react-memo-component@loader.tsx
@@ -1,4 +1,3 @@
 import { importedLoader } from '../../shared/imported';
-import { Route } from "react-memo-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
 import { importedComponent } from '../../shared/imported';
-import { Route } from "react-memo-imported-component.tsx";
 const SplitComponent = React.memo(importedComponent);
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/react-memo-imported-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/react-memo-imported-component@loader.tsx
@@ -1,4 +1,3 @@
 import { importedLoader } from '../../shared/imported';
-import { Route } from "react-memo-imported-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-export-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-export-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,3 @@
 import * as React from 'react';
-import { Route } from "retain-export-component.tsx";
-import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
 const SIDEBAR_MINI_WIDTH = '80px';
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-export-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-export-component@loader.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { importedLoader } from '../../shared/imported';
-import { Route } from "retain-export-component.tsx";
-import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
 const SIDEBAR_MINI_WIDTH = '80px';
 const ASIDE_WIDTH = '250px';
 const SplitLoader = importedLoader;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-const@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-const@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-const.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-const@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-const@loader.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-const.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-function.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-function@loader.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-function.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -18,9 +18,6 @@ function Layout() {
       <Outlet />
     </main>;
 }
-import { Route } from "retain-exports-loader.tsx";
 const HEADER_HEIGHT = '63px';
-import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
 const ASIDE_WIDTH = '250px';
 export { Layout as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-loader@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-loader@loader.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-loader.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/undefined-literals@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/undefined-literals@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "undefined-literals.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/undefined-literals@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/undefined-literals@loader.tsx
@@ -1,1 +1,0 @@
-import { Route } from "undefined-literals.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/useStateDestructure@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/useStateDestructure@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,2 @@
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
-import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/useStateDestructure@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/useStateDestructure@loader.tsx
@@ -1,3 +1,2 @@
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
-import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/using@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/using@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "using.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/using@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/using@loader.tsx
@@ -6,7 +6,6 @@ const DummyPostResource = (postId: string) => ({
   },
   [Symbol.dispose]: () => console.log('disposing!')
 });
-import { Route } from "using.tsx";
 const SplitLoader = ({
   params: {
     postId

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/arrow-function@errorComponent.tsx
@@ -1,2 +1,1 @@
 import * as React from 'react';
-import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/boolean-null-literals@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/boolean-null-literals@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 // Test errorComponent with false literal
-import { Route } from "boolean-null-literals.tsx";
 const SplitLoader = async () => ({
   data: 'test'
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/boolean-null-literals@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/boolean-null-literals@errorComponent.tsx
@@ -1,2 +1,0 @@
-// Test errorComponent with false literal
-import { Route } from "boolean-null-literals.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/chinese@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/chinese@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Route } from "chinese.tsx";
 function HomeComponent() {
   return <div className="p-2">
       <Demo title="标题很好看，谁说不是呢？" />

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/chinese@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/chinese@errorComponent.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/circular-reference-arrow-function@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/circular-reference-arrow-function@component---loader---notFoundComponent---pendingComponent.tsx
@@ -16,5 +16,4 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-arrow-function.tsx";
 export { App as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/circular-reference-arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/circular-reference-arrow-function@errorComponent.tsx
@@ -16,4 +16,3 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/circular-reference-function@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/circular-reference-function@component---loader---notFoundComponent---pendingComponent.tsx
@@ -16,5 +16,4 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-function.tsx";
 export { App as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/circular-reference-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/circular-reference-function@errorComponent.tsx
@@ -16,4 +16,3 @@ function OtherComponent() {
   });
   return <div>App component name is {componentName}</div>;
 }
-import { Route } from "circular-reference-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/conditional-properties@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/conditional-properties@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,7 +1,6 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { FalseComponent, falseLoader } from '@modules/false-component';
-import { Route } from "conditional-properties.tsx";
 const SplitLoader = isEnabled ? TrueImport.loader : falseLoader;
 export { SplitLoader as loader };
 const SplitComponent = isEnabled ? TrueImport.Component : FalseComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/conditional-properties@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/conditional-properties@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/destructured-react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/destructured-react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,5 @@
 import { memo } from 'react';
 import { importedLoader } from '../../shared/imported';
-import { Route } from "destructured-react-memo-imported-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/destructured-react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/destructured-react-memo-imported-component@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/explicit-undefined-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/explicit-undefined-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "explicit-undefined-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/explicit-undefined-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/explicit-undefined-component@errorComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "explicit-undefined-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component-and-normal-notFound@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component-and-normal-notFound@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Route } from "export-default-component-and-normal-notFound.tsx";
 function NotFoundComponent() {
   return <div>Not Found</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component-and-normal-notFound@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component-and-normal-notFound@errorComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component-and-normal-notFound.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component@errorComponent.tsx
@@ -1,2 +1,1 @@
 import React from 'react';
-import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/function-declaration@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/function-declaration@errorComponent.tsx
@@ -1,2 +1,1 @@
 import * as React from 'react';
-import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/importAttribute@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/importAttribute@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
 import { test } from './test' with { type: 'macro' };
-import { Route } from "importAttribute.tsx";
 const SplitComponent = () => test;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/importAttribute@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/importAttribute@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-default-component-destructured-loader@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-default-component-destructured-loader@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import importedComponent, { importedLoader } from '../../shared/imported';
-import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };
 const SplitComponent = importedComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-default-component-destructured-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-default-component-destructured-loader@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-default-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-default-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
 import ImportedDefaultComponent from '../../shared/imported';
-import { Route } from "imported-default-component.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-default-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-default-component@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-errorComponent@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-errorComponent@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
 import ImportedDefaultComponent from '../../shared/imported';
-import { Route } from "imported-errorComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-errorComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-errorComponent@errorComponent.tsx
@@ -1,4 +1,3 @@
 import { importedErrorComponent } from '../../shared/imported';
-import { Route } from "imported-errorComponent.tsx";
 const SplitErrorComponent = importedErrorComponent;
 export { SplitErrorComponent as errorComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-notFoundComponent@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-notFoundComponent@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import ImportedDefaultComponent, { importedNotFoundComponent } from '../../shared/imported';
-import { Route } from "imported-notFoundComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitNotFoundComponent = importedNotFoundComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-notFoundComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-notFoundComponent@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-pendingComponent@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-pendingComponent@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import ImportedDefaultComponent, { importedPendingComponent } from '../../shared/imported';
-import { Route } from "imported-pendingComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitPendingComponent = importedPendingComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-pendingComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported-pendingComponent@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,4 @@
 import { importedComponent, importedLoader } from '../../shared';
-import { Route } from "imported.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };
 const SplitComponent = importedComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/imported@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/inline@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/inline@errorComponent.tsx
@@ -1,4 +1,3 @@
 import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
-import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/random-number@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/random-number@errorComponent.tsx
@@ -10,12 +10,9 @@ import agGridImage from '~/images/ag-grid.png';
 import nozzleImage from '~/images/nozzle.png';
 import bytesImage from '~/images/bytes.svg';
 import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
-import { textColors } from "random-number.tsx";
-import { gradients } from "random-number.tsx";
 const courses = [{
   name: 'The Official TanStack React Query Course',
   cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
   href: 'https://query.gg/?s=tanstack',
   description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
 }];
-import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/react-memo-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/react-memo-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { importedLoader } from '../../shared/imported';
-import { Route } from "react-memo-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/react-memo-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/react-memo-component@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { importedLoader, importedComponent } from '../../shared/imported';
-import { Route } from "react-memo-imported-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };
 const SplitComponent = React.memo(importedComponent);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/react-memo-imported-component@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-export-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-export-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { importedLoader } from '../../shared/imported';
-import { Route } from "retain-export-component.tsx";
-import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
 const SIDEBAR_MINI_WIDTH = '80px';
 const ASIDE_WIDTH = '250px';
 const SplitLoader = importedLoader;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-export-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-export-component@errorComponent.tsx
@@ -1,5 +1,3 @@
 import * as React from 'react';
-import { Route } from "retain-export-component.tsx";
-import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
 const SIDEBAR_MINI_WIDTH = '80px';
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-const@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-const@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-const.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-const@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-const@errorComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-const.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-function@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-function@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-function.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-function@errorComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-function.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-loader@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-loader@component---loader---notFoundComponent---pendingComponent.tsx
@@ -18,9 +18,6 @@ function Layout() {
       <Outlet />
     </main>;
 }
-import { Route } from "retain-exports-loader.tsx";
 const HEADER_HEIGHT = '63px';
-import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
 const ASIDE_WIDTH = '250px';
 export { Layout as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-loader@errorComponent.tsx
@@ -1,5 +1,2 @@
 import * as React from 'react';
-import { Route } from "retain-exports-loader.tsx";
-import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
-import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
 const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/undefined-literals@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/undefined-literals@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "undefined-literals.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/undefined-literals@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/undefined-literals@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "undefined-literals.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/useStateDestructure@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/useStateDestructure@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,2 @@
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
-import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/useStateDestructure@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/useStateDestructure@errorComponent.tsx
@@ -1,3 +1,2 @@
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
-import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/using@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/using@component---loader---notFoundComponent---pendingComponent.tsx
@@ -6,7 +6,6 @@ const DummyPostResource = (postId: string) => ({
   },
   [Symbol.dispose]: () => console.log('disposing!')
 });
-import { Route } from "using.tsx";
 const SplitLoader = ({
   params: {
     postId

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/using@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/using@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "using.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/arrow-function@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/arrow-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/arrow-function@notFoundComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/2-components-combined-loader-separate/arrow-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/2-components-combined-loader-separate/arrow-function@loader.tsx
@@ -1,4 +1,3 @@
 import { fetchPosts } from '../posts';
-import { Route } from "arrow-function.tsx";
 const SplitLoader = fetchPosts;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/3-all-combined-errorComponent-separate/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/3-all-combined-errorComponent-separate/arrow-function@errorComponent.tsx
@@ -1,1 +1,0 @@
-import { Route } from "arrow-function.tsx";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dead code elimination in code-splitting transformation to better track imported identifiers and remove unused dependencies from generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->