### PR TITLE
fix: prerendering with docker build

### DIFF
--- a/packages/start-plugin-core/src/prerender.ts
+++ b/packages/start-plugin-core/src/prerender.ts
@@ -271,6 +271,7 @@ async function startPreviewServer(
     return await vite.preview({
       configFile: viteConfig.configFile,
       preview: {
+        host: '127.0.0.1',
         port: 0,
         open: false,
       },


### PR DESCRIPTION
Fix #6275

This binds the vite preview server to 127.0.0.1 to avoid Docker build failure caused by resolved network URLs pointing to non-listening interfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preview server configuration to bind to the loopback address for local development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->