### PR TITLE
docs(router-core): make startTrasition deprecation note agnostic

### DIFF
--- a/packages/router-core/src/RouterProvider.ts
+++ b/packages/router-core/src/RouterProvider.ts
@@ -16,7 +16,7 @@ export interface CommitLocationOptions {
   hashScrollIntoView?: boolean | ScrollIntoViewOptions
   viewTransition?: boolean | ViewTransitionOptions
   /**
-   * @deprecated All navigations use React transitions under the hood now
+   * @deprecated All navigations use transitions under the hood now
    **/
   startTransition?: boolean
   ignoreBlocker?: boolean


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deprecation messaging for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->