### PR TITLE
docs(router): URL encoding note on <Link/> and how to opt out

### DIFF
--- a/docs/router/framework/react/api/router/linkComponent.md
+++ b/docs/router/framework/react/api/router/linkComponent.md
@@ -39,11 +39,11 @@ function Component() {
 By default, param values with characters such as `@` will be encoded in the URL:
 
 ```tsx
-// url path will be `/%40foo` 
-<Link to="/$username" params={{ username: "@foo" }} />
+// url path will be `/%40foo`
+<Link to="/$username" params={{ username: '@foo' }} />
 ```
 
-To opt-out, update the [pathParamsAllowedCharacters](../router/RouterOptionsType#pathparamsallowedcharacters-property)  config on the router
+To opt-out, update the [pathParamsAllowedCharacters](../router/RouterOptionsType#pathparamsallowedcharacters-property) config on the router
 
 ```tsx
 import { createRouter } from '@tanstack/react-router'


### PR DESCRIPTION
Took me weeks to find out about the config option `pathParamsAllowedCharacters`, otherwise I was trying some hack to stop the encoding in the URL path params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that special characters in URL parameters are URL-encoded by default (e.g., "@" → "%40").
  * Added examples demonstrating how encoded paths appear at runtime.
  * Documented how to opt out or customize parameter encoding via router configuration, including a usage example for the configuration option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->