### PR TITLE
fix: remove unused peer dependency

### DIFF
--- a/packages/router-devtools-core/package.json
+++ b/packages/router-devtools-core/package.json
@@ -73,8 +73,7 @@
   },
   "peerDependencies": {
     "@tanstack/router-core": "workspace:^",
-    "csstype": "^3.0.10",
-    "solid-js": ">=1.9.5"
+    "csstype": "^3.0.10"
   },
   "peerDependenciesMeta": {
     "csstype": {


### PR DESCRIPTION
Solid has been bundled since https://github.com/TanStack/router/pull/5422. As a result, there's no need to have it specified as a peer dependency. Unfortunately I missed that in the last PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the explicit solid-js peer dependency from router-devtools-core to allow more flexible dependency configurations and reduce strict version coupling. The csstype peer requirement remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->