### PR TITLE
docs: Update useLoaderData signature in fetching-external-api tutorial

### DIFF
--- a/docs/start/framework/react/tutorial/fetching-external-api.md
+++ b/docs/start/framework/react/tutorial/fetching-external-api.md
@@ -218,10 +218,7 @@ Finally, let's create the main component that consumes the loader data:
 ```tsx
 // MoviesPage component
 const MoviesPage = () => {
-  const { movies, error } = Route.useLoaderData()<{
-    movies: Movie[]
-    error: string | null
-  }>()
+  const { movies, error } = Route.useLoaderData()
 
   return (
     <div


### PR DESCRIPTION
Going through the tutorial, it seems the return type of this Route.useLoaderData is automatically inferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated tutorial documentation for fetching external data to showcase streamlined API usage. The example now demonstrates automatic type inference capabilities, eliminating the need for explicit type annotations when retrieving data from loaders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->