### PR TITLE
refactor(router-core): buildLocation performance by simplifying 'from' location parsing

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1570,7 +1570,7 @@ export class RouterCore<
     //   destRoutes: matchedRoutes,
     //   _includeValidateSearch: true,
     // })
-    
+
     // Accumulate search validation through route chain
     const accumulatedSearch = { ...location.search }
     for (const route of matchedRoutes) {
@@ -1599,7 +1599,12 @@ export class RouterCore<
       const strictParams: Record<string, unknown> = { ...routeParams }
       for (const route of matchedRoutes) {
         try {
-          extractStrictParams(route, routeParams, parsedParams ?? {}, strictParams)
+          extractStrictParams(
+            route,
+            routeParams,
+            parsedParams ?? {},
+            strictParams,
+          )
         } catch {
           // Ignore errors, we're not actually routing
         }


### PR DESCRIPTION
The `buildLocation` function needs some information about the `from` location.

Before this PR, to get this information we would build a full match branch through `matchRoutes`, but with a `_buildLocation: true` argument that skipped *some* things.

This PR proposes that we implement a fully separate function that can skip much more work. We also allow for the case where `from` is the current location to short-circuit search validation and params validation.


Before
<img width="791" height="345" alt="Screenshot 2026-01-23 at 14 40 34" src="https://github.com/user-attachments/assets/af8ab388-4f3a-4aa0-a2f9-365b0cb0f35b" />


After
<img width="791" height="345" alt="Screenshot 2026-01-23 at 15 04 23" src="https://github.com/user-attachments/assets/ec171c71-3080-449f-813b-0b40584b32e8" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the optional build-location flag from route-matching configuration (public interface change).

* **Performance Improvements**
  * Added a lightweight route-matching path to speed up path computation and validation.

* **Bug Fixes**
  * Consolidated parameter parsing and unified error propagation for more consistent handling during route resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->