### PR TITLE
fix(router-core): skipOnParamError on index route should still allow mathing other node types beyond it on error

### DIFF
--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -1067,18 +1067,21 @@ function getNodeMatch<T extends RouteLike>(
         rawParams,
         parsedParams,
       }
+      let indexValid = true
       if (node.index.skipOnParamError) {
         const result = validateMatchParams(path, parts, indexFrame)
-        if (!result) continue
+        if (!result) indexValid = false
       }
-      // perfect match, no need to continue
-      // this is an optimization, algorithm should work correctly without this block
-      if (statics === partsLength && !dynamics && !optionals && !skipped) {
-        return indexFrame
-      }
-      if (isFrameMoreSpecific(bestMatch, indexFrame)) {
-        // index matches skip the stack because they cannot have children
-        bestMatch = indexFrame
+      if (indexValid) {
+        // perfect match, no need to continue
+        // this is an optimization, algorithm should work correctly without this block
+        if (statics === partsLength && !dynamics && !optionals && !skipped) {
+          return indexFrame
+        }
+        if (isFrameMoreSpecific(bestMatch, indexFrame)) {
+          // index matches skip the stack because they cannot have children
+          bestMatch = indexFrame
+        }
       }
     }
 

--- a/packages/router-core/tests/skip-route-on-parse-error.test.ts
+++ b/packages/router-core/tests/skip-route-on-parse-error.test.ts
@@ -636,6 +636,39 @@ describe('skipRouteOnParseError', () => {
       expect(otherResult?.route.id).toBe('/files')
       expect(otherResult?.rawParams['**']).toBe('../../secret/photo.jpg')
     })
+    it('index parse failure does not block wildcard sibling', () => {
+      const tree = {
+        id: '__root__',
+        isRoot: true,
+        fullPath: '/',
+        path: '/',
+        children: [
+          {
+            id: '/a/',
+            fullPath: '/a/',
+            path: 'a/',
+            options: {
+              params: {
+                parse: () => {
+                  throw new Error('Invalid index')
+                },
+              },
+              skipRouteOnParseError: { params: true },
+            },
+          },
+          {
+            id: '/a/$',
+            fullPath: '/a/$',
+            path: 'a/$',
+            options: {},
+          },
+        ],
+      }
+      const { processedTree } = processRouteTree(tree)
+      const result = findRouteMatch('/a', processedTree)
+      expect(result?.route.id).toBe('/a/$')
+      expect(result?.rawParams).toEqual({ '*': '', _splat: '' })
+    })
   })
 
   describe('multiple validated routes competing', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route matching to prevent parameter parse errors from blocking wildcard sibling routes when error skipping is enabled. Index frame processing now properly handles validation failures, ensuring more reliable fallback routing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->