### PR TITLE
fix(router-core): correct splat param extraction after a skipped optional param

### DIFF
--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -899,6 +899,7 @@ function extractParams<T extends RouteLike>(
     } else if (node.kind === SEGMENT_TYPE_OPTIONAL_PARAM) {
       if (leaf.skipped & (1 << nodeIndex)) {
         partIndex-- // stay on the same part
+        pathIndex = currentPathIndex - 1 // undo pathIndex advancement; -1 to account for loop increment
         continue
       }
       nodeParts ??= leaf.node.fullPath.split('/')

--- a/packages/router-core/tests/new-process-route-tree.test.ts
+++ b/packages/router-core/tests/new-process-route-tree.test.ts
@@ -864,6 +864,28 @@ describe('findRouteMatch', () => {
         expect(result?.route.id).toBe('/_pathless/{-$language}/')
         expect(result?.rawParams).toEqual({ language: 'sv' })
       })
+      it('skipped optional, ends with wildcard', () => {
+        const tree = {
+          id: '__root__',
+          fullPath: '/',
+          path: '/',
+          isRoot: true,
+          options: {},
+          children: [
+            {
+              id: '/{-$foo}/bar/$',
+              fullPath: '/{-$foo}/bar/$',
+              path: '{-$foo}/bar/$',
+              isRoot: false,
+              options: {},
+            },
+          ],
+        }
+        const { processedTree } = processRouteTree(tree)
+        const result = findRouteMatch(`/bar/rest`, processedTree)
+        expect(result?.route.id).toBe('/{-$foo}/bar/$')
+        expect(result?.rawParams).toEqual({ '*': 'rest', _splat: 'rest' })
+      })
     })
   })
   describe('pathless routes', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route parameter extraction to properly align path segments when optional parameters are skipped during route matching.

* **Tests**
  * Added test coverage for route matching scenarios with optional parameters followed by wildcard segments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->