### PR TITLE
fix: prevent crash in buildLocation when params stringification fails (#6310)

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1701,7 +1701,11 @@ export class RouterCore<
           const fn =
             route.options.params?.stringify ?? route.options.stringifyParams
           if (fn) {
-            Object.assign(nextParams, fn(nextParams))
+            try {
+              Object.assign(nextParams, fn(nextParams))
+            } catch (err) {
+              //
+            }
           }
         }
       }


### PR DESCRIPTION
### Description
Fixes #6310

I investigated the issue using the reproduction repository provided in the issue.
Currently, `buildLocation` attempts to execute `stringify` even when `params.parse` fails or throws an error. In SSR environments, this causes the server to throw a 500 error (crash) instead of rendering the `NotFound` boundary.

### Proposed Solution
I wrapped the `stringify` execution in a `try-catch` block within `buildLocation`.
If stringification fails, it now silently ignores the error. This prevents the app from crashing and allows the router to render the `NotFound` component correctly.

**Before:**
<img width="1031" height="432" alt="before" src="https://github.com/user-attachments/assets/44169fc1-b7dd-43ea-b232-12f67330a74d" />


**After:**
<img width="914" height="346" alt="after" src="https://github.com/user-attachments/assets/a19f1fc8-e93f-4939-997d-e6291d534c8f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router stability by implementing graceful error handling for parameter serialization. Navigation will no longer fail unexpectedly due to serialization errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->