### PR TITLE
fix(start-plugin-core): remove crawlFrameworkPkgs from optimizeDeps.exclude

### DIFF
--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -244,7 +244,6 @@ export function TanStackStartVitePluginCore(
                 outDir: getClientOutputDirectory(viteConfig),
               },
               optimizeDeps: {
-                exclude: crawlFrameworkPkgsResult.optimizeDeps.exclude,
                 // Ensure user code can be crawled for dependencies
                 entries: [clientAlias, routerAlias].map((entry) =>
                   // Entries are treated as `tinyglobby` patterns so need to be escaped


### PR DESCRIPTION
## Summary

Fixes #5738 - Server-side modules incorrectly bundled into the client

Starting with `@tanstack/react-start@1.134.7`, server-side modules (like the `cookie` module from Clerk SDK) were incorrectly being bundled into the client bundle, causing runtime errors like:

```
SyntaxError: The requested module '/node_modules/cookie/dist/index.js' does not provide an export named 'parse'
```

## Root Cause

The `crawlFrameworkPkgs` function finds packages that have `@tanstack/react-start` or `@tanstack/start-client-core` as `peerDependencies` and was adding them to `optimizeDeps.exclude`. This caused third-party packages (like Clerk SDK, tanstack-themes) to not be pre-bundled properly, leading to server-side module leakage.

## The Fix

Remove `exclude: crawlFrameworkPkgsResult.optimizeDeps.exclude` from the client environment's `optimizeDeps` configuration. This allows Vite to properly pre-bundle third-party packages and their dependencies.

## Testing

Verified the fix works with:
- **Clerk SDK** (`@clerk/tanstack-react-start`) - No more `cookie` module errors
- **tanstack-themes** (`@tanstack-themes/react`) - Works correctly
- **TanStack Form** (`@tanstack/react-form`) - No more `use-sync-external-store` errors

All unit and type tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency optimization configuration in the build process. Framework-related packages will now be processed during dependency optimization, potentially affecting how dependencies are pre-bundled in client builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->