### PR TITLE
docs(hosting): update nitro to v3

### DIFF
--- a/docs/start/framework/react/guide/hosting.md
+++ b/docs/start/framework/react/guide/hosting.md
@@ -195,7 +195,7 @@ tool](https://docs.netlify.com/start/quickstarts/deploy-from-ai-code-generation-
 
 [Nitro](https://v3.nitro.build/) is an agnostic layer that allows you to deploy TanStack Start applications to [a wide range of hostings](https://v3.nitro.build/deploy).
 
-**⚠️ The [`nitro/vite`](https://v3.nitro.build/) plugin is an official plugin from the Nitro team for using Nitro v3 as the underlying build tool for TanStack Start. It is still in development and is receiving regular updates. Please report any issues that you encounter to investigate.**
+**⚠️ The [`nitro/vite`](https://v3.nitro.build/) plugin natively integrates with Vite Environments API as the underlying build tool for TanStack Start. It is still under active development and receives regular updates. Please report any issues you encounter with reproduction so they can be investigated.**
 
 ```tsx
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
@@ -258,13 +258,8 @@ import { defineConfig } from 'vite'
 import { nitro } from 'nitro/vite'
 import viteReact from '@vitejs/plugin-react'
 
-
 export default defineConfig({
-  plugins: [
-    tanstackStart(),
-    nitro({ preset: 'bun' }),
-    viteReact(),
-  ],
+  plugins: [tanstackStart(), nitro({ preset: 'bun' }), viteReact()],
 })
 ```
 


### PR DESCRIPTION
Simplify docs to recommand latest nitro v3 native vite plugin as we can support it easier.

/cc @schiller-manuel 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated React hosting guide around Nitro v3 deployment and "hostings" usage
  * Removed legacy Nitro v2/ALPHA guidance and outdated references
  * Updated examples to use the Nitro v3 Vite plugin and a unified configuration pattern (including Bun presets)
  * Clarified import order, comments, and links to reflect current Nitro v3 hosting endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->