### PR TITLE
docs: Rename validator to inputValidator in fetch functions

### DIFF
--- a/docs/start/framework/react/guide/rendering-markdown.md
+++ b/docs/start/framework/react/guide/rendering-markdown.md
@@ -428,7 +428,9 @@ type GitHubContent = {
 }
 
 export const fetchRepoContents = createServerFn({ method: 'GET' })
-  .inputValidator((params: { repo: string; branch: string; path: string }) => params)
+  .inputValidator(
+    (params: { repo: string; branch: string; path: string }) => params,
+  )
   .handler(async ({ data: { repo, branch, path } }) => {
     const url = `https://api.github.com/repos/${repo}/contents/${path}?ref=${branch}`
 


### PR DESCRIPTION
Tiny one. Docs were still referencing the old `validator` function name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal server-side validation patterns to improve code consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->