### PR TITLE
fix(router-core): only rerender Link on search change if search prop is a function

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -93,8 +93,7 @@ export function useLinkProps<
 
   // subscribe to search params to re-build location if it changes
   const currentSearch = useRouterState({
-    select: (s) =>
-      options.search ? s.location.search : null,
+    select: (s) => (options.search ? s.location.search : null),
     structuralSharing: true as any,
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Link component's search parameter tracking so changes are only tracked when configured, improving update behavior for static vs. dynamic search options.
  * Reduces unnecessary updates and ensures navigation reflects the intended search behavior, leading to more predictable link updates and fewer unexpected re-renders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->