### PR TITLE
docs: remove duplicate console.info from beforeLoad example

### DIFF
--- a/docs/router/framework/react/guide/data-loading.md
+++ b/docs/router/framework/react/guide/data-loading.md
@@ -321,7 +321,7 @@ export const Route = createFileRoute('/posts')({
     fetchPosts: () => console.info('foo'),
   }),
   loader: ({ context: { fetchPosts } }) => {
-    console.info(fetchPosts()) // 'foo'
+    fetchPosts() // 'foo'
 
     // ...
   },


### PR DESCRIPTION
Updated the example to call fetchPosts() directly instead of wrapping it in console.info(), reflecting the intended usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the data-loading guide example to remove console logging from the route loader pattern, providing a cleaner approach to data-fetching operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->