### PR TITLE
fix: don't use alias for configuring ssr env input

### DIFF
--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -281,7 +281,7 @@ export function TanStackStartVitePluginCore(
                 rollupOptions: {
                   input:
                     viteConfig.environments?.[VITE_ENVIRONMENT_NAMES.server]
-                      ?.build?.rollupOptions?.input ?? ENTRY_POINTS.server,
+                      ?.build?.rollupOptions?.input ?? serverAlias,
                 },
                 outDir: getServerOutputDirectory(viteConfig),
                 commonjsOptions: {


### PR DESCRIPTION
this makes it transparent for other plugins which file is being used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server build entry path resolution to use the server entry alias for more consistent configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->