### PR TITLE
fix: add serverFnMeta as optional to request middleware

### DIFF
--- a/packages/start-client-core/src/createMiddleware.ts
+++ b/packages/start-client-core/src/createMiddleware.ts
@@ -753,6 +753,12 @@ export interface RequestServerOptions<TRegister, TMiddlewares> {
   pathname: string
   context: Expand<AssignAllServerRequestContext<TRegister, TMiddlewares>>
   next: RequestServerNextFn<TRegister, TMiddlewares>
+  /**
+   * Metadata about the server function being invoked.
+   * This is only present when the request is handling a server function call.
+   * For regular page requests, this will be undefined.
+   */
+  serverFnMeta?: ServerFnMeta
 }
 
 export type RequestServerNextFn<TRegister, TMiddlewares> = <

--- a/packages/start-client-core/src/tests/createServerMiddleware.test-d.ts
+++ b/packages/start-client-core/src/tests/createServerMiddleware.test-d.ts
@@ -3,6 +3,7 @@ import { createMiddleware } from '../createMiddleware'
 import type { RequestServerNextFn } from '../createMiddleware'
 import type { ConstrainValidator } from '../createServerFn'
 import type { Register } from '@tanstack/router-core'
+import type { ServerFnMeta } from '../constants'
 
 test('createServeMiddleware removes middleware after middleware,', () => {
   const middleware = createMiddleware({ type: 'function' })
@@ -659,6 +660,7 @@ test('createMiddleware with type request, no middleware or context', () => {
       next: RequestServerNextFn<{}, undefined>
       pathname: string
       context: undefined
+      serverFnMeta?: ServerFnMeta
     }>()
 
     const result = await options.next()
@@ -681,6 +683,7 @@ test('createMiddleware with type request, no middleware with context', () => {
       next: RequestServerNextFn<{}, undefined>
       pathname: string
       context: undefined
+      serverFnMeta?: ServerFnMeta
     }>()
 
     const result = await options.next({ context: { a: 'a' } })
@@ -704,6 +707,7 @@ test('createMiddleware with type request, middleware and context', () => {
         next: RequestServerNextFn<{}, undefined>
         pathname: string
         context: undefined
+        serverFnMeta?: ServerFnMeta
       }>()
 
       const result = await options.next({ context: { a: 'a' } })
@@ -727,6 +731,7 @@ test('createMiddleware with type request, middleware and context', () => {
         next: RequestServerNextFn<{}, undefined>
         pathname: string
         context: { a: string }
+        serverFnMeta?: ServerFnMeta
       }>()
 
       const result = await options.next({ context: { b: 'b' } })
@@ -749,6 +754,7 @@ test('createMiddleware with type request can return Response directly', () => {
       next: RequestServerNextFn<{}, undefined>
       pathname: string
       context: undefined
+      serverFnMeta?: ServerFnMeta
     }>()
 
     // Should be able to return a Response directly
@@ -768,6 +774,7 @@ test('createMiddleware with type request can return Promise<Response>', () => {
       next: RequestServerNextFn<{}, undefined>
       pathname: string
       context: undefined
+      serverFnMeta?: ServerFnMeta
     }>()
 
     // Should be able to return a Promise<Response>
@@ -782,6 +789,7 @@ test('createMiddleware with type request can return sync Response', () => {
       next: RequestServerNextFn<{}, undefined>
       pathname: string
       context: undefined
+      serverFnMeta?: ServerFnMeta
     }>()
 
     // Should be able to return a synchronous Response


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request middleware now captures and exposes server function metadata (id, name, filename) through loader data and route context
  * Full server function metadata is available server-side while client-side access is appropriately restricted for security and isolation
  * Developers can now track which server functions are being invoked and access their details throughout the application lifecycle

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->