### PR TITLE
chore: fix links to router/start header images in readme

### DIFF
--- a/packages/react-router-ssr-query/README.md
+++ b/packages/react-router-ssr-query/README.md
@@ -2,7 +2,7 @@
 
 # TanStack React Router
 
-![TanStack Router Header](https://github.com/tanstack/router/raw/main/media/header.png)
+![TanStack Router Header](https://github.com/tanstack/router/raw/main/media/header_router.png)
 
 🤖 Type-safe router w/ built-in caching & URL state management for React!
 

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -2,7 +2,7 @@
 
 # TanStack React Router
 
-![TanStack Router Header](https://github.com/tanstack/router/raw/main/media/header.png)
+![TanStack Router Header](https://github.com/tanstack/router/raw/main/media/header_router.png)
 
 🤖 Type-safe router w/ built-in caching & URL state management for React!
 

--- a/packages/react-start/README.md
+++ b/packages/react-start/README.md
@@ -2,7 +2,7 @@
 
 # TanStack React Start
 
-![TanStack React Start Header](https://github.com/tanstack/router/raw/main/media/header.png)
+![TanStack React Start Header](https://github.com/tanstack/router/raw/main/media/header_start.png)
 
 SSR, Streaming, Server Functions, API Routes, bundling and more powered by [TanStack Router](https://tanstack.com/router) and Vite. Ready to deploy to your favorite hosting provider.
 

--- a/packages/solid-router-ssr-query/README.md
+++ b/packages/solid-router-ssr-query/README.md
@@ -1,3 +1,5 @@
+![TanStack Router Header](https://github.com/tanstack/router/raw/main/media/header_router.png)
+
 # @tanstack/solid-router-ssr-query
 
 SSR query integration for TanStack Solid Router and TanStack Solid Query.

--- a/packages/solid-router/README.md
+++ b/packages/solid-router/README.md
@@ -2,7 +2,7 @@
 
 # TanStack Solid Router
 
-![TanStack Router Header](https://github.com/tanstack/router/raw/main/media/header.png)
+![TanStack Router Header](https://github.com/tanstack/router/raw/main/media/header_router.png)
 
 🤖 Type-safe router w/ built-in caching & URL state management for Solid!
 

--- a/packages/solid-start/README.md
+++ b/packages/solid-start/README.md
@@ -2,7 +2,7 @@
 
 # TanStack Solid Start
 
-![TanStack Solid Start Header](https://github.com/tanstack/router/raw/main/media/header.png)
+![TanStack Solid Start Header](https://github.com/tanstack/router/raw/main/media/header_start.png)
 
 SSR, Streaming, Server Functions, API Routes, bundling and more powered by [TanStack Router](https://tanstack.com/router) and Vite. Ready to deploy to your favorite hosting provider.
 


### PR DESCRIPTION
there are links to header.png, but the files are called

header_starst.png
header_router.png

That's why there are broken links in the readmes on e.g. NPM "TanStack Router Header":

<img width="804" height="497" alt="Screenshot 2025-11-02 at 14 36 16" src="https://github.com/user-attachments/assets/b306dd9c-399f-468c-9308-4ef93ac6b9f9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated header image references across package documentation for visual consistency.
  * Expanded solid-router-ssr-query documentation with new Installation, Usage, and License sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->