### PR TITLE
fix(react-start): Update useServerFn return type to be undefined after redirect

### DIFF
--- a/e2e/react-start/basic-auth/src/hooks/useMutation.ts
+++ b/e2e/react-start/basic-auth/src/hooks/useMutation.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 export function useMutation<TVariables, TData, TError = Error>(opts: {
-  fn: (variables: TVariables) => Promise<TData>
+  fn: (variables: TVariables) => Promise<TData | undefined>
   onSuccess?: (ctx: { data: TData }) => void | Promise<void>
 }) {
   const [submittedAt, setSubmittedAt] = React.useState<number | undefined>()
@@ -20,11 +20,13 @@ export function useMutation<TVariables, TData, TError = Error>(opts: {
       //
       try {
         const data = await opts.fn(variables)
-        await opts.onSuccess?.({ data })
-        setStatus('success')
-        setError(undefined)
-        setData(data)
-        return data
+        if (data !== undefined) {
+          await opts.onSuccess?.({ data })
+          setStatus('success')
+          setError(undefined)
+          setData(data)
+          return data
+        }
       } catch (err: any) {
         setStatus('error')
         setError(err)

--- a/examples/react/start-supabase-basic/src/hooks/useMutation.ts
+++ b/examples/react/start-supabase-basic/src/hooks/useMutation.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 export function useMutation<TVariables, TData, TError = Error>(opts: {
-  fn: (variables: TVariables) => Promise<TData>
+  fn: (variables: TVariables) => Promise<TData | undefined>
   onSuccess?: (ctx: { data: TData }) => void | Promise<void>
 }) {
   const [submittedAt, setSubmittedAt] = React.useState<number | undefined>()
@@ -20,11 +20,13 @@ export function useMutation<TVariables, TData, TError = Error>(opts: {
       //
       try {
         const data = await opts.fn(variables)
-        await opts.onSuccess?.({ data })
-        setStatus('success')
-        setError(undefined)
-        setData(data)
-        return data
+        if (data !== undefined) {
+          await opts.onSuccess?.({ data })
+          setStatus('success')
+          setError(undefined)
+          setData(data)
+          return data
+        }
       } catch (err) {
         setStatus('error')
         setError(err as TError)

--- a/packages/react-start/src/useServerFn.ts
+++ b/packages/react-start/src/useServerFn.ts
@@ -3,7 +3,7 @@ import { isRedirect, useRouter } from '@tanstack/react-router'
 
 export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
   serverFn: T,
-): (...args: Parameters<T>) => ReturnType<T> {
+): (...args: Parameters<T>) => ReturnType<T> | Promise<undefined> {
   const router = useRouter()
 
   return React.useCallback(
@@ -26,5 +26,5 @@ export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
       }
     },
     [router, serverFn],
-  ) as any
+  )
 }


### PR DESCRIPTION
`useServerFn` returns a promise that resolves to `undefined` when the server function redirects. This PR updates the return type to reflect that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mutation hooks now allow empty/void results; success callbacks and state updates run only when data is returned.
  * Server-facing hooks now accept void-returning flows (e.g., redirects), so caller return types can be a value or void.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->