### PR TITLE
chore: rename `_types` to `'~types'`

### DIFF
--- a/packages/start-client-core/src/createMiddleware.ts
+++ b/packages/start-client-core/src/createMiddleware.ts
@@ -108,7 +108,7 @@ export interface FunctionMiddlewareWithTypes<
   TClientContext,
   TClientSendContext,
 > {
-  _types: FunctionMiddlewareTypes<
+  '~types': FunctionMiddlewareTypes<
     TRegister,
     TMiddlewares,
     TInputValidator,
@@ -187,9 +187,9 @@ export type IntersectAllValidatorInputs<TMiddlewares, TInputValidator> =
 export type IntersectAllMiddleware<
   TMiddlewares,
   TType extends
-    | keyof AnyFunctionMiddleware['_types']
-    | keyof AnyRequestMiddleware['_types']
-    | keyof AnyServerFn['_types'],
+    | keyof AnyFunctionMiddleware['~types']
+    | keyof AnyRequestMiddleware['~types']
+    | keyof AnyServerFn['~types'],
   TAcc = undefined,
 > = TMiddlewares extends readonly [infer TMiddleware, ...infer TRest]
   ? TMiddleware extends
@@ -201,7 +201,7 @@ export type IntersectAllMiddleware<
         TType,
         IntersectAssign<
           TAcc,
-          TMiddleware['_types'][TType & keyof TMiddleware['_types']]
+          TMiddleware['~types'][TType & keyof TMiddleware['~types']]
         >
       >
     : TAcc
@@ -246,9 +246,9 @@ export type AssignAllClientContextBeforeNext<
 export type AssignAllMiddleware<
   TMiddlewares,
   TType extends
-    | keyof AnyFunctionMiddleware['_types']
-    | keyof AnyRequestMiddleware['_types']
-    | keyof AnyServerFn['_types'],
+    | keyof AnyFunctionMiddleware['~types']
+    | keyof AnyRequestMiddleware['~types']
+    | keyof AnyServerFn['~types'],
   TAcc = undefined,
 > = TMiddlewares extends readonly [infer TMiddleware, ...infer TRest]
   ? TMiddleware extends
@@ -258,7 +258,7 @@ export type AssignAllMiddleware<
     ? AssignAllMiddleware<
         TRest,
         TType,
-        Assign<TAcc, TMiddleware['_types'][TType & keyof TMiddleware['_types']]>
+        Assign<TAcc, TMiddleware['~types'][TType & keyof TMiddleware['~types']]>
       >
     : TAcc
   : TAcc
@@ -480,7 +480,7 @@ export type FunctionServerResultWithContext<
   in out TSendContext,
 > = {
   'use functions must return the result of next()': true
-  _types: {
+  '~types': {
     context: TServerContext
     sendContext: TSendContext
   }
@@ -703,7 +703,7 @@ export interface RequestMiddlewareWithTypes<
   TMiddlewares,
   TServerContext,
 > {
-  _types: RequestMiddlewareTypes<TRegister, TMiddlewares, TServerContext>
+  '~types': RequestMiddlewareTypes<TRegister, TMiddlewares, TServerContext>
   options: RequestMiddlewareOptions<TRegister, TMiddlewares, TServerContext>
 }
 

--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -536,7 +536,7 @@ export interface ServerFnWithTypes<
   in out TInputValidator,
   in out TResponse,
 > {
-  _types: ServerFnTypes<
+  '~types': ServerFnTypes<
     TRegister,
     TMethod,
     TMiddlewares,
@@ -690,7 +690,7 @@ function serverFnBaseToMiddleware(
   options: ServerFnBaseOptions<any, any, any, any, any>,
 ): AnyFunctionMiddleware {
   return {
-    _types: undefined!,
+    '~types': undefined!,
     options: {
       inputValidator: options.inputValidator,
       client: async ({ next, sendContext, ...ctx }) => {

--- a/packages/start-client-core/src/tests/createServerMiddleware.test-d.ts
+++ b/packages/start-client-core/src/tests/createServerMiddleware.test-d.ts
@@ -56,7 +56,7 @@ test('createMiddleware merges server context', () => {
 
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
-        _types: {
+        '~types': {
           context: {
             a: boolean
           }
@@ -80,7 +80,7 @@ test('createMiddleware merges server context', () => {
 
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
-        _types: {
+        '~types': {
           context: {
             b: string
           }
@@ -103,7 +103,7 @@ test('createMiddleware merges server context', () => {
 
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
-        _types: {
+        '~types': {
           context: {
             c: number
           }
@@ -129,7 +129,7 @@ test('createMiddleware merges server context', () => {
 
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
-        _types: {
+        '~types': {
           context: {
             d: number
           }
@@ -236,7 +236,7 @@ test('createMiddleware merges client context and sends to the server', () => {
 
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
-        _types: {
+        '~types': {
           context: {
             e: string
           }
@@ -314,7 +314,7 @@ test('createMiddleware merges server context and client context, sends server co
 
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
-        _types: {
+        '~types': {
           context: {
             fromServer1: string
           }
@@ -353,7 +353,7 @@ test('createMiddleware merges server context and client context, sends server co
 
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
-        _types: {
+        '~types': {
           context: {
             fromServer2: string
           }
@@ -403,7 +403,7 @@ test('createMiddleware merges server context and client context, sends server co
 
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
-        _types: {
+        '~types': {
           context: {
             fromServer3: string
           }
@@ -463,7 +463,7 @@ test('createMiddleware merges server context and client context, sends server co
 
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
-        _types: {
+        '~types': {
           context: {
             fromServer4: string
           }
@@ -532,7 +532,7 @@ test('createMiddleware merges server context and client context, sends server co
 
       expectTypeOf(result).toEqualTypeOf<{
         'use functions must return the result of next()': true
-        _types: {
+        '~types': {
           context: {
             fromServer5: string
           }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type property naming in core middleware and server function exports for improved consistency in TypeScript type resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->