### PR TITLE
fix(router-core): handle wildcard nodes like any other index node

### DIFF
--- a/packages/router-core/tests/new-process-route-tree.test.ts
+++ b/packages/router-core/tests/new-process-route-tree.test.ts
@@ -546,6 +546,23 @@ describe('findRouteMatch', () => {
       expect(res?.route.id).toBe('/a/b/$')
       expect(res?.params).toEqual({ _splat: 'foo', '*': 'foo' })
     })
+    describe('edge-case #5969: trailing empty wildcard should match', () => {
+      it('basic', () => {
+        const tree = makeTree(['/a/$'])
+        expect(findRouteMatch('/a/', tree)?.route.id).toBe('/a/$')
+        expect(findRouteMatch('/a', tree)?.route.id).toBe('/a/$')
+      })
+      it('with layout route', () => {
+        const tree = makeTree(['/a', '/a/$'])
+        expect(findRouteMatch('/a/', tree)?.route.id).toBe('/a/$')
+        expect(findRouteMatch('/a', tree)?.route.id).toBe('/a/$')
+      })
+      it('with index route (should not match)', () => {
+        const tree = makeTree(['/a/', '/a/$'])
+        expect(findRouteMatch('/a/', tree)?.route.id).toBe('/a/')
+        expect(findRouteMatch('/a', tree)?.route.id).toBe('/a/')
+      })
+    })
   })
 
   describe('nested routes', () => {


### PR DESCRIPTION
Fixes https://github.com/TanStack/router/issues/5969

This implementation, however elegant, would fails this test:
```ts
it('edge-case: deeper index route through skipped optional segments (should not match)', () => {
  const tree = makeTree(['/{-$foo}/{-$bar}/a/', '/a/$'])
  expect(findRouteMatch('/a/', tree)?.route.id).toBe('/{-$foo}/{-$bar}/a/')
  expect(findRouteMatch('/a', tree)?.route.id).toBe('/{-$foo}/{-$bar}/a/')
})
```

We're going to go w/ https://github.com/TanStack/router/pull/5971 instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed wildcard route matching to properly handle trailing slash scenarios across different route configurations.
  - Improved path resolution for routes with wildcard segments by refining index-route handling during traversal.
  - Enhanced overall wildcard routing stability and consistency for better routing predictability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->