### PR TITLE
fix: update sitemap build condition to check for sitemap.enabled instead of pages length

### DIFF
--- a/packages/start-plugin-core/src/post-server-build.ts
+++ b/packages/start-plugin-core/src/post-server-build.ts
@@ -59,7 +59,7 @@ export async function postServerBuild({
   }
 
   // Run the sitemap build process
-  if (startConfig.pages.length) {
+  if (startConfig.sitemap?.enabled) {
     buildSitemap({
       startConfig,
       publicDir:


### PR DESCRIPTION
Fixes #5419 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Sitemap generation is now explicitly configurable. Previously, sitemaps were automatically generated whenever pages were present in your site configuration. The system now requires explicit enablement through configuration settings, providing greater control over when sitemaps are created and how your site is built.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->