### PR TITLE
Refactor path parameter usage in documentation

### DIFF
--- a/docs/router/framework/solid/guide/path-params.md
+++ b/docs/router/framework/solid/guide/path-params.md
@@ -7,9 +7,9 @@ replace:
     '{ fileName } = Route.useParams()': 'params = Route.useParams',
     '{ userId } = Route.useParams()': 'params = Route.useParams',
     '{ _splat } = Route.useParams()': 'params = Route.useParams',
-    '{postId}': '{params.postId()}',
-    '{userId}': '{params.userId()}',
-    '{fileName}': '{params.userId()}',
-    '{_splat}': '{params._splat()}',
+    '{postId}': '{params().postId}',
+    '{userId}': '{params().userId}',
+    '{fileName}': '{params().userId}',
+    '{_splat}': '{params()._splat}',
   }
 ---


### PR DESCRIPTION
Route.useParams() returns a signal accessor that needs to be called like a function in order to access its properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Solid router path parameter access syntax documentation to reflect the current method for retrieving route parameters in components and handlers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->