### PR TITLE
fix(router-plugin): do not `process.exit` after code transformation for webpack and rspack

### DIFF
--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -247,9 +247,15 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
         },
       },
 
-      rspack() {
+      rspack(compiler) {
         ROOT = process.cwd()
         initUserConfig()
+
+        if (compiler.options.mode === 'production') {
+          compiler.hooks.done.tap(PLUGIN_NAME, () => {
+            console.info('✅ ' + PLUGIN_NAME + ': code-splitting done!')
+          })
+        }
       },
 
       webpack(compiler) {
@@ -259,9 +265,6 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
         if (compiler.options.mode === 'production') {
           compiler.hooks.done.tap(PLUGIN_NAME, () => {
             console.info('✅ ' + PLUGIN_NAME + ': code-splitting done!')
-            setTimeout(() => {
-              process.exit(0)
-            })
           })
         }
       },


### PR DESCRIPTION
Closes #5069 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic process exit behavior in webpack code-splitting to improve application stability.

* **Improvements**
  * Added production-mode logging for rspack code-splitting completion status.
  * Enhanced compiler parameter handling in router code-splitter plugin initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->