### PR TITLE
docs(solid-start): sync nitro v3 hosting guide to react

### DIFF
--- a/docs/start/framework/solid/guide/hosting.md
+++ b/docs/start/framework/solid/guide/hosting.md
@@ -198,7 +198,7 @@ import { nitro } from 'nitro/vite'
 import viteSolid from 'vite-plugin-solid'
 
 export default defineConfig({
-  plugins: [tanstackStart(), nitro(), viteSolid({ssr: true})],
+  plugins: [tanstackStart(), nitro(), viteSolid({ ssr: true })],
   nitro: {},
 })
 ```


### PR DESCRIPTION
below pr only updated react-start hosting docs:
- https://github.com/TanStack/router/pull/5821

This pr updates solid-start so they are in sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hosting guide to reflect Nitro v3 plugin integration with simplified configuration model
  * Removed legacy Nitro v2 examples and outdated plugin references
  * Updated code samples with current plugin patterns and import paths for improved accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->