### PR TITLE
refactor(router-core): improve interpolatePath performance by pre-compiling a single regex decoder

### DIFF
--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  compileDecodeCharMap,
   exactPathTest,
   interpolatePath,
   removeTrailingSlash,
@@ -309,9 +310,7 @@ describe('interpolatePath', () => {
         path: '/users/$id',
         params: { id: '?#@john+smith' },
         result: '/users/%3F%23@john+smith',
-        decodeCharMap: new Map(
-          ['@', '+'].map((char) => [encodeURIComponent(char), char]),
-        ),
+        decoder: compileDecodeCharMap(['@', '+']),
       },
       {
         name: 'should interpolate the path with the splat param at the end',
@@ -348,12 +347,12 @@ describe('interpolatePath', () => {
         params: { _splat: 'sean/cassiere' },
         result: '/users/sean/cassiere',
       },
-    ])('$name', ({ path, params, decodeCharMap, result }) => {
+    ])('$name', ({ path, params, decoder, result }) => {
       expect(
         interpolatePath({
           path,
           params,
-          decodeCharMap,
+          decoder,
         }).interpolatedPath,
       ).toBe(result)
     })

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -178,7 +178,7 @@ function RouteComp({
     const interpolated = interpolatePath({
       path: route.fullPath,
       params: allParams,
-      decodeCharMap: router().pathParamsDecodeCharMap,
+      decoder: router().pathParamsDecoder,
     })
 
     // only if `interpolated` is not missing params, return the path since this


### PR DESCRIPTION
`interpolatePath` is in the hot path for most things (Link, navigation, preload, ...)

This PR adds a total of 8 lines of code (excluding comments) but significantly improves performance (by 0 to 70%) depending on the input string.

bench

```
@tanstack/router-core  new (decodeConfig) - interpolatePath: simple path
  1.77x faster than old (decodeCharMap)

@tanstack/router-core  new (decodeConfig) - interpolatePath: params with special characters
  1.53x faster than old (decodeCharMap)

@tanstack/router-core  new (decodeConfig) - interpolatePath: multiple params
  1.66x faster than old (decodeCharMap)

@tanstack/router-core  new (decodeConfig) - interpolatePath: complex params with many special chars
  1.61x faster than old (decodeCharMap)

@tanstack/router-core  old (decodeCharMap) - interpolatePath: curly brace params
  1.03x faster than new (decodeConfig)

@tanstack/router-core  old (decodeCharMap) - interpolatePath: optional params
  1.01x faster than new (decodeConfig)

@tanstack/router-core  old (decodeCharMap) - interpolatePath: splat/wildcard
  1.01x faster than new (decodeConfig)

@tanstack/router-core  new (decodeConfig) - interpolatePath: mixed complex path
  1.27x faster than old (decodeCharMap)

@tanstack/router-core  new (decodeConfig) - interpolatePath: aggregate all cases
  1.39x faster than old (decodeCharMap)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved path parameter handling with a more efficient internal mechanism, enhancing router performance and code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->