### PR TITLE
fix(start-server-core): use public h3 api .res

### DIFF
--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -327,7 +327,7 @@ export function clearSession(config: Partial<SessionConfig>): Promise<void> {
 // not public API
 export function getResponse() {
   const event = getH3Event()
-  return event._res
+  return event.res
 }
 
 // not public API (yet)

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -221,8 +221,8 @@ export const handleServerAction = async ({
           return new Response(
             nonStreamingBody ? JSON.stringify(nonStreamingBody) : undefined,
             {
-              status: response?.status,
-              statusText: response?.statusText,
+              status: response.status,
+              statusText: response.statusText,
               headers: {
                 'Content-Type': 'application/json',
                 [X_TSS_SERIALIZED]: 'true',
@@ -251,8 +251,8 @@ export const handleServerAction = async ({
           },
         })
         return new Response(stream, {
-          status: response?.status,
-          statusText: response?.statusText,
+          status: response.status,
+          statusText: response.statusText,
           headers: {
             'Content-Type': 'application/x-ndjson',
             [X_TSS_SERIALIZED]: 'true',
@@ -261,8 +261,8 @@ export const handleServerAction = async ({
       }
 
       return new Response(undefined, {
-        status: response?.status,
-        statusText: response?.statusText,
+        status: response.status,
+        statusText: response.statusText,
       })
     } catch (error: any) {
       if (error instanceof Response) {
@@ -301,8 +301,8 @@ export const handleServerAction = async ({
       )
       const response = getResponse()
       return new Response(serializedError, {
-        status: response?.status ?? 500,
-        statusText: response?.statusText,
+        status: response.status ?? 500,
+        statusText: response.statusText,
         headers: {
           'Content-Type': 'application/json',
           [X_TSS_SERIALIZED]: 'true',


### PR DESCRIPTION
forward compat, since ._res is removed in next release (2.0.0-rc.1) of h3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected response handling to use framework standard properties.
  * Improved server function response property access patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->