### PR TITLE
fix(router-plugin): remove process.exit from webpack code-splitter

### DIFF
--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -256,14 +256,9 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
         ROOT = process.cwd()
         initUserConfig()
 
-        if (compiler.options.mode === 'production') {
-          compiler.hooks.done.tap(PLUGIN_NAME, () => {
-            console.info('✅ ' + PLUGIN_NAME + ': code-splitting done!')
-            setTimeout(() => {
-              process.exit(0)
-            })
-          })
-        }
+        compiler.hooks.done.tap(PLUGIN_NAME, () => {
+          console.info('✅ ' + PLUGIN_NAME + ': code-splitting done!')
+        })
       },
     },
     {


### PR DESCRIPTION
Fixes issue: "Webpack: router-code-splitter plugin calls process.exit(0) on done in production, terminating the process prematurely" #5069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unexpected process termination in the build pipeline, improving deployment stability and allowing builds to complete normally.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->