### PR TITLE
Expose fullPath and to on RouteApi from getRouteApi

### DIFF
--- a/packages/react-router/tests/route.test.tsx
+++ b/packages/react-router/tests/route.test.tsx
@@ -62,6 +62,42 @@ describe('getRouteApi', () => {
     const api = getRouteApi('foo')
     expect(api.useNavigate).toBeDefined()
   })
+
+  it('should have the fullPath property', () => {
+    const api = getRouteApi('/posts')
+    expect(api.fullPath).toBe('/posts')
+  })
+
+  it('should have the to property', () => {
+    const api = getRouteApi('/posts')
+    expect(api.to).toBe('/posts')
+  })
+
+  it('fullPath should equal id for standard routes', () => {
+    const api = getRouteApi('/invoices/$invoiceId')
+    expect(api.fullPath).toBe('/invoices/$invoiceId')
+    expect(api.to).toBe('/invoices/$invoiceId')
+    expect(api.fullPath).toBe(api.id)
+  })
+
+  it('fullPath should differ from id for pathless layout routes', () => {
+    const rootRoute = createRootRoute()
+    const layoutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      id: '_layout',
+    })
+    const postsRoute = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: 'posts',
+    })
+    const routeTree = rootRoute.addChildren([layoutRoute.addChildren([postsRoute])])
+    createRouter({ routeTree, history })
+
+    const api = getRouteApi('/_layout/posts')
+    expect(api.id).toBe('/_layout/posts')
+    expect(api.fullPath).toBe('/posts')
+    expect(api.to).toBe('/posts')
+  })
 })
 
 describe('createRoute has the same hooks as getRouteApi', () => {

--- a/packages/react-router/tests/routeApi.test-d.tsx
+++ b/packages/react-router/tests/routeApi.test-d.tsx
@@ -29,8 +29,19 @@ const invoiceRoute = createRoute({
   loader: () => ({ data: 0 }),
 })
 
+const layoutRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: '_layout',
+})
+
+const postsRoute = createRoute({
+  getParentRoute: () => layoutRoute,
+  path: 'posts',
+})
+
 const routeTree = rootRoute.addChildren([
   invoicesRoute.addChildren([invoicesIndexRoute, invoiceRoute]),
+  layoutRoute.addChildren([postsRoute]),
   indexRoute,
 ])
 
@@ -93,6 +104,39 @@ describe('getRouteApi', () => {
     expectTypeOf(Link).toEqualTypeOf<
       LinkComponentRoute<'/invoices/$invoiceId'>
     >()
+  })
+  test('fullPath', () => {
+    expectTypeOf(invoiceRouteApi.fullPath).toEqualTypeOf<'/invoices/$invoiceId'>()
+  })
+  test('to', () => {
+    expectTypeOf(invoiceRouteApi.to).toEqualTypeOf<'/invoices/$invoiceId'>()
+  })
+  test('id', () => {
+    expectTypeOf(invoiceRouteApi.id).toEqualTypeOf<'/invoices/$invoiceId'>()
+  })
+})
+
+describe('getRouteApi with pathless layout route', () => {
+  const postsRouteApi = getRouteApi<'/_layout/posts', DefaultRouter>(
+    '/_layout/posts',
+  )
+
+  test('id includes the layout segment', () => {
+    expectTypeOf(postsRouteApi.id).toEqualTypeOf<'/_layout/posts'>()
+  })
+
+  test('fullPath excludes the pathless layout segment', () => {
+    expectTypeOf(postsRouteApi.fullPath).toEqualTypeOf<'/posts'>()
+  })
+
+  test('to excludes the pathless layout segment', () => {
+    expectTypeOf(postsRouteApi.to).toEqualTypeOf<'/posts'>()
+  })
+
+  test('fullPath is a valid RoutePaths type for Link from prop', () => {
+    // Verify fullPath is assignable to RoutePaths (valid for Link's from prop)
+    type RoutePaths = '/posts' | '/invoices' | '/invoices/$invoiceId' | '/'
+    expectTypeOf(postsRouteApi.fullPath).toMatchTypeOf<RoutePaths>()
   })
 })
 

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1912,6 +1912,28 @@ export class BaseRouteApi<TId, TRouter extends AnyRouter = RegisteredRouter> {
     this.id = id as any
   }
 
+  /**
+   * The full path of the route, which can be used as the `from` parameter
+   * in navigation APIs like `<Link from={routeApi.fullPath}>` or `navigate({ from: routeApi.fullPath })`.
+   */
+  get fullPath(): RouteTypesById<TRouter, TId>['fullPath'] {
+    if (typeof window !== 'undefined' && window.__TSR_ROUTER__) {
+      const route = window.__TSR_ROUTER__.routesById[this.id as string]
+      if (route) {
+        return route.fullPath as RouteTypesById<TRouter, TId>['fullPath']
+      }
+    }
+    return this.id as RouteTypesById<TRouter, TId>['fullPath']
+  }
+
+  /**
+   * The `to` path of the route, an alias for `fullPath` that can be used
+   * for navigation. This provides parity with the `Route.to` property.
+   */
+  get to(): RouteTypesById<TRouter, TId>['fullPath'] {
+    return this.fullPath
+  }
+
   notFound = (opts?: NotFoundError) => {
     return notFound({ routeId: this.id as string, ...opts })
   }

--- a/packages/solid-router/tests/route.test.tsx
+++ b/packages/solid-router/tests/route.test.tsx
@@ -61,6 +61,42 @@ describe('getRouteApi', () => {
     const api = getRouteApi('foo')
     expect(api.useNavigate).toBeDefined()
   })
+
+  it('should have the fullPath property', () => {
+    const api = getRouteApi('/posts')
+    expect(api.fullPath).toBe('/posts')
+  })
+
+  it('should have the to property', () => {
+    const api = getRouteApi('/posts')
+    expect(api.to).toBe('/posts')
+  })
+
+  it('fullPath should equal id for standard routes', () => {
+    const api = getRouteApi('/invoices/$invoiceId')
+    expect(api.fullPath).toBe('/invoices/$invoiceId')
+    expect(api.to).toBe('/invoices/$invoiceId')
+    expect(api.fullPath).toBe(api.id)
+  })
+
+  it('fullPath should differ from id for pathless layout routes', () => {
+    const rootRoute = createRootRoute()
+    const layoutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      id: '_layout',
+    })
+    const postsRoute = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: 'posts',
+    })
+    const routeTree = rootRoute.addChildren([layoutRoute.addChildren([postsRoute])])
+    createRouter({ routeTree, history })
+
+    const api = getRouteApi('/_layout/posts')
+    expect(api.id).toBe('/_layout/posts')
+    expect(api.fullPath).toBe('/posts')
+    expect(api.to).toBe('/posts')
+  })
 })
 
 describe('createRoute has the same hooks as getRouteApi', () => {

--- a/packages/solid-router/tests/routeApi.test-d.tsx
+++ b/packages/solid-router/tests/routeApi.test-d.tsx
@@ -30,8 +30,19 @@ const invoiceRoute = createRoute({
   loader: () => ({ data: 0 }),
 })
 
+const layoutRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: '_layout',
+})
+
+const postsRoute = createRoute({
+  getParentRoute: () => layoutRoute,
+  path: 'posts',
+})
+
 const routeTree = rootRoute.addChildren([
   invoicesRoute.addChildren([invoicesIndexRoute, invoiceRoute]),
+  layoutRoute.addChildren([postsRoute]),
   indexRoute,
 ])
 
@@ -104,6 +115,33 @@ describe('getRouteApi', () => {
     expectTypeOf(Link).toEqualTypeOf<
       LinkComponentRoute<'/invoices/$invoiceId'>
     >()
+  })
+  test('fullPath', () => {
+    expectTypeOf(invoiceRouteApi.fullPath).toEqualTypeOf<'/invoices/$invoiceId'>()
+  })
+  test('to', () => {
+    expectTypeOf(invoiceRouteApi.to).toEqualTypeOf<'/invoices/$invoiceId'>()
+  })
+  test('id', () => {
+    expectTypeOf(invoiceRouteApi.id).toEqualTypeOf<'/invoices/$invoiceId'>()
+  })
+})
+
+describe('getRouteApi with pathless layout route', () => {
+  const postsRouteApi = getRouteApi<'/_layout/posts', DefaultRouter>(
+    '/_layout/posts',
+  )
+
+  test('id includes the layout segment', () => {
+    expectTypeOf(postsRouteApi.id).toEqualTypeOf<'/_layout/posts'>()
+  })
+
+  test('fullPath excludes the pathless layout segment', () => {
+    expectTypeOf(postsRouteApi.fullPath).toEqualTypeOf<'/posts'>()
+  })
+
+  test('to excludes the pathless layout segment', () => {
+    expectTypeOf(postsRouteApi.to).toEqualTypeOf<'/posts'>()
   })
 })
 

--- a/packages/vue-router/tests/route.test.tsx
+++ b/packages/vue-router/tests/route.test.tsx
@@ -61,6 +61,42 @@ describe('getRouteApi', () => {
     const api = getRouteApi('foo')
     expect(api.useNavigate).toBeDefined()
   })
+
+  it('should have the fullPath property', () => {
+    const api = getRouteApi('/posts')
+    expect(api.fullPath).toBe('/posts')
+  })
+
+  it('should have the to property', () => {
+    const api = getRouteApi('/posts')
+    expect(api.to).toBe('/posts')
+  })
+
+  it('fullPath should equal id for standard routes', () => {
+    const api = getRouteApi('/invoices/$invoiceId')
+    expect(api.fullPath).toBe('/invoices/$invoiceId')
+    expect(api.to).toBe('/invoices/$invoiceId')
+    expect(api.fullPath).toBe(api.id)
+  })
+
+  it('fullPath should differ from id for pathless layout routes', () => {
+    const rootRoute = createRootRoute()
+    const layoutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      id: '_layout',
+    })
+    const postsRoute = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: 'posts',
+    })
+    const routeTree = rootRoute.addChildren([layoutRoute.addChildren([postsRoute])])
+    createRouter({ routeTree, history })
+
+    const api = getRouteApi('/_layout/posts')
+    expect(api.id).toBe('/_layout/posts')
+    expect(api.fullPath).toBe('/posts')
+    expect(api.to).toBe('/posts')
+  })
 })
 
 describe('createRoute has the same hooks as getRouteApi', () => {

--- a/packages/vue-router/tests/routeApi.test-d.tsx
+++ b/packages/vue-router/tests/routeApi.test-d.tsx
@@ -29,8 +29,19 @@ const invoiceRoute = createRoute({
   loader: () => ({ data: 0 }),
 })
 
+const layoutRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: '_layout',
+})
+
+const postsRoute = createRoute({
+  getParentRoute: () => layoutRoute,
+  path: 'posts',
+})
+
 const routeTree = rootRoute.addChildren([
   invoicesRoute.addChildren([invoicesIndexRoute, invoiceRoute]),
+  layoutRoute.addChildren([postsRoute]),
   indexRoute,
 ])
 
@@ -95,6 +106,33 @@ describe('getRouteApi', () => {
     expectTypeOf(invoiceRouteApi.useMatch<DefaultRouter>()).toEqualTypeOf<
       Vue.Ref<MakeRouteMatch<typeof routeTree, '/invoices/$invoiceId'>>
     >()
+  })
+  test('fullPath', () => {
+    expectTypeOf(invoiceRouteApi.fullPath).toEqualTypeOf<'/invoices/$invoiceId'>()
+  })
+  test('to', () => {
+    expectTypeOf(invoiceRouteApi.to).toEqualTypeOf<'/invoices/$invoiceId'>()
+  })
+  test('id', () => {
+    expectTypeOf(invoiceRouteApi.id).toEqualTypeOf<'/invoices/$invoiceId'>()
+  })
+})
+
+describe('getRouteApi with pathless layout route', () => {
+  const postsRouteApi = getRouteApi<'/_layout/posts', DefaultRouter>(
+    '/_layout/posts',
+  )
+
+  test('id includes the layout segment', () => {
+    expectTypeOf(postsRouteApi.id).toEqualTypeOf<'/_layout/posts'>()
+  })
+
+  test('fullPath excludes the pathless layout segment', () => {
+    expectTypeOf(postsRouteApi.fullPath).toEqualTypeOf<'/posts'>()
+  })
+
+  test('to excludes the pathless layout segment', () => {
+    expectTypeOf(postsRouteApi.to).toEqualTypeOf<'/posts'>()
   })
 })
 


### PR DESCRIPTION
## Summary
- Adds `fullPath` and `to` getters to `RouteApi` (returned by `getRouteApi`)
- Provides parity with `Route` objects which already expose `fullPath` and `to`
- Enables type-safe navigation: `<Link from={routeApi.fullPath} to="./relative">`
- Uses the global router reference to resolve the correct `fullPath` at runtime
- Correctly handles pathless/layout routes where `id` differs from `fullPath`

## Test plan
- [x] Runtime tests for standard routes (`id === fullPath`)
- [x] Runtime tests for pathless layout routes (`id = '/_layout/posts'`, `fullPath = '/posts'`)
- [x] Type tests verifying correct typing for both cases
- [x] Tests added for react/vue/solid-router