### PR TITLE
fix: make sure prerendering runs after other plugins' buildApp hook

### DIFF
--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -345,12 +345,13 @@ export function TanStackStartVitePluginCore(
         }
       },
     },
-    // Separate plugin for buildApp hook without enforce: 'pre'
+    // Separate plugin for buildApp hook with enforce: 'post'
     // This ensures proper ordering with other plugins that also have
-    // buildApp hooks with order: 'post'. The enforce: 'pre' on the config plugin
-    // would cause this hook to run before those others' buildApp, breaking prerendering.
+    // buildApp hooks with order: 'post'. The enforce: 'post' ensures this
+    // runs after other plugins (like Nitro) complete their builds.
     {
       name: 'tanstack-start-core:post-build',
+      enforce: 'post',
       buildApp: {
         order: 'post',
         async handler(builder) {


### PR DESCRIPTION
fixes #5939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced build process by ensuring the post-build plugin executes in the correct sequence after other plugins.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->