### PR TITLE
docs: fix typo in pathless layout routes explanation

### DIFF
--- a/docs/router/framework/react/routing/routing-concepts.md
+++ b/docs/router/framework/react/routing/routing-concepts.md
@@ -309,7 +309,7 @@ routes/
 │   ├── b.tsx
 ```
 
-However, unlike Layout Routes, since Pathless Layout Routes do match based on URL path segments, this means that these routes do not support [Dynamic Route Segments](#dynamic-route-segments) as part of their path and therefore cannot be matched in the URL.
+However, unlike Layout Routes, since Pathless Layout Routes do not match based on URL path segments, this means that these routes do not support [Dynamic Route Segments](#dynamic-route-segments) as part of their path and therefore cannot be matched in the URL.
 
 This means that you cannot do this:
 


### PR DESCRIPTION
The docs are currently saying that since pathless layout routes <ins>do</ins> match URL segments, it's not possible to do dynamic route segments as part of their path. However, the reasons to me seems that pathless layout routes <ins>do not</ins> match URL segments. Am I missing something?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Pathless Layout Routes documentation to accurately clarify that they do not match based on URL path segments or dynamic route segments. Updated related examples for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->