### PR TITLE
refactor(router-core): findSingleMatch caches the trees it generate in an LRUCache, not a Map

### DIFF
--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -535,7 +535,7 @@ export type ProcessedTree<
   /** a mini route tree generated from the flat `routeMasks` list */
   masksTree: AnySegmentNode<TFlat> | null
   /** @deprecated keep until v2 so that `router.matchRoute` can keep not caring about the actual route tree */
-  singleCache: Map<any, AnySegmentNode<TSingle>>
+  singleCache: LRUCache<string, AnySegmentNode<TSingle>>
   /** a cache of route matches from the `segmentTree` */
   matchCache: LRUCache<string, ReturnType<typeof findMatch<TTree>>>
   /** a cache of route matches from the `masksTree` */
@@ -675,7 +675,7 @@ export function processRouteTree<
   sortTreeNodes(segmentTree)
   const processedTree: ProcessedTree<TRouteLike, any, any> = {
     segmentTree,
-    singleCache: new Map(),
+    singleCache: createLRUCache<string, AnySegmentNode<any>>(1000),
     matchCache: createLRUCache<
       string,
       ReturnType<typeof findMatch<TRouteLike>>


### PR DESCRIPTION
I forgot to change this before merging: the tree cache for `findSingleMatch` should be an LRU cache like the rest, not a `Map` that can grow indefinitely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized route cache management with improved memory efficiency and eviction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->