### PR TITLE
fix(solid-router): dont show fallback unless pendingMinMs > 0

### DIFF
--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -296,7 +296,7 @@ export const MatchInner = (props: { matchId: string }): any => {
 
           return (
             <>
-              {FallbackComponent ? (
+              {FallbackComponent && pendingMinMs > 0 ? (
                 <Dynamic component={FallbackComponent} />
               ) : null}
               {loaderResult()}


### PR DESCRIPTION
Closes https://github.com/TanStack/router/issues/5787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined fallback component rendering to only display when a minimum pending duration threshold is configured, improving loading state visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->