### PR TITLE
refactor(react-router): Link component self time improvements by removing 'delete'

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -593,11 +593,7 @@ export function createLink<const TComp>(
 export const Link: LinkComponent<'a'> = React.forwardRef<Element, any>(
   (props, ref) => {
     const { _asChild, ...rest } = props
-    const {
-      type: _type,
-      ref: innerRef,
-      ...linkProps
-    } = useLinkProps(rest as any, ref)
+    const { type: _type, ...linkProps } = useLinkProps(rest as any, ref)
 
     const children =
       typeof rest.children === 'function'
@@ -606,20 +602,13 @@ export const Link: LinkComponent<'a'> = React.forwardRef<Element, any>(
           })
         : rest.children
 
-    if (_asChild === undefined) {
+    if (!_asChild) {
       // the ReturnType of useLinkProps returns the correct type for a <a> element, not a general component that has a disabled prop
       // @ts-expect-error
-      delete linkProps.disabled
+      const { disabled: _, ...rest } = linkProps
+      return React.createElement('a', rest, children)
     }
-
-    return React.createElement(
-      _asChild ? _asChild : 'a',
-      {
-        ...linkProps,
-        ref: innerRef,
-      },
-      children,
-    )
+    return React.createElement(_asChild, linkProps, children)
   },
 ) as any
 


### PR DESCRIPTION
On a benchmark w/ 100 concurrent requests for 30s, loading pages w/ 100 links in them, we can observe the `<Link>` component with a *self time* of > 3s. Simply removing the `delete` keyword, we can get this down to < 1s.

| Before | After |
|--------|--------|
|  <img width="500" height="277" alt="Screenshot 2026-01-22 at 21 03 18" src="https://github.com/user-attachments/assets/58153eb5-8d09-4cd5-91bb-74eeb14d5056" /> | <img width="530" height="315" alt="Screenshot 2026-01-22 at 21 03 36" src="https://github.com/user-attachments/assets/87655cea-5ff3-4f55-b46e-ab046de4bd67" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Link component's internal implementation for better type handling and prop management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->