### PR TITLE
test(solid-start-ssr-query): remove experimental_prefetchInRender

### DIFF
--- a/e2e/solid-start/basic-solid-query/src/router.tsx
+++ b/e2e/solid-start/basic-solid-query/src/router.tsx
@@ -6,13 +6,7 @@ import { DefaultCatchBoundary } from './components/DefaultCatchBoundary'
 import { NotFound } from './components/NotFound'
 
 export function getRouter() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        experimental_prefetchInRender: true,
-      },
-    },
-  })
+  const queryClient = new QueryClient()
   const router = createRouter({
     routeTree,
     context: { queryClient },

--- a/e2e/solid-start/query-integration/src/router.tsx
+++ b/e2e/solid-start/query-integration/src/router.tsx
@@ -4,13 +4,7 @@ import { setupRouterSsrQueryIntegration } from '@tanstack/solid-router-ssr-query
 import { routeTree } from './routeTree.gen'
 
 export function getRouter() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        experimental_prefetchInRender: true,
-      },
-    },
-  })
+  const queryClient = new QueryClient()
   const router = createRouter({
     routeTree,
     context: { queryClient },

--- a/e2e/solid-start/server-functions/src/router.tsx
+++ b/e2e/solid-start/server-functions/src/router.tsx
@@ -6,13 +6,7 @@ import { DefaultCatchBoundary } from './components/DefaultCatchBoundary'
 import { NotFound } from './components/NotFound'
 
 export function getRouter() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        experimental_prefetchInRender: true,
-      },
-    },
-  })
+  const queryClient = new QueryClient()
   const router = createRouter({
     routeTree,
     defaultPreload: 'intent',

--- a/examples/solid/start-basic-solid-query/src/router.tsx
+++ b/examples/solid/start-basic-solid-query/src/router.tsx
@@ -6,13 +6,7 @@ import { DefaultCatchBoundary } from './components/DefaultCatchBoundary'
 import { NotFound } from './components/NotFound'
 
 export function getRouter() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        experimental_prefetchInRender: true,
-      },
-    },
-  })
+  const queryClient = new QueryClient()
 
   const router = createRouter({
     routeTree,


### PR DESCRIPTION
This workaround is no longer needed with the latest version of solid-query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated query client initialization across multiple router configurations to use default settings, removing custom prefetch behavior from the query system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->