### PR TITLE
example: remove undocumented `vite start` command

### DIFF
--- a/examples/react/start-bare/package.json
+++ b/examples/react/start-bare/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.136.17",

--- a/examples/react/start-basic-auth/package.json
+++ b/examples/react/start-basic-auth/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
     "prisma-generate": "prisma generate"
   },
   "dependencies": {

--- a/examples/react/start-basic-react-query/package.json
+++ b/examples/react/start-basic-react-query/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",

--- a/examples/react/start-basic-rsc/package.disabled.json
+++ b/examples/react/start-basic-rsc/package.disabled.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
-    "start": "vite start"
+    "build": "vite build"
   },
   "dependencies": {
     "@babel/plugin-syntax-typescript": "^7.25.9",

--- a/examples/react/start-basic-static/package.json
+++ b/examples/react/start-basic-static/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.136.17",

--- a/examples/react/start-clerk-basic/package.json
+++ b/examples/react/start-clerk-basic/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@clerk/tanstack-react-start": "^0.26.3",

--- a/examples/react/start-convex-trellaux/package.json
+++ b/examples/react/start-convex-trellaux/package.json
@@ -7,8 +7,7 @@
     "dev": "npx convex dev --once && concurrently -r npm:dev:web npm:dev:db",
     "dev:web": "vite dev",
     "dev:db": "convex dev --run board:seed",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@convex-dev/react-query": "0.0.0-alpha.8",

--- a/examples/react/start-counter/package.json
+++ b/examples/react/start-counter/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.136.17",

--- a/examples/react/start-large/package.json
+++ b/examples/react/start-large/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && tsc --noEmit",
-    "start": "vite start",
     "gen": "node ./src/createRoutes.mjs",
     "test:types": "tsc --extendedDiagnostics"
   },

--- a/examples/react/start-material-ui/package.json
+++ b/examples/react/start-material-ui/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@emotion/cache": "11.14.0",

--- a/examples/react/start-streaming-data-from-server-functions/package.json
+++ b/examples/react/start-streaming-data-from-server-functions/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.136.17",

--- a/examples/react/start-supabase-basic/package.json
+++ b/examples/react/start-supabase-basic/package.json
@@ -6,8 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/examples/react/start-trellaux/package.json
+++ b/examples/react/start-trellaux/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.0",

--- a/examples/react/start-workos/package.json
+++ b/examples/react/start-workos/package.json
@@ -6,8 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/start-basic-auth/package.json
+++ b/examples/solid/start-basic-auth/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
     "prisma-generate": "prisma generate"
   },
   "dependencies": {

--- a/examples/solid/start-basic-solid-query/package.json
+++ b/examples/solid/start-basic-solid-query/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/solid-query": "^5.90.9",

--- a/examples/solid/start-basic-static/package.json
+++ b/examples/solid/start-basic-static/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
-    "start": "vite start"
+    "build": "vite build"
   },
   "dependencies": {
     "@tanstack/solid-router": "^1.136.17",

--- a/examples/solid/start-basic/package.json
+++ b/examples/solid/start-basic/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/solid-router": "^1.136.17",

--- a/examples/solid/start-convex-better-auth/package.json
+++ b/examples/solid/start-convex-better-auth/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "dev": "vite dev",
     "convex:dev": "convex dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@convex-dev/better-auth": "^0.9.7",

--- a/examples/solid/start-counter/package.json
+++ b/examples/solid/start-counter/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/solid-router": "^1.136.17",

--- a/examples/solid/start-large/package.json
+++ b/examples/solid/start-large/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && tsc --noEmit",
-    "start": "vite start",
     "gen": "node ./src/createRoutes.mjs",
     "test:types": "tsc --extendedDiagnostics"
   },

--- a/examples/solid/start-streaming-data-from-server-functions/package.json
+++ b/examples/solid/start-streaming-data-from-server-functions/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "dependencies": {
     "@tanstack/solid-router": "^1.136.17",

--- a/examples/solid/start-supabase-basic/package.json
+++ b/examples/solid/start-supabase-basic/package.json
@@ -6,8 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && tsc --noEmit",
-    "start": "vite start"
+    "build": "vite build && tsc --noEmit"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
There is no start command e.g. `vite start`, so i remove it here since it's just confusing.

Basically vite just reads `start` as an unknown command and launches a dev server on port 5173, instead of honoring port settings in vite.config.ts like defined commands `vite`/`vite dev`/`vite serve`

What we really need is a "preview" command ot show the production build, like suggested here:
- https://github.com/TanStack/router/pull/5910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed start scripts from multiple React and Solid example projects. Build scripts remain available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->