### PR TITLE
refactor(router-core): trimPathRight more performant w/o trailing slash

### DIFF
--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -36,7 +36,8 @@ export function trimPathLeft(path: string) {
 /** Trim trailing slashes (except preserving root '/'). */
 /** Trim trailing slashes (except preserving root '/'). */
 export function trimPathRight(path: string) {
-  return path === '/' ? path : path.replace(/\/{1,}$/, '')
+  const len = path.length
+  return len > 1 && path[len - 1] === '/' ? path.replace(/\/{1,}$/, '') : path
 }
 
 /** Trim both leading and trailing slashes. */


### PR DESCRIPTION
`trimPathRight` is used on every `matchRoutes` call, any perf is good to take

## bench

TL;DR: same when there is a trailing slash, 2x faster when there isn't.

```
 ✓  @tanstack/router-core  tests/trim.bench.ts > trimPathRight (trailing slash) 5363ms
     name                           hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · Old Implementation  18,094,606.91  0.0000  4.5986  0.0001  0.0001  0.0001  0.0001  0.0002  ±1.80%  9047304
   · New Implementation  17,929,428.10  0.0000  3.7125  0.0001  0.0001  0.0001  0.0001  0.0001  ±1.46%  8964715

 ✓  @tanstack/router-core  tests/trim.bench.ts > trimPathRight (no trailing slash) 8778ms
     name                           hz     min     max    mean     p75     p99    p995    p999     rme   samples
   · Old Implementation  22,495,982.20  0.0000  0.0367  0.0000  0.0000  0.0001  0.0001  0.0001  ±0.07%  11247992
   · New Implementation  47,478,310.39  0.0000  1.9014  0.0000  0.0000  0.0000  0.0000  0.0000  ±0.86%  23739157

 ✓  @tanstack/router-core  tests/trim.bench.ts > trimPathRight (root path) 11253ms
     name                           hz     min     max    mean     p75     p99    p995    p999     rme   samples
   · Old Implementation  48,767,386.88  0.0000  0.1359  0.0000  0.0000  0.0000  0.0000  0.0000  ±0.09%  24383695
   · New Implementation  48,798,276.83  0.0000  0.8486  0.0000  0.0000  0.0000  0.0000  0.0000  ±0.34%  24399139

 BENCH  Summary

   @tanstack/router-core  Old Implementation - tests/trim.bench.ts > trimPathRight (trailing slash)
    1.01x faster than New Implementation

   @tanstack/router-core  New Implementation - tests/trim.bench.ts > trimPathRight (no trailing slash)
    2.11x faster than Old Implementation

   @tanstack/router-core  New Implementation - tests/trim.bench.ts > trimPathRight (root path)
    1.00x faster than Old Implementation
```

```ts
describe('trimPathRight (trailing slash)', () => {
  bench('Old Implementation', () => {
    trimPathRightOld('/some/test/path/')
  })
  bench('New Implementation', () => {
    trimPathRightNew('/some/test/path/')
  })
})

describe('trimPathRight (no trailing slash)', () => {
  bench('Old Implementation', () => {
    trimPathRightOld('/some/test/path')
  })
  bench('New Implementation', () => {
    trimPathRightNew('/some/test/path')
  })
})

describe('trimPathRight (root path)', () => {
  bench('Old Implementation', () => {
    trimPathRightOld('/')
  })
  bench('New Implementation', () => {
    trimPathRightNew('/')
  })
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path handling for edge cases with very short strings, ensuring single-character inputs are now correctly preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->