### PR TITLE
Fixes #6270

### DIFF
--- a/packages/start-plugin-core/src/start-compiler-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-compiler-plugin/plugin.ts
@@ -232,7 +232,7 @@ export function startCompilerPlugin(
       transform: {
         filter: {
           id: {
-            exclude: [new RegExp(`${SERVER_FN_LOOKUP}$`), /node_modules/],
+            exclude: [new RegExp(`${SERVER_FN_LOOKUP}$`), /node_modules\/(?!@tanstack)/],
             include: TRANSFORM_ID_REGEX,
           },
           code: {


### PR DESCRIPTION
I'm running this patch in production successfully.

Fixes #6270 

## Why this works TLDR

 The compiler must skip third-party node_modules (which may contain non-standard JavaScript that Babel can't parse), but must still transform @tanstack/* packages—which contain isomorphic functions whose server-only imports need to be dead-code-eliminated to prevent node:async_hooks from leaking into client bundles.
 
 ## Why this works 
 
The TanStack Start compiler transforms isomorphic functions by replacing server-only code paths and running dead code elimination. Without excluding node_modules, it also transforms third-party packages (like xlsx-js-style) which may contain non-standard JavaScript that Babel can't parse, causing build failures.

The negative lookahead (?!@tanstack) is critical: TanStack's internal packages (@tanstack/start-client-core, etc.) contain isomorphic functions with top-level imports from @tanstack/start-storage-context. These packages must still be transformed so the .server() callbacks and their node:async_hooks imports are eliminated from client bundles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the compiler plugin's code transformation logic to better handle dependency exclusion patterns, enhancing build processing during compilation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->