### PR TITLE
Handle css quotes when collecting dev styles

### DIFF
--- a/e2e/react-start/css-modules/src/styles/global.css
+++ b/e2e/react-start/css-modules/src/styles/global.css
@@ -1,5 +1,10 @@
 /* Global styles for testing CSS collection in dev mode */
 
+.global-container:before {
+  content: ' ';
+  content: " ";
+}
+
 .global-container {
   background-color: #3b82f6; /* blue-500 */
   padding: 24px;

--- a/e2e/solid-start/css-modules/src/styles/global.css
+++ b/e2e/solid-start/css-modules/src/styles/global.css
@@ -1,5 +1,10 @@
 /* Global styles for testing CSS collection in dev mode */
 
+.global-container:before {
+  content: ' ';
+  content: " ";
+}
+
 .global-container {
   background-color: #3b82f6; /* blue-500 */
   padding: 24px;

--- a/e2e/vue-start/css-modules/src/styles/global.css
+++ b/e2e/vue-start/css-modules/src/styles/global.css
@@ -1,5 +1,10 @@
 /* Global styles for testing CSS collection in dev mode */
 
+.global-container:before {
+  content: ' ';
+  content: " ";
+}
+
 .global-container {
   background-color: #3b82f6; /* blue-500 */
   padding: 24px;

--- a/packages/start-plugin-core/src/dev-server-plugin/dev-styles.ts
+++ b/packages/start-plugin-core/src/dev-server-plugin/dev-styles.ts
@@ -20,7 +20,8 @@ export function normalizeCssModuleCacheKey(idOrFile: string): string {
 // URL params that indicate CSS should not be injected (e.g., ?url, ?inline)
 const CSS_SIDE_EFFECT_FREE_PARAMS = ['url', 'inline', 'raw', 'inline-css']
 
-const VITE_CSS_REGEX = /const\s+__vite__css\s*=\s*["'`]([\s\S]*?)["'`]/
+const VITE_CSS_REGEX =
+  /const\s+__vite__css\s*=\s*(["'`])((?:\\[\s\S]|(?!\1)[\s\S])*)\1/
 
 const ESCAPE_CSS_COMMENT_START_REGEX = /\/\*/g
 const ESCAPE_CSS_COMMENT_END_REGEX = /\*\//g
@@ -250,9 +251,9 @@ async function fetchCssFromModule(
 
 function extractCssFromCode(code: string): string | undefined {
   const match = VITE_CSS_REGEX.exec(code)
-  if (!match?.[1]) return undefined
+  if (!match?.[2]) return undefined
 
-  return match[1]
+  return match[2]
     .replace(/\\n/g, '\n')
     .replace(/\\t/g, '\t')
     .replace(/\\"/g, '"')


### PR DESCRIPTION
CSS with quotes like this:
```css
.something {
    content: ' ';
}
```
was breaking the CSS detection when collecting styles in dev, causing it to cut off at that point.

This updates the regex to fix that, and handle quotes when they are escaped. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS processing and handling across React, Solid, and Vue framework starters.
  * Enhanced CSS extraction and parsing in the development server to ensure proper style handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->