### PR TITLE
fix(router-devtools): move vite to devDependencies

### DIFF
--- a/packages/react-router-devtools/package.json
+++ b/packages/react-router-devtools/package.json
@@ -62,13 +62,13 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@tanstack/router-devtools-core": "workspace:*",
-    "vite": "^7.1.7"
+    "@tanstack/router-devtools-core": "workspace:*"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",
     "react": ">=19",
-    "react-dom": ">=19"
+    "react-dom": ">=19",
+    "vite": "^7.1.7"
   },
   "peerDependencies": {
     "@tanstack/react-router": "workspace:^",

--- a/packages/router-devtools-core/package.json
+++ b/packages/router-devtools-core/package.json
@@ -64,11 +64,11 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "goober": "^2.1.16",
-    "vite": "^7.1.7",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
     "solid-js": "^1.9.10",
+    "vite": "^7.1.7",
     "vite-plugin-solid": "^2.11.10"
   },
   "peerDependencies": {

--- a/packages/router-devtools/package.json
+++ b/packages/router-devtools/package.json
@@ -64,13 +64,13 @@
   "dependencies": {
     "@tanstack/react-router-devtools": "workspace:*",
     "clsx": "^2.1.1",
-    "goober": "^2.1.16",
-    "vite": "^7.1.7"
+    "goober": "^2.1.16"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "vite": "^7.1.7"
   },
   "peerDependencies": {
     "@tanstack/react-router": "workspace:^",

--- a/packages/solid-router-devtools/package.json
+++ b/packages/solid-router-devtools/package.json
@@ -66,11 +66,11 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@tanstack/router-devtools-core": "workspace:*",
-    "vite": "^7.1.7"
+    "@tanstack/router-devtools-core": "workspace:*"
   },
   "devDependencies": {
     "solid-js": "^1.9.10",
+    "vite": "^7.1.7",
     "vite-plugin-solid": "^2.11.10"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9367,9 +9367,6 @@ importers:
       '@tanstack/router-devtools-core':
         specifier: workspace:^
         version: link:../router-devtools-core
-      vite:
-        specifier: ^7.1.7
-        version: 7.1.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
@@ -9380,6 +9377,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      vite:
+        specifier: ^7.1.7
+        version: 7.1.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
 
   packages/react-router-ssr-query:
     dependencies:
@@ -9565,9 +9565,6 @@ importers:
       goober:
         specifier: ^2.1.16
         version: 2.1.16(csstype@3.1.3)
-      vite:
-        specifier: ^7.1.7
-        version: 7.1.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
@@ -9578,6 +9575,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      vite:
+        specifier: ^7.1.7
+        version: 7.1.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
 
   packages/router-devtools-core:
     dependencies:
@@ -9596,13 +9596,13 @@ importers:
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
-      vite:
-        specifier: ^7.1.7
-        version: 7.1.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
     devDependencies:
       solid-js:
         specifier: 1.9.10
         version: 1.9.10
+      vite:
+        specifier: ^7.1.7
+        version: 7.1.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vite-plugin-solid:
         specifier: ^2.11.10
         version: 2.11.10(@testing-library/jest-dom@6.6.3)(solid-js@1.9.10)(vite@7.1.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
@@ -9872,13 +9872,13 @@ importers:
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../solid-router
-      vite:
-        specifier: ^7.1.7
-        version: 7.1.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
     devDependencies:
       solid-js:
         specifier: 1.9.10
         version: 1.9.10
+      vite:
+        specifier: ^7.1.7
+        version: 7.1.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vite-plugin-solid:
         specifier: ^2.11.10
         version: 2.11.10(@testing-library/jest-dom@6.6.3)(solid-js@1.9.10)(vite@7.1.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))


### PR DESCRIPTION
fixes #6022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized build tool dependencies across multiple development packages. Development-only build tools have been moved from production dependencies to development-only configuration sections. This change improves overall dependency management, results in cleaner package structures, and ensures more accurate dependency declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->