### PR TITLE
fix: HMR: only invalidate router if match is existing and not cached

### DIFF
--- a/packages/router-plugin/src/core/route-hmr-statement.ts
+++ b/packages/router-plugin/src/core/route-hmr-statement.ts
@@ -1,5 +1,5 @@
 import * as template from '@babel/template'
-import type { AnyRoute } from '@tanstack/router-core'
+import type { AnyRoute, AnyRouteMatch } from '@tanstack/router-core'
 
 type AnyRouteWithPrivateProps = AnyRoute & {
   _path: string
@@ -26,7 +26,13 @@ function handleRouteUpdate(
   if (oldRouteIndex > -1) {
     router.flatRoutes[oldRouteIndex] = newRoute
   }
-  router.invalidate({ filter: (m) => m.routeId === oldRoute.id })
+  const filter = (m: AnyRouteMatch) => m.routeId === oldRoute.id
+  if (
+    router.state.matches.find(filter) ||
+    router.state.pendingMatches?.find(filter)
+  ) {
+    router.invalidate({ filter })
+  }
 }
 
 export const routeHmrStatement = template.statement(

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@true.tsx
@@ -25,9 +25,12 @@ if (import.meta.hot) {
           router.flatRoutes[oldRouteIndex] = newRoute;
         }
         ;
-        router.invalidate({
-          filter: m => m.routeId === oldRoute.id
-        });
+        const filter = m => m.routeId === oldRoute.id;
+        if (router.state.matches.find(filter) || router.state.pendingMatches?.find(filter)) {
+          router.invalidate({
+            filter
+          });
+        }
       })(Route, newModule.Route);
     }
   });

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/function-declaration@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/function-declaration@true.tsx
@@ -25,9 +25,12 @@ if (import.meta.hot) {
           router.flatRoutes[oldRouteIndex] = newRoute;
         }
         ;
-        router.invalidate({
-          filter: m => m.routeId === oldRoute.id
-        });
+        const filter = m => m.routeId === oldRoute.id;
+        if (router.state.matches.find(filter) || router.state.pendingMatches?.find(filter)) {
+          router.invalidate({
+            filter
+          });
+        }
       })(Route, newModule.Route);
     }
   });

--- a/packages/router-plugin/tests/add-hmr/snapshots/solid/arrow-function@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/solid/arrow-function@true.tsx
@@ -24,9 +24,12 @@ if (import.meta.hot) {
           router.flatRoutes[oldRouteIndex] = newRoute;
         }
         ;
-        router.invalidate({
-          filter: m => m.routeId === oldRoute.id
-        });
+        const filter = m => m.routeId === oldRoute.id;
+        if (router.state.matches.find(filter) || router.state.pendingMatches?.find(filter)) {
+          router.invalidate({
+            filter
+          });
+        }
       })(Route, newModule.Route);
     }
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hot module replacement efficiency by conditionally invalidating routes only when a matching route exists, reducing unnecessary invalidations during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->