### PR TITLE
docs(react) fix property name (`path` -> `params`)

### DIFF
--- a/docs/router/framework/react/api/router/ToOptionsType.md
+++ b/docs/router/framework/react/api/router/ToOptionsType.md
@@ -19,6 +19,6 @@ type SearchParamOptions = {
 }
 
 type PathParamOptions = {
-  path?: true | Record<string, TPathParam> | ((prev: TFromParams) => TToParams)
+  params?: true | Record<string, TPathParam> | ((prev: TFromParams) => TToParams)
 }
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated routing configuration API: Property name changed from `path` to `params` in type options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->