### PR TITLE
fix(router-core): extract params from URL for snapshot when using string navigation

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1856,10 +1856,13 @@ export class RouterCore<
       nextState = replaceEqualDeep(currentLocation.state, nextState)
 
       // Build match snapshot for fast-path on back/forward navigation
-      // Use destRoutes and nextParams directly (after stringify)
+      // Extract params from the interpolated path to ensure correct params
+      // even when navigating with string URLs (where dest.params is undefined)
+      const { routeParams: extractedParams } =
+        this.getMatchedRoutes(nextPathname)
       const matchSnapshot = buildMatchSnapshotFromRoutes({
         routes: destRoutes,
-        params: nextParams,
+        params: extractedParams,
         searchStr,
         globalNotFoundRouteId: globalNotFoundMatch?.routeId,
       })


### PR DESCRIPTION
## Summary

When navigating with a string URL (e.g., `navigate({ to: '/users/abc123' })`), the match snapshot was incorrectly using params from the **current location** instead of extracting params from the **destination URL**.

This caused `Route.useParams()` to return `undefined` for dynamic params when the source route didn't have those params in its path.

## The Bug

In `buildLocation()`, when `dest.params` is not provided:
- `nextParams` was set to `fromParams` (params from current location)
- The snapshot was built with these incorrect params
- `matchRoutesInternal()` used the snapshot via fast-path
- Matches had wrong params, causing `useParams()` to fail

**Example scenario:**
- Navigate from `/users/123/settings` to `/users/123/posts/abc`
- Using `navigate({ to: '/users/123/posts/abc' })` (string URL)
- `Route.useParams()` returned `{ userId: '123' }` but `postId` was `undefined`
- This happened because `/settings` route didn't have `postId` in its params

## The Fix

Extract params from the final interpolated pathname using `getMatchedRoutes()` before building the snapshot:

```typescript
// Before: used nextParams which could be wrong for string URLs
params: nextParams,

// After: extract params from the actual destination URL
const { routeParams: extractedParams } = this.getMatchedRoutes(nextPathname)
params: extractedParams,
```

## Why This Only Affected Production

The snapshot fast-path (line 1290-1295 in `matchRoutesInternal`) is only used when the snapshot's session ID matches the current router session. In development with hot reloading, session IDs often don't match, causing the fallback path (which correctly extracts params from the URL) to be used instead.

## Test Plan

- [x] Existing `load.test.ts` tests pass (26 tests)
- [x] Existing `callbacks.test.ts` tests pass (3 tests)
- [x] Existing `match-by-path.test.ts` tests pass (91 tests)
- [x] Existing `path.test.ts` tests pass (205 tests)

## Considerations

A few things we thought about but believe are acceptable trade-offs:

1. **Extra `getMatchedRoutes` call**: This adds one additional route matching operation per navigation. Route matching is a fast trie lookup, and this is called once per navigation (not in a hot loop), so the performance impact should be negligible. Happy to explore reusing the existing `destMatches` result if you'd prefer to avoid this.

2. **`parsedParams` typing**: When using typed params with non-string values (e.g., `params: { id: 123 }`), the snapshot's `parsedParams` will now contain strings extracted from the URL rather than the original types. However, params are re-parsed later in the match creation flow using the route's `parseParams` function, so this shouldn't cause issues in practice.

3. **`opts.leaveParams` edge case**: If `leaveParams` is true, the pathname retains `$param` placeholders and params won't be extracted. This is an existing edge case for template path preservation that this fix doesn't make worse.

Open to feedback on any of these points!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where route parameters were not correctly preserved during back/forward browser navigation when using string-based URLs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->