### PR TITLE
docs: Rename solid to Vue

### DIFF
--- a/packages/vue-router/README.md
+++ b/packages/vue-router/README.md
@@ -1,19 +1,19 @@
 <img src="https://static.scarf.sh/a.png?x-pxid=d988eb79-b0fc-4a2b-8514-6a1ab932d188" />
 
-# TanStack Solid Router
+# TanStack Vue Router
 
 ![TanStack Router Header](https://github.com/tanstack/router/raw/main/media/header.png)
 
-🤖 Type-safe router w/ built-in caching & URL state management for Solid!
+🤖 Type-safe router w/ built-in caching & URL state management for Vue!
 
 <a href="https://twitter.com/intent/tweet?button_hashtag=TanStack" target="\_parent">
   <img alt="#TanStack" src="https://img.shields.io/twitter/url?color=%2308a0e9&label=%23TanStack&style=social&url=https%3A%2F%2Ftwitter.com%2Fintent%2Ftweet%3Fbutton_hashtag%3DTanStack">
 </a><a href="https://discord.com/invite/WrRKjPJ" target="\_parent">
   <img alt="" src="https://img.shields.io/badge/Discord-TanStack-%235865F2" />
-</a><a href="https://npmjs.com/package/@tanstack/solid-router" target="\_parent">
+</a><a href="https://npmjs.com/package/@tanstack/vue-router" target="\_parent">
   <img alt="" src="https://img.shields.io/npm/dm/@tanstack/router.svg" />
-</a><a href="https://bundlephobia.com/result?p=@tanstack/solid-router" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/solid-router" />
+</a><a href="https://bundlephobia.com/result?p=@tanstack/vue-router" target="\_parent">
+  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/vue-router" />
 </a><a href="#badge">
     <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
   </a><a href="https://github.com/tanstack/router/discussions">


### PR DESCRIPTION
This pull request updates the `README.md` for the `@tanstack/vue-router`. Renamed Solid to Vue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project README with Vue Router branding, including package names, links, and resource references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->