### PR TITLE
fix(router-core): clear leftoverHtml after flushing closing tags to prevent repeated SSR injections

### DIFF
--- a/packages/router-core/src/ssr/transformStreamWithRouter.ts
+++ b/packages/router-core/src/ssr/transformStreamWithRouter.ts
@@ -238,6 +238,7 @@ export function transformStreamWithRouter(
 
         finalPassThrough.write(processed)
         leftover = chunkString.slice(lastIndex)
+        leftoverHtml = ''
       } else {
         leftover = chunkString
         leftoverHtml += getBufferedRouterStream()


### PR DESCRIPTION
fixes #5992 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a server-side rendering issue where HTML content wasn't properly reset during stream processing, potentially causing rendering problems with routed content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->