### PR TITLE
Update static export support details in documentation

### DIFF
--- a/docs/start/framework/react/comparison.md
+++ b/docs/start/framework/react/comparison.md
@@ -66,7 +66,7 @@ Feature/Capability Key:
 | Serverless Support                                                | ✅                                               | ✅                                            | ✅                                         |
 | Node.js Support                                                   | ✅                                               | ✅                                            | ✅                                         |
 | Docker Support                                                    | ✅                                               | ✅                                            | ✅                                         |
-| Static Export                                                     | ✅                                               | 🟡 (App Router does not support useParams() on client)  | ✅                                         |
+| Static Export                                                     | ✅                                               | 🟡 (App Router doesn't support useParams())   | ✅                                         |
 | Official Cloudflare Support                                       | ✅                                               | 🟡                                            | ✅                                         |
 | Official Netlify Support                                          | ✅                                               | 🟡                                            | ✅                                         |
 | Official Vercel Support                                           | ✅ (via Nitro)                                   | ✅                                            | ✅                                         |


### PR DESCRIPTION
Clarify the limitations of static export support in the comparison documentation, specifically noting that the App Router does not support useParams() on the client.

https://github.com/vercel/next.js/discussions/64660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified framework comparison: static export support for Next.js now marked as partial, with a note about App Router limitations for client-side parameter access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->