### PR TITLE
refactor(router-core): search middleware performance

### DIFF
--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -188,7 +188,7 @@ export type LooseAsyncReturnType<T> = T extends (
  * Return the last element of an array.
  * Intended for non-empty arrays used within router internals.
  */
-export function last<T>(arr: Array<T>) {
+export function last<T>(arr: ReadonlyArray<T>) {
   return arr[arr.length - 1]
 }
 


### PR DESCRIPTION
On a benchmark w/ 100 concurrent requests for 30s, loading pages w/ 100 links in them, we can observe the `applySearchMiddleware` function with a *total time* of > 2s. By refactoring how the middleware chain is built, we can get this down to < 100ms.

| Before | After |
|--------|--------|
| <img width="469" height="318" alt="Screenshot 2026-01-23 at 11 10 27" src="https://github.com/user-attachments/assets/c8b70273-8fd5-4119-9d80-810da4ddf936" /> | <img width="504" height="310" alt="Screenshot 2026-01-23 at 11 10 49" src="https://github.com/user-attachments/assets/5384b058-86a3-49e0-bec9-4bcff74e044b" /> | 

As a bonus, the new implementation makes the middleware chain *cacheable*. So once we persist router caches across requests on the server, we can also save time on building the chain and only pay the execution cost.