### PR TITLE
fix(router-plugin): normalize file paths for Windows compatibility with rspack/webpack

### DIFF
--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -17,7 +17,7 @@ import {
   tsrSplit,
 } from './constants'
 import { decodeIdentifier } from './code-splitter/path-ids'
-import { debug } from './utils'
+import { debug, normalizePath } from './utils'
 import type { CodeSplitGroupings, SplitRouteIdentNodes } from './constants'
 import type { GetRoutesByFileMapResultValue } from '@tanstack/router-generator'
 import type { Config } from './config'
@@ -212,7 +212,9 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
           },
         },
         handler(code, id) {
-          const generatorFileInfo = globalThis.TSR_ROUTES_BY_ID_MAP?.get(id)
+          const normalizedId = normalizePath(id)
+          const generatorFileInfo =
+            globalThis.TSR_ROUTES_BY_ID_MAP?.get(normalizedId)
           if (
             generatorFileInfo &&
             includedCode.some((included) => code.includes(included))
@@ -227,7 +229,11 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
               }
             }
 
-            return handleCompilingReferenceFile(code, id, generatorFileInfo)
+            return handleCompilingReferenceFile(
+              code,
+              normalizedId,
+              generatorFileInfo,
+            )
           }
 
           return null
@@ -280,8 +286,8 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
         handler(code, id) {
           const url = pathToFileURL(id)
           url.searchParams.delete('v')
-          id = fileURLToPath(url).replace(/\\/g, '/')
-          return handleCompilingVirtualFile(code, id)
+          const normalizedId = normalizePath(fileURLToPath(url))
+          return handleCompilingVirtualFile(code, normalizedId)
         },
       },
     },

--- a/packages/router-plugin/src/core/router-hmr-plugin.ts
+++ b/packages/router-plugin/src/core/router-hmr-plugin.ts
@@ -1,6 +1,6 @@
 import { generateFromAst, logDiff, parseAst } from '@tanstack/router-utils'
 import { routeHmrStatement } from './route-hmr-statement'
-import { debug } from './utils'
+import { debug, normalizePath } from './utils'
 import { getConfig } from './config'
 import type { UnpluginFactory } from 'unplugin'
 import type { Config } from './config'
@@ -34,18 +34,19 @@ export const unpluginRouterHmrFactory: UnpluginFactory<
         },
       },
       handler(code, id) {
-        if (!globalThis.TSR_ROUTES_BY_ID_MAP?.has(id)) {
+        const normalizedId = normalizePath(id)
+        if (!globalThis.TSR_ROUTES_BY_ID_MAP?.has(normalizedId)) {
           return null
         }
 
-        if (debug) console.info('Adding HMR handling to route ', id)
+        if (debug) console.info('Adding HMR handling to route ', normalizedId)
 
         const ast = parseAst({ code })
         ast.program.body.push(routeHmrStatement)
         const result = generateFromAst(ast, {
           sourceMaps: true,
-          filename: id,
-          sourceFileName: id,
+          filename: normalizedId,
+          sourceFileName: normalizedId,
         })
         if (debug) {
           logDiff(code, result.code)

--- a/packages/router-plugin/src/core/utils.ts
+++ b/packages/router-plugin/src/core/utils.ts
@@ -1,3 +1,14 @@
 export const debug =
   process.env.TSR_VITE_DEBUG &&
   ['true', 'router-plugin'].includes(process.env.TSR_VITE_DEBUG)
+
+/**
+ * Normalizes a file path by converting Windows backslashes to forward slashes.
+ * This ensures consistent path handling across different bundlers and operating systems.
+ *
+ * The route generator stores paths with forward slashes, but rspack/webpack on Windows
+ * pass native paths with backslashes to transform handlers.
+ */
+export function normalizePath(path: string): string {
+  return path.replace(/\\/g, '/')
+}

--- a/packages/router-plugin/tests/utils.test.ts
+++ b/packages/router-plugin/tests/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { normalizePath } from '../src/core/utils'
+
+describe('normalizePath', () => {
+  it('should convert Windows backslashes to forward slashes', () => {
+    expect(normalizePath('C:\\Users\\project\\src\\routes\\index.tsx')).toBe(
+      'C:/Users/project/src/routes/index.tsx',
+    )
+  })
+
+  it('should handle mixed slashes', () => {
+    expect(normalizePath('C:/Users\\project/src\\routes/index.tsx')).toBe(
+      'C:/Users/project/src/routes/index.tsx',
+    )
+  })
+
+  it('should leave forward slashes unchanged', () => {
+    expect(normalizePath('/home/user/project/src/routes/index.tsx')).toBe(
+      '/home/user/project/src/routes/index.tsx',
+    )
+  })
+
+  it('should handle relative paths with backslashes', () => {
+    expect(normalizePath('src\\routes\\index.tsx')).toBe('src/routes/index.tsx')
+  })
+
+  it('should handle empty string', () => {
+    expect(normalizePath('')).toBe('')
+  })
+
+  it('should handle path with query string', () => {
+    expect(normalizePath('C:\\project\\file.tsx?tsr-split=component')).toBe(
+      'C:/project/file.tsx?tsr-split=component',
+    )
+  })
+})


### PR DESCRIPTION
The route generator stores file paths with forward slashes but rspack and webpack on Windows pass native paths with backslashes to transform handlers.
This caused `TSR_ROUTES_BY_ID_MAP` lookups to fail, preventing `autoCodeSplitting` from working on Windows with rspack. The route generator stores file paths with forward slashes, but rspack and webpack on Windows pass native paths with backslashes to transform handlers.

This caused `TSR_ROUTES_BY_ID_MAP` lookups to fail, preventing autoCodeSplitting from working on Windows with rspack.

Closes #6253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path normalization for route handling across Windows and Unix-based systems to ensure consistent behavior regardless of operating system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->