### PR TITLE
fix: useBlocker does not work with memoryHistory

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -593,6 +593,11 @@ export function createMemoryHistory(
 
   const getLocation = () => parseHref(entries[index]!, states[index])
 
+  let blockers: Array<NavigationBlocker> = []
+  const _getBlockers = () => blockers
+  const _setBlockers = (newBlockers: Array<NavigationBlocker>) =>
+    (blockers = newBlockers)
+
   return createHistory({
     getLocation,
     getLength: () => entries.length,
@@ -620,6 +625,8 @@ export function createMemoryHistory(
       index = Math.min(Math.max(index + n, 0), entries.length - 1)
     },
     createHref: (path) => path,
+    getBlockers: _getBlockers,
+    setBlockers: _setBlockers,
   })
 }
 


### PR DESCRIPTION
Used Opus to generate a fix for this. Seems reasonable

Fixes https://github.com/TanStack/router/issues/6393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation blocking support added to memory history, enabling control over navigation with new management capabilities.

* **Tests**
  * Added tests validating navigation blocking behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->