### PR TITLE
fix: handle notFound from params.parse correctly

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1379,7 +1379,7 @@ export class RouterCore<
 
       const strictParams = existingMatch?._strictParams ?? usedParams
 
-      let paramsError: PathParamError | undefined = undefined
+      let paramsError: unknown = undefined
 
       if (!existingMatch) {
         const strictParseParams =
@@ -1392,9 +1392,13 @@ export class RouterCore<
               strictParseParams(strictParams as Record<string, string>),
             )
           } catch (err: any) {
-            paramsError = new PathParamError(err.message, {
-              cause: err,
-            })
+            if (isNotFound(err) || isRedirect(err)) {
+              paramsError = err
+            } else {
+              paramsError = new PathParamError(err.message, {
+                cause: err,
+              })
+            }
 
             if (opts?.throwOnError) {
               throw paramsError


### PR DESCRIPTION
## Summary

Fixes #5733

Previously, these errors were wrapped in PathParamError, causing a 500 error instead of 404.
When notFound() is thrown from params.parse, the router now correctly Sets match status to notFound

## Changes

- Changed paramsError type from PathParamError | undefined to unknown
- NotFoundError and Redirect directly in paramsError
- Added tests in `load.test.ts` for params.parse throwing notFound()

## Test Plan

   - params.parse throwing notFound() sets match status to 'notFound' and statusCode to 404
   - params.parse with valid input succeeds with status 'success' and statusCode 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during route parameter parsing to properly distinguish between NotFound, Redirect, and other error types, improving error propagation behavior when route matching fails.

* **Tests**
  * Added test coverage for route parameter parsing scenarios, validating correct behavior for both invalid and valid route identifiers in parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->