### PR TITLE
docs: Update quick-start.md - fix wording of package manager

### DIFF
--- a/docs/start/framework/react/quick-start.md
+++ b/docs/start/framework/react/quick-start.md
@@ -17,7 +17,7 @@ or
 npm create @tanstack/start@latest
 ```
 
-depending on your package manage of choice. You'll be prompted to add things like Tailwind, eslint, and a ton of other options.
+depending on your package manager of choice. You'll be prompted to add things like Tailwind, eslint, and a ton of other options.
 
 You can also clone and run the [Basic](https://github.com/TanStack/router/tree/main/examples/react/start-basic) example right away with the following commands:
 


### PR DESCRIPTION
The text should be "package manager" not current "package manage". This corrects that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar in the React quick-start guide for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->