### PR TITLE
refactor(router-core): utils/decodePath minor performance improvements

### DIFF
--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -546,7 +546,6 @@ export function decodePath(
   part: string,
   decodeIgnore: Array<string> = DECODE_IGNORE_LIST,
 ): string {
-
   // if the path segment does not contain any encoded uri components return the path as is
   if (part === '' || !/%[0-9A-Fa-f]{2}/g.test(part)) return part
 


### PR DESCRIPTION
Minor performance improvements of `decodePath` in `router-core/utils`:
- `splitAndDecode` is pure and should be declared outside of `decodePath` so it has a better chance of getting JIT optimized
- `DECODE_IGNORE_LIST` is a static array, and should be initialized as an array (instead of `Array.from(new Map([...]).values())`)
- length of `partsToJoin` is known in advance, so should be initialized w/ a length from the start to avoid memory layout changes when we `.push()` on every iteration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal path decoding logic in the router utility to improve code structure and maintainability. Public API remains unchanged and fully compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->