### PR TITLE
fix(vue-router): inherit attr

### DIFF
--- a/packages/vue-router/src/HeadContent.tsx
+++ b/packages/vue-router/src/HeadContent.tsx
@@ -132,6 +132,7 @@ export const useTags = () => {
  */
 export const HeadContent = Vue.defineComponent({
   name: 'HeadContent',
+  inheritAttrs: false,
   setup() {
     const tags = useTags()
 

--- a/packages/vue-router/src/Match.tsx
+++ b/packages/vue-router/src/Match.tsx
@@ -415,6 +415,7 @@ export const MatchInner = Vue.defineComponent({
 
 export const Outlet = Vue.defineComponent({
   name: 'Outlet',
+  inheritAttrs: false,
   setup() {
     const router = useRouter()
     const matchId = Vue.inject(matchContext)

--- a/packages/vue-router/src/Scripts.tsx
+++ b/packages/vue-router/src/Scripts.tsx
@@ -10,6 +10,7 @@ const VUE_DEFER_SCRIPT = 'self.$_TSR_DEFER=true'
 
 export const Scripts = Vue.defineComponent({
   name: 'Scripts',
+  inheritAttrs: false,
   setup() {
     const router = useRouter()
     const nonce = router.options.ssr?.nonce


### PR DESCRIPTION
When running in dev with @tanstack/devtools-vite, the plugin injects a data-tsd-source attribute onto JSX elements for
“click-to-source”. In Vue, if a component renders a fragment/teleport/text root (instead of a single DOM element), Vue cannot automatically inherit extraneous non-prop attributes to a root element. That causes a lot of server logs because of vue-router's components


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attribute inheritance behavior in core router components to ensure proper handling of non-prop attributes without unintended propagation to child elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->