### PR TITLE
fix: handle `$&quot` in defaultRenderHandler correctly

### DIFF
--- a/packages/react-router/src/ssr/renderRouterToString.tsx
+++ b/packages/react-router/src/ssr/renderRouterToString.tsx
@@ -17,7 +17,7 @@ export const renderRouterToString = async ({
     const injectedHtml = await Promise.all(router.serverSsr!.injectedHtml).then(
       (htmls) => htmls.join(''),
     )
-    html = html.replace(`</body>`, `${injectedHtml}</body>`)
+    html = html.replace(`</body>`, () => `${injectedHtml}</body>`)
     return new Response(`<!DOCTYPE html>${html}`, {
       status: router.state.statusCode,
       headers: responseHeaders,

--- a/packages/solid-router/src/ssr/renderRouterToString.tsx
+++ b/packages/solid-router/src/ssr/renderRouterToString.tsx
@@ -29,7 +29,7 @@ export const renderRouterToString = async ({
     const injectedHtml = await Promise.all(router.serverSsr!.injectedHtml).then(
       (htmls) => htmls.join(''),
     )
-    html = html.replace(`</body>`, `${injectedHtml}</body>`)
+    html = html.replace(`</body>`, () => `${injectedHtml}</body>`)
     return new Response(`<!DOCTYPE html>${html}`, {
       status: router.state.statusCode,
       headers: responseHeaders,


### PR DESCRIPTION
resolves #5868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering stability for HTML injection to handle edge cases more reliably across React Router and Solid Router packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->