### PR TITLE
fix(start): allow request middleware to return Response

### DIFF
--- a/packages/start-client-core/src/createMiddleware.ts
+++ b/packages/start-client-core/src/createMiddleware.ts
@@ -760,11 +760,16 @@ export type RequestServerNextFn<TRegister, TMiddlewares> = <
   TServerContext = undefined,
 >(
   options?: RequestServerNextFnOptions<TServerContext>,
-) => RequestMiddlewareServerFnResult<TRegister, TMiddlewares, TServerContext>
+) => RequestServerNextFnResult<TRegister, TMiddlewares, TServerContext>
 
 export interface RequestServerNextFnOptions<TServerContext> {
   context?: TServerContext
 }
+
+export type RequestServerNextFnResult<TRegister, TMiddlewares, TServerContext> =
+
+    | Promise<RequestServerResult<TRegister, TMiddlewares, TServerContext>>
+    | RequestServerResult<TRegister, TMiddlewares, TServerContext>
 
 export type RequestMiddlewareServerFnResult<
   TRegister,

--- a/packages/start-client-core/src/tests/createServerMiddleware.test-d.ts
+++ b/packages/start-client-core/src/tests/createServerMiddleware.test-d.ts
@@ -663,15 +663,12 @@ test('createMiddleware with type request, no middleware or context', () => {
 
     const result = await options.next()
 
-    expectTypeOf(result).toEqualTypeOf<
-      | {
-          context: undefined
-          pathname: string
-          request: Request
-          response: Response
-        }
-      | Response
-    >()
+    expectTypeOf(result).toEqualTypeOf<{
+      context: undefined
+      pathname: string
+      request: Request
+      response: Response
+    }>()
 
     return result
   })
@@ -688,15 +685,12 @@ test('createMiddleware with type request, no middleware with context', () => {
 
     const result = await options.next({ context: { a: 'a' } })
 
-    expectTypeOf(result).toEqualTypeOf<
-      | {
-          context: { a: string }
-          pathname: string
-          request: Request
-          response: Response
-        }
-      | Response
-    >()
+    expectTypeOf(result).toEqualTypeOf<{
+      context: { a: string }
+      pathname: string
+      request: Request
+      response: Response
+    }>()
 
     return result
   })
@@ -714,15 +708,12 @@ test('createMiddleware with type request, middleware and context', () => {
 
       const result = await options.next({ context: { a: 'a' } })
 
-      expectTypeOf(result).toEqualTypeOf<
-        | {
-            context: { a: string }
-            pathname: string
-            request: Request
-            response: Response
-          }
-        | Response
-      >()
+      expectTypeOf(result).toEqualTypeOf<{
+        context: { a: string }
+        pathname: string
+        request: Request
+        response: Response
+      }>()
 
       return result
     },
@@ -740,15 +731,12 @@ test('createMiddleware with type request, middleware and context', () => {
 
       const result = await options.next({ context: { b: 'b' } })
 
-      expectTypeOf(result).toEqualTypeOf<
-        | {
-            context: { a: string; b: string }
-            pathname: string
-            request: Request
-            response: Response
-          }
-        | Response
-      >()
+      expectTypeOf(result).toEqualTypeOf<{
+        context: { a: string; b: string }
+        pathname: string
+        request: Request
+        response: Response
+      }>()
 
       return result
     })


### PR DESCRIPTION
Fixes #5846. This change allows `RequestMiddleware` to return a `Response` object directly, as expected by the issue report. Updated type tests to reflect this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Middleware server functions can now return a Response object directly (sync or Promise) in addition to previous result types, allowing more flexible response handling.

* **Tests**
  * Added tests covering direct Response returns (sync and async) to validate the widened return behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->