### PR TITLE
refactor(router-core): cache matched route branch alongside the rest of the route match

### DIFF
--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -606,7 +606,7 @@ export function findSingleMatch(
 type RouteMatch<T extends Extract<RouteLike, { fullPath: string }>> = {
   route: T
   params: Record<string, string>
-  branch: Array<T>
+  branch: ReadonlyArray<T>
 }
 
 export function findRouteMatch<

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -697,7 +697,7 @@ export type ParseLocationFn<TRouteTree extends AnyRoute> = (
 ) => ParsedLocation<FullSearchSchema<TRouteTree>>
 
 export type GetMatchRoutesFn = (pathname: string) => {
-  matchedRoutes: Array<AnyRoute>
+  matchedRoutes: ReadonlyArray<AnyRoute>
   routeParams: Record<string, string>
   foundRoute: AnyRoute | undefined
 }
@@ -1248,9 +1248,9 @@ export class RouterCore<
     next: ParsedLocation,
     opts?: MatchRoutesOpts,
   ): Array<AnyRouteMatch> {
-    const { foundRoute, matchedRoutes, routeParams } = this.getMatchedRoutes(
-      next.pathname,
-    )
+    const matchedRoutesResult = this.getMatchedRoutes(next.pathname)
+    const { foundRoute, routeParams } = matchedRoutesResult
+    let { matchedRoutes } = matchedRoutesResult
     let isGlobalNotFound = false
 
     // Check to see if the route needs a 404 entry
@@ -1263,7 +1263,7 @@ export class RouterCore<
     ) {
       // If the user has defined an (old) 404 route, use it
       if (this.options.notFoundRoute) {
-        matchedRoutes.push(this.options.notFoundRoute)
+        matchedRoutes = [...matchedRoutes, this.options.notFoundRoute]
       } else {
         // If there is no routes found during path matching
         isGlobalNotFound = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Route matching now includes route ancestry (branch) with each match, simplifying how matched routes are built.
  * Simplified traversal: matched routes are derived directly from branch data rather than walking parent links.
  * Immutable handling: matched route lists are treated as readonly and extended immutably (no in-place mutation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->