### PR TITLE
docs: add i18n guide

### DIFF
--- a/docs/router/framework/react/guide/internationalization-i18n.md
+++ b/docs/router/framework/react/guide/internationalization-i18n.md
@@ -26,7 +26,7 @@ This pattern relies exclusively on TanStack Router features. It is suitable when
 Optional path parameters are ideal for implementing locale-aware routing without duplicating routes.
 
 ```ts
-;/{-$locale}/about
+;/{-$locale}/abotu
 ```
 
 This single route matches:


### PR DESCRIPTION
I got a section from the optional params guide demonstrating how to use it to achieve i18n, we could also remove that part from the optional params guide to not repeat ourselves and just link to here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive internationalization (i18n) guide covering optional path parameters for locale routing, language switching strategies, type-safe locale handling, and integration patterns with popular i18n libraries. Includes practical code examples for client-side and server-side implementations, URL localization, HTML lang attributes, and SEO considerations for localized routes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->