### PR TITLE
Prevent the root path "/" from being removed

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -1247,7 +1247,7 @@ ${acc.routeTree.map((child) => `${child.variableName}Route: typeof ${getResolved
     )
 
     if (
-      node._fsRouteType === 'layout' ||
+      (node._fsRouteType === 'layout' && node.cleanedPath !== '/') ||
       node._fsRouteType === 'pathless_layout'
     ) {
       node.cleanedPath = removeTrailingSlash(node.cleanedPath)


### PR DESCRIPTION
This PR prevents the root path "/" from being emptied by `removeTrailingSlash`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of trailing slashes in layout-type routes to correctly exclude the root path from trailing-slash removal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->