### PR TITLE
fix: properly track re-exports of server function factories

### DIFF
--- a/e2e/react-start/server-functions/src/routes/factory/-functions/functions.ts
+++ b/e2e/react-start/server-functions/src/routes/factory/-functions/functions.ts
@@ -2,6 +2,10 @@ import { createMiddleware, createServerFn } from '@tanstack/react-start'
 import { createBarServerFn } from './createBarServerFn'
 import { createFooServerFn } from './createFooServerFn'
 import { createFakeFn } from './createFakeFn'
+// Test re-export syntax: `export { foo } from './module'`
+import { reexportFactory } from './reexportIndex'
+// Test star re-export syntax: `export * from './module'`
+import { starReexportFactory } from './starReexportIndex'
 
 export const fooFn = createFooServerFn().handler(({ context }) => {
   return {
@@ -91,3 +95,23 @@ export const composedFn = composeFactory()
       context,
     }
   })
+
+// Test that re-exported factories (using `export { foo } from './module'`) work correctly
+// The middleware from reexportFactory should execute and add { reexport: 'reexport-middleware-executed' } to context
+export const reexportedFactoryFn = reexportFactory().handler(({ context }) => {
+  return {
+    name: 'reexportedFactoryFn',
+    context,
+  }
+})
+
+// Test that star re-exported factories (using `export * from './module'`) work correctly
+// The middleware from starReexportFactory should execute and add { starReexport: 'star-reexport-middleware-executed' } to context
+export const starReexportedFactoryFn = starReexportFactory().handler(
+  ({ context }) => {
+    return {
+      name: 'starReexportedFactoryFn',
+      context,
+    }
+  },
+)

--- a/e2e/react-start/server-functions/src/routes/factory/-functions/reexportIndex.ts
+++ b/e2e/react-start/server-functions/src/routes/factory/-functions/reexportIndex.ts
@@ -1,0 +1,2 @@
+// This file tests re-exporting a factory function from another module
+export { reexportFactory } from './reexportWrapper'

--- a/e2e/react-start/server-functions/src/routes/factory/-functions/reexportWrapper.ts
+++ b/e2e/react-start/server-functions/src/routes/factory/-functions/reexportWrapper.ts
@@ -1,0 +1,12 @@
+import { createMiddleware, createServerFn } from '@tanstack/react-start'
+
+const reexportMiddleware = createMiddleware({ type: 'function' }).server(
+  ({ next }) => {
+    console.log('reexport middleware triggered')
+    return next({
+      context: { reexport: 'reexport-middleware-executed' } as const,
+    })
+  },
+)
+
+export const reexportFactory = createServerFn().middleware([reexportMiddleware])

--- a/e2e/react-start/server-functions/src/routes/factory/-functions/starReexportIndex.ts
+++ b/e2e/react-start/server-functions/src/routes/factory/-functions/starReexportIndex.ts
@@ -1,0 +1,2 @@
+// This file tests re-exporting a factory function from another module using the star syntax
+export * from './starReexportWrapper'

--- a/e2e/react-start/server-functions/src/routes/factory/-functions/starReexportWrapper.ts
+++ b/e2e/react-start/server-functions/src/routes/factory/-functions/starReexportWrapper.ts
@@ -1,0 +1,14 @@
+import { createMiddleware, createServerFn } from '@tanstack/react-start'
+
+const starReexportMiddleware = createMiddleware({ type: 'function' }).server(
+  ({ next }) => {
+    console.log('star reexport middleware triggered')
+    return next({
+      context: { starReexport: 'star-reexport-middleware-executed' } as const,
+    })
+  },
+)
+
+export const starReexportFactory = createServerFn().middleware([
+  starReexportMiddleware,
+])

--- a/e2e/react-start/server-functions/src/routes/factory/index.tsx
+++ b/e2e/react-start/server-functions/src/routes/factory/index.tsx
@@ -12,6 +12,8 @@ import {
   fooFnPOST,
   localFn,
   localFnPOST,
+  reexportedFactoryFn,
+  starReexportedFactoryFn,
 } from './-functions/functions'
 
 export const Route = createFileRoute('/factory/')({
@@ -128,6 +130,26 @@ const functions = {
     expected: {
       name: 'fakeFn',
       window,
+    },
+  },
+  // Test that re-exported factories (using `export { foo } from './module'`) work correctly
+  // The middleware from reexportFactory should execute and add { reexport: 'reexport-middleware-executed' } to context
+  reexportedFactoryFn: {
+    fn: reexportedFactoryFn,
+    type: 'serverFn',
+    expected: {
+      name: 'reexportedFactoryFn',
+      context: { reexport: 'reexport-middleware-executed' },
+    },
+  },
+  // Test that star re-exported factories (using `export * from './module'`) work correctly
+  // The middleware from starReexportFactory should execute and add { starReexport: 'star-reexport-middleware-executed' } to context
+  starReexportedFactoryFn: {
+    fn: starReexportedFactoryFn,
+    type: 'serverFn',
+    expected: {
+      name: 'starReexportedFactoryFn',
+      context: { starReexport: 'star-reexport-middleware-executed' },
     },
   },
 } satisfies Record<string, TestCase>

--- a/e2e/react-start/server-functions/tests/server-functions.spec.ts
+++ b/e2e/react-start/server-functions/tests/server-functions.spec.ts
@@ -543,3 +543,51 @@ test('redirect in server function called in query during SSR', async ({
   await expect(page.getByTestId('redirect-target-ssr')).toBeVisible()
   expect(page.url()).toContain('/redirect-test-ssr/target')
 })
+
+test('re-exported server function factory middleware executes correctly', async ({
+  page,
+}) => {
+  // This test specifically verifies that when a server function factory is re-exported
+  // using `export { foo } from './module'` syntax, the middleware still executes.
+  // Previously, this syntax caused middleware to be silently skipped.
+  await page.goto('/factory')
+
+  await expect(page.getByTestId('factory-route-component')).toBeInViewport()
+
+  // Click the button for the re-exported factory function
+  await page.getByTestId('btn-fn-reexportedFactoryFn').click()
+
+  // Wait for the result
+  await expect(page.getByTestId('fn-result-reexportedFactoryFn')).toContainText(
+    'reexport-middleware-executed',
+  )
+
+  // Verify the full context was returned (middleware executed)
+  await expect(
+    page.getByTestId('fn-comparison-reexportedFactoryFn'),
+  ).toContainText('equal')
+})
+
+test('star re-exported server function factory middleware executes correctly', async ({
+  page,
+}) => {
+  // This test specifically verifies that when a server function factory is re-exported
+  // using `export * from './module'` syntax, the middleware still executes.
+  // Previously, this syntax caused middleware to be silently skipped.
+  await page.goto('/factory')
+
+  await expect(page.getByTestId('factory-route-component')).toBeInViewport()
+
+  // Click the button for the star re-exported factory function
+  await page.getByTestId('btn-fn-starReexportedFactoryFn').click()
+
+  // Wait for the result
+  await expect(
+    page.getByTestId('fn-result-starReexportedFactoryFn'),
+  ).toContainText('star-reexport-middleware-executed')
+
+  // Verify the full context was returned (middleware executed)
+  await expect(
+    page.getByTestId('fn-comparison-starReexportedFactoryFn'),
+  ).toContainText('equal')
+})


### PR DESCRIPTION
fixes #6029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added re-exported server function examples (named and wildcard) that surface middleware-applied context when invoked.

* **Compiler**
  * Enhanced compiler resolution to support re-exported server functions (named and export * patterns).

* **Tests**
  * Added end-to-end tests confirming middleware executes and context is propagated for re-exported server functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->