### PR TITLE
fix(router-core): skip URL parsing for safe 'to' props

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -156,6 +156,11 @@ export function useLinkProps<
       }
       return hrefOption.href
     }
+    const isSafeInternal =
+      typeof to === 'string' &&
+      to.charCodeAt(0) === 47 && // '/'
+      to.charCodeAt(1) !== 47 // but not '//'
+    if (isSafeInternal) return undefined
     try {
       new URL(to as any)
       // Block dangerous protocols like javascript:, data:, vbscript:


### PR DESCRIPTION
If a `to` prop starts with `/` but not `//` it can be safely considered a relative path to be handled by the router and we don't need to go through the full `new URL` parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of internal route navigation by optimizing link validation logic, enhancing performance for internal routes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->