### PR TITLE
feat: createServerEntry

### DIFF
--- a/docs/start/framework/react/guide/server-entry-point.md
+++ b/docs/start/framework/react/guide/server-entry-point.md
@@ -8,15 +8,18 @@ title: Server Entry Point
 > [!NOTE]
 > The server entry point is **optional** out of the box. If not provided, TanStack Start will automatically handle the server entry point for you using the below as a default.
 
-The Server Entry Point conforms to the [universal fetch handler](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/) format, which means the default export must conform to the `ServerEntry` interface:
+The Server Entry Point supports the universal fetch handler format, commonly used by [Cloudflare Workers](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/) and other WinterCG-compatible runtimes.
+
+To ensure interoperability, the default export must conform to our `ServerEntry` interface:
 
 ```ts
 export default {
-  fetch(req: Request, opts?: RequestOptions): Promise<Response> {
+  fetch(req: Request, opts?: RequestOptions): Response | Promise<Response> {
     // ...
   },
 }
 ```
+
 TanStack Start exposes a wrapper to make creation type-safe. This is done in the `src/server.ts` file.
 
 ```tsx

--- a/packages/react-start/src/default-entry/server.ts
+++ b/packages/react-start/src/default-entry/server.ts
@@ -12,8 +12,8 @@ export type ServerEntry = { fetch: RequestHandler<Register> }
 
 export function createServerEntry(entry: ServerEntry): ServerEntry {
   return {
-    async fetch(request) {
-      return await entry.fetch(request)
+    async fetch(...args) {
+      return await entry.fetch(...args)
     },
   }
 }

--- a/packages/solid-start/src/default-entry/server.ts
+++ b/packages/solid-start/src/default-entry/server.ts
@@ -12,8 +12,8 @@ export type ServerEntry = { fetch: RequestHandler<Register> }
 
 export function createServerEntry(entry: ServerEntry): ServerEntry {
   return {
-    async fetch(request) {
-      return await entry.fetch(request)
+    async fetch(...args) {
+      return await entry.fetch(...args)
     },
   }
 }


### PR DESCRIPTION
type-safe `createServerEntry` that will help with adding `try/catch` internally later on without users having to change a thing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated server entry guide and examples to show the new wrapped export pattern and clarify request handler usage.

* **Refactor**
  * Server entry export now uses a lightweight wrapper/factory approach for request handlers, replacing the previous direct-object export to improve interoperability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->