### PR TITLE
fix(start): handle Cloudflare SPA fallback hydration mismatch

### DIFF
--- a/packages/start-client-core/src/client/hydrateStart.ts
+++ b/packages/start-client-core/src/client/hydrateStart.ts
@@ -1,4 +1,7 @@
 import { hydrate } from '@tanstack/router-core/ssr/client'
+import {
+  trimPathRight,
+} from '@tanstack/router-core'
 
 import { ServerFunctionSerializationAdapter } from './ServerFunctionSerializationAdapter'
 import type { AnyStartInstanceOptions } from '../createStart'
@@ -44,7 +47,8 @@ export async function hydrateStart(): Promise<AnyRouter> {
   if (!router.state.matches.length) {
     if (
       window.__TSS_SPA_SHELL__ &&
-      window.location.pathname !== (router.options.basepath || '/')
+      trimPathRight(window.location.pathname) !==
+        trimPathRight(router.options.basepath || '/')
     ) {
       // If we are loading the SPA shell (index.html) and the path is not the root,
       // it means we are in a fallback scenario (e.g. Cloudflare SPA fallback).

--- a/packages/start-client-core/tests/hydrateStart.test.ts
+++ b/packages/start-client-core/tests/hydrateStart.test.ts
@@ -98,16 +98,16 @@ describe('hydrateStart', () => {
   })
 
   describe('Custom basepath handling', () => {
-    it('should respect custom basepath when checking SPA shell fallback', async () => {
+    it('should hydrate when path matches basepath with trailing slash', async () => {
       window.__TSS_SPA_SHELL__ = true
-      window.history.pushState({}, '', '/app')
+      window.history.pushState({}, '', '/app/')
       
       mockGetRouter.mockResolvedValueOnce(createMockRouter({
         options: { basepath: '/app' }
       }))
       
       await hydrateStart()
-      expect(hydrate).toHaveBeenCalled() // /app matches basepath, so hydrate
+      expect(hydrate).toHaveBeenCalled() // /app/ matches basepath /app after normalization
     })
 
     it('should skip hydration when path is deeper than custom basepath', async () => {

--- a/packages/start-client-core/tests/hydrateStart.test.ts
+++ b/packages/start-client-core/tests/hydrateStart.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { hydrateStart } from '../src/client/hydrateStart'
+import { hydrate } from '@tanstack/router-core/ssr/client'
+import type { AnyRouter } from '@tanstack/router-core'
+
+declare global {
+  interface Window {
+    __TSS_START_OPTIONS__?: any
+  }
+}
+
+// Mocks
+vi.mock('@tanstack/router-core/ssr/client', () => ({
+  hydrate: vi.fn(),
+}))
+
+// Mock factory to avoid duplication
+const createMockRouter = (overrides = {}): Partial<AnyRouter> => ({
+  state: { matches: [] } as any,
+  options: { basepath: '/' } as any,
+  update: vi.fn(),
+  ...overrides,
+})
+
+let mockGetRouter: ReturnType<typeof vi.fn>
+
+vi.mock('#tanstack-router-entry', () => ({
+  get getRouter() {
+    if (!mockGetRouter) {
+      mockGetRouter = vi.fn(() => Promise.resolve(createMockRouter()))
+    }
+    return mockGetRouter
+  },
+  startInstance: undefined
+}))
+
+vi.mock('#tanstack-start-entry', () => ({
+  get getRouter() {
+    if (!mockGetRouter) {
+      mockGetRouter = vi.fn(() => Promise.resolve(createMockRouter()))
+    }
+    return mockGetRouter
+  },
+  startInstance: undefined
+}))
+
+describe('hydrateStart', () => {
+  beforeEach(() => {
+    // Ensure mockGetRouter is initialized
+    if (!mockGetRouter) {
+      mockGetRouter = vi.fn(() => Promise.resolve(createMockRouter()))
+    }
+    
+    vi.clearAllMocks()
+    delete window.__TSS_SPA_SHELL__
+    delete window.__TSS_START_OPTIONS__
+    window.history.pushState({}, '', '/')
+    mockGetRouter.mockResolvedValue(createMockRouter())
+  })
+
+  describe('Normal hydration (no SPA shell)', () => {
+    it('should call hydrate(router) when no SPA shell marker is present', async () => {
+      const router = await hydrateStart()
+      
+      expect(hydrate).toHaveBeenCalledWith(router)
+      expect(router.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serializationAdapters: expect.any(Array)
+        })
+      )
+    })
+
+    it('should call hydrate(router) when SPA shell marker is present but path matches root', async () => {
+      window.__TSS_SPA_SHELL__ = true
+      window.history.pushState({}, '', '/')
+      
+      const router = await hydrateStart()
+      expect(hydrate).toHaveBeenCalledWith(router)
+    })
+  })
+
+  describe('SPA shell fallback detection', () => {
+    it('should NOT call hydrate(router) when SPA shell marker is present and path is deep', async () => {
+      window.__TSS_SPA_SHELL__ = true
+      window.history.pushState({}, '', '/deep/link')
+      
+      await hydrateStart()
+      expect(hydrate).not.toHaveBeenCalled()
+    })
+
+    it('should skip hydration for deep paths with trailing slash', async () => {
+      window.__TSS_SPA_SHELL__ = true
+      window.history.pushState({}, '', '/deep/link/')
+      
+      await hydrateStart()
+      expect(hydrate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Custom basepath handling', () => {
+    it('should respect custom basepath when checking SPA shell fallback', async () => {
+      window.__TSS_SPA_SHELL__ = true
+      window.history.pushState({}, '', '/app')
+      
+      mockGetRouter.mockResolvedValueOnce(createMockRouter({
+        options: { basepath: '/app' }
+      }))
+      
+      await hydrateStart()
+      expect(hydrate).toHaveBeenCalled() // /app matches basepath, so hydrate
+    })
+
+    it('should skip hydration when path is deeper than custom basepath', async () => {
+      window.__TSS_SPA_SHELL__ = true
+      window.history.pushState({}, '', '/app/dashboard')
+      
+      mockGetRouter.mockResolvedValueOnce(createMockRouter({
+        options: { basepath: '/app' }
+      }))
+      
+      await hydrateStart()
+      expect(hydrate).not.toHaveBeenCalled()
+    })
+
+    it('should handle empty basepath', async () => {
+      window.__TSS_SPA_SHELL__ = true
+      window.history.pushState({}, '', '/any-path')
+      
+      mockGetRouter.mockResolvedValueOnce(createMockRouter({
+        options: { basepath: '' }
+      }))
+      
+      await hydrateStart()
+      expect(hydrate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Existing matches handling', () => {
+    it('should skip hydration when matches already exist', async () => {
+      mockGetRouter.mockResolvedValueOnce(createMockRouter({
+        state: { matches: [{ id: 'test-match' }] }
+      }))
+      
+      await hydrateStart()
+      expect(hydrate).not.toHaveBeenCalled()
+    })
+
+    it('should not check SPA shell when matches exist', async () => {
+      window.__TSS_SPA_SHELL__ = true
+      window.history.pushState({}, '', '/deep/link')
+      
+      mockGetRouter.mockResolvedValueOnce(createMockRouter({
+        state: { matches: [{ id: 'test-match' }] }
+      }))
+      
+      await hydrateStart()
+      // Should skip entire hydration block, not just the SPA check
+      expect(hydrate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Router configuration', () => {
+    it('should always call router.update with serializationAdapters', async () => {
+      const router = await hydrateStart()
+      
+      expect(router.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          basepath: process.env.TSS_ROUTER_BASEPATH,
+          serializationAdapters: expect.arrayContaining([
+            expect.objectContaining({ key: expect.any(String) })
+          ])
+        })
+      )
+    })
+
+    it('should merge router serializationAdapters if they exist', async () => {
+      const existingAdapter = { name: 'existing-adapter', serialize: vi.fn() }
+      mockGetRouter.mockResolvedValueOnce(createMockRouter({
+        options: { 
+          basepath: '/',
+          serializationAdapters: [existingAdapter]
+        }
+      }))
+      
+      const router = await hydrateStart()
+      
+      expect(router.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serializationAdapters: expect.arrayContaining([existingAdapter])
+        })
+      )
+    })
+  })
+})

--- a/packages/start-plugin-core/src/prerender.ts
+++ b/packages/start-plugin-core/src/prerender.ts
@@ -234,7 +234,29 @@ export async function prerender({
             routerBasePath,
           )
 
-          const html = await res.text()
+          let html = await res.text()
+
+          if (isSpaShell) {
+            // Inject SPA shell marker for client-side detection
+            const headCloseTag = '</head>'
+            if (html.includes(headCloseTag)) {
+              html = html.replace(
+                headCloseTag,
+                '<script>window.__TSS_SPA_SHELL__ = true</script>' +
+                  headCloseTag,
+              )
+            } else {
+              // Fallback: inject at the beginning of body if </head> not found
+              const bodyOpenTag = '<body'
+              if (html.includes(bodyOpenTag)) {
+                html = html.replace(
+                  bodyOpenTag,
+                  '<script>window.__TSS_SPA_SHELL__ = true</script>' +
+                    bodyOpenTag,
+                )
+              }
+            }
+          }
 
           const filepath = path.join(outputDir, filename)
 


### PR DESCRIPTION
## Problem
When deploying a TanStack Start application to Cloudflare Pages with SPA mode enabled, directly navigating to non-root routes (e.g., `/example`) causes React hydration errors.
**Root Cause:**
- Cloudflare's SPA fallback serves `index.html` (app shell) for all routes
- Client expects to hydrate the deep route (e.g., `/example`)
- Server HTML contains the root shell content
- Mismatch causes hydration error and visible content flash
**Reproduction:**
See Issue #6455 and <https://github.com/bbertold/tanstack-start-spa>
## Solution
Implemented a two-part fix:
### 1. Build-time Marker Injection (`start-plugin-core`)
- Inject `window.__TSS_SPA_SHELL__ = true` into the SPA shell during prerendering
- Only applied to the shell file (identified by `spa.prerender.outputPath`)
- Robust injection with fallback: tries `</head>` first, then `<body>` if not found
### 2. Client-side Detection (`start-client-core`)
- Check for `__TSS_SPA_SHELL__` marker before hydration
- If marker exists AND current path ≠ basepath, skip server hydration
- Let RouterProvider mount the router freshly (client render)

<img width="7313" height="1241" alt="image" src="https://github.com/user-attachments/assets/2f9f996a-c3ac-49d3-94f3-14f5f8deda58" />


This fix is server-agnostic and will resolve similar hydration issues on servers like Caddy, Nginx, or Vercel when configured for SPA fallback 😄 👍 

## Testing
### Unit Tests (11 new tests)
- Normal hydration scenarios (no marker, root path)
- SPA shell fallback detection (deep links, trailing slashes)
- Custom basepath handling (3 scenarios)
- Existing matches handling (2 scenarios)
- Router configuration verification (2 tests)
All tests passing ✅



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SPA shell support: client now conditionally skips or performs hydration based on a runtime SPA-shell marker and the current URL path (respecting basepath).
  * Prerender now injects a SPA-shell marker into HTML to enable the above behavior.

* **Tests**
  * Added comprehensive tests covering hydration fallback scenarios, basepath handling, existing router matches, and adapter merging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->