### PR TITLE
docs: fix CLI command syntax in Solid Start getting started guide

### DIFF
--- a/docs/start/framework/solid/getting-started.md
+++ b/docs/start/framework/solid/getting-started.md
@@ -7,7 +7,7 @@ title: Getting Started
 
 Choose one of the following options to start building a _new_ TanStack Start project:
 
-- [TanStack Start CLI] - Just run `npm create @tanstack/start@latest -- --framework solid`. Local, fast, and optionally customizable
+- [TanStack Start CLI] - Just run `npm create @tanstack/start@latest --framework solid`. Local, fast, and optionally customizable
 - [TanStack Builder](#) (coming soon!) - A visual interface to configure new TanStack projects with a few clicks
 - [Quick Start Examples](./quick-start) Download or clone one of our official examples
 - [Build a project from scratch](./build-from-scratch) - A guide to building a TanStack Start project line-by-line, file-by-file.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Corrected the TanStack Start CLI command example in the Solid framework Getting Started documentation. The command syntax has been updated to ensure users have the accurate installation instructions for creating new projects with the Solid framework, following current best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->