### PR TITLE
chore: fix devtools dependeicies

### DIFF
--- a/packages/react-router-devtools/package.json
+++ b/packages/react-router-devtools/package.json
@@ -72,7 +72,13 @@
   },
   "peerDependencies": {
     "@tanstack/react-router": "workspace:^",
+    "@tanstack/router-core": "workspace:^",
     "react": ">=18.0.0 || >=19.0.0",
     "react-dom": ">=18.0.0 || >=19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@tanstack/router-core": {
+      "optional": true
+    }
   }
 }

--- a/packages/router-devtools-core/package.json
+++ b/packages/router-devtools-core/package.json
@@ -64,7 +64,8 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "goober": "^2.1.16",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
     "solid-js": "^1.9.10",
@@ -73,8 +74,7 @@
   "peerDependencies": {
     "@tanstack/router-core": "workspace:^",
     "csstype": "^3.0.10",
-    "solid-js": ">=1.9.5",
-    "tiny-invariant": "^1.3.3"
+    "solid-js": ">=1.9.5"
   },
   "peerDependenciesMeta": {
     "csstype": {

--- a/packages/solid-router-devtools/package.json
+++ b/packages/solid-router-devtools/package.json
@@ -74,7 +74,13 @@
     "vite-plugin-solid": "^2.11.10"
   },
   "peerDependencies": {
+    "@tanstack/router-core": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "solid-js": "^1.9.10"
+  },
+  "peerDependenciesMeta": {
+    "@tanstack/router-core": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7986,6 +7986,9 @@ importers:
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../react-router
+      '@tanstack/router-core':
+        specifier: workspace:*
+        version: link:../router-core
       '@tanstack/router-devtools-core':
         specifier: workspace:^
         version: link:../router-devtools-core
@@ -8485,6 +8488,9 @@ importers:
 
   packages/solid-router-devtools:
     dependencies:
+      '@tanstack/router-core':
+        specifier: workspace:*
+        version: link:../router-core
       '@tanstack/router-devtools-core':
         specifier: workspace:^
         version: link:../router-devtools-core


### PR DESCRIPTION
This PR fixes wrong dependency config of devtools related packages:

`router-devtools-core` > `tiny-invariant` should be a normal dependency

`react-router-devtools` and `solid-router-devtools` do not provide `router-devtools-core` 's peer dependency `router-core` so added it as optional peerDeps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency configuration across multiple devtools packages to improve overall compatibility and streamline the package installation process.
  * Refined and optimized internal dependencies for better module resolution and reduced potential installation conflicts between packages.
  * Updated peer dependency settings to ensure proper compatibility across different router framework integrations and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->