### PR TITLE
Fix mispelling/typo

### DIFF
--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -241,7 +241,7 @@ You can customize function ID generation for the production build by providing a
 
 Prefer deterministic inputs (filename + functionName) so IDs remain stable between builds.
 
-Please note that this customization is **experimental** und subject to change.
+Please note that this customization is **experimental** and subject to change.
 
 Example:
 


### PR DESCRIPTION
Tiny typo in the docs: `und` should be `and`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the server functions documentation to improve clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->