### PR TITLE
feat: static replacement of process.env.NODE_ENV during build

### DIFF
--- a/docs/start/framework/react/guide/environment-variables.md
+++ b/docs/start/framework/react/guide/environment-variables.md
@@ -465,6 +465,79 @@ interface ImportMetaEnv {
 2. Validate required variables at build time
 3. Use deployment-specific `.env` files
 
+## Server Build Configuration
+
+### Static `NODE_ENV` Replacement
+
+By default, TanStack Start statically replaces `process.env.NODE_ENV` in **server builds** at build time. This enables dead code elimination (tree-shaking) for development-only code paths in your server bundle.
+
+**Why this matters:** Vite automatically replaces `process.env.NODE_ENV` in client builds, but server builds run in Node.js where `process.env` is a real runtime object. Without static replacement, code like this would remain in your production server bundle:
+
+```typescript
+if (process.env.NODE_ENV === 'development') {
+  // This code would NOT be eliminated without static replacement
+  enableDevTools()
+  logDebugInfo()
+}
+```
+
+With static replacement enabled (the default), the bundler sees `"production" === 'development'` and eliminates the entire block.
+
+### Configuring Static Replacement
+
+The replacement is controlled by the `server.build.staticNodeEnv` option:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import viteReact from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [
+    tanstackStart({
+      server: {
+        build: {
+          // Replace process.env.NODE_ENV at build time (default: true)
+          staticNodeEnv: true,
+        },
+      },
+    }),
+    viteReact(),
+  ],
+})
+```
+
+The replacement value is determined in this order:
+
+1. `process.env.NODE_ENV` at build time (if set)
+2. Vite's `mode` (e.g., from `--mode staging`)
+3. `"production"` (fallback)
+
+### When to Disable Static Replacement
+
+Set `staticNodeEnv: false` if you need `NODE_ENV` to remain dynamic at runtime:
+
+```ts
+tanstackStart({
+  server: {
+    build: {
+      staticNodeEnv: false, // Keep NODE_ENV dynamic at runtime
+    },
+  },
+})
+```
+
+Common reasons to disable:
+
+- **Same build, multiple environments**: Deploying one build artifact to staging and production
+- **Runtime environment detection**: Code that must check the actual runtime environment
+- **Testing production builds locally**: Running production builds with `NODE_ENV=development`
+
+> **Note:** Disabling static replacement means development-only code paths will remain in your production bundle and be evaluated at runtime.
+
+> **Important:** If you disable `staticNodeEnv`, you **must** set `NODE_ENV=production` at runtime when running your server in production. Without this, React (and possibly other libraries) will run in development mode, which is significantly slower and includes extra warnings and checks not intended for production use.
+
 ## Related Resources
 
 - [Code Execution Patterns](./code-execution-patterns.md) - Learn about server vs client code execution

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -301,6 +301,10 @@ export function TanStackStartVitePluginCore(
             ...defineReplaceEnv('TSS_ROUTER_BASEPATH', startConfig.router.basepath),
             ...(command === 'serve' ? defineReplaceEnv('TSS_SHELL', startConfig.spa?.enabled ? 'true' : 'false') : {}),
             ...defineReplaceEnv('TSS_DEV_SERVER', command === 'serve' ? 'true' : 'false'),
+            // Replace NODE_ENV during build (unless opted out) for dead code elimination in server bundles
+            ...(command === 'build' && startConfig.server.build.staticNodeEnv ? {
+              'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || viteConfig.mode || 'production'),
+            } : {}),
           },
           builder: {
             sharedPlugins: true,

--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -153,6 +153,12 @@ const tanstackStartOptionsSchema = z
     server: z
       .object({
         entry: z.string().optional(),
+        build: z
+          .object({
+            staticNodeEnv: z.boolean().optional().default(true),
+          })
+          .optional()
+          .default({}),
       })
       .optional()
       .default({}),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Server Build Configuration section to React and Solid framework environment variables guides, explaining static NODE_ENV replacement behavior and configuration.

* **New Features**
  * Introduced `server.build.staticNodeEnv` configuration option (enabled by default) to control static NODE_ENV replacement during server builds, with ability to disable when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->