### PR TITLE
fix: set progressiveChunkSize to infinity

### DIFF
--- a/packages/react-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/react-router/src/ssr/renderRouterToStream.tsx
@@ -24,7 +24,7 @@ export const renderRouterToStream = async ({
     const stream = await ReactDOMServer.renderToReadableStream(children, {
       signal: request.signal,
       nonce: router.options.ssr?.nonce,
-      progressiveChunkSize: router.options.ssr?.progressiveChunkSize,
+      progressiveChunkSize: Number.POSITIVE_INFINITY,
     })
 
     if (isbot(request.headers.get('User-Agent'))) {
@@ -47,7 +47,7 @@ export const renderRouterToStream = async ({
     try {
       const pipeable = ReactDOMServer.renderToPipeableStream(children, {
         nonce: router.options.ssr?.nonce,
-        progressiveChunkSize: router.options.ssr?.progressiveChunkSize,
+        progressiveChunkSize: Number.POSITIVE_INFINITY,
         ...(isbot(request.headers.get('User-Agent'))
           ? {
               onAllReady() {

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -468,7 +468,6 @@ export interface RouterOptions<
   origin?: string
   ssr?: {
     nonce?: string
-    progressiveChunkSize?: number
   }
 }
 


### PR DESCRIPTION
fixes #5383

In reference to this: https://github.com/facebook/react/commit/18212ca960ee2f0acf538c2198f7ba36c3042ecd

Currently, when the shell hits ~12.5KB, any suspense boundary larger than 500 bytes triggers an empty fallback. 

This results in pages loading without the content at first, and then having them render shortly after.

This PR simply adds a way to increase that size to whatever the user deems fit if he wishes to avoid this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Modified server-side rendering streaming behavior to ensure consistent chunk handling during content delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->