### PR TITLE
fix(router-core): replaceEqualDeep max depth

### DIFF
--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -219,10 +219,12 @@ const hasOwn = Object.prototype.hasOwnProperty
  * This can be used for structural sharing between immutable JSON values for example.
  * Do not use this with signals
  */
-export function replaceEqualDeep<T>(prev: any, _next: T): T {
+export function replaceEqualDeep<T>(prev: any, _next: T, _depth = 0): T {
   if (prev === _next) {
     return prev
   }
+
+  if (_depth > 500) return _next
 
   const next = _next as any
 
@@ -261,7 +263,7 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
       continue
     }
 
-    const v = replaceEqualDeep(p, n)
+    const v = replaceEqualDeep(p, n, _depth + 1)
     copy[key] = v
     if (v === p) equalItems++
   }


### PR DESCRIPTION
Add max depth for recursive `replaceEqualDeep` to avoid *insanely deep* objects (500 nested levels) slowing/freezing the main thread. Beyond 500, we just return the new object.

The function is still callable w/ the same parameters as before. It should have now impact on users, except for those that have *insanely deep* objects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability by adding safeguards to prevent performance degradation when processing deeply nested data structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->