### PR TITLE
docs: add Cloudflare Workers handlers section to server entry point

### DIFF
--- a/docs/start/framework/react/guide/server-entry-point.md
+++ b/docs/start/framework/react/guide/server-entry-point.md
@@ -101,47 +101,6 @@ The server entry point is where you can configure server-specific behavior:
 
 This flexibility allows you to customize how your TanStack Start application handles server-side rendering while maintaining the framework's conventions.
 
-## Extending with Cloudflare Workers Handlers
+## Cloudflare Workers
 
-`createServerEntry()` returns a plain object, so you can spread it and add other Workers handlers. This makes `server.ts` a full-fledged Cloudflare Worker entrypoint capable of:
-
-- **SSR + Server Functions** (fetch handler)
-- **Queue Consumer + Producer** (queue handler + server functions can send messages)
-- **Cron Jobs** (scheduled handler)
-- **Other Workers features** (Durable Objects via named exports, etc.)
-
-```tsx
-// src/server.ts
-import handler, { createServerEntry } from '@tanstack/react-start/server-entry'
-
-// Durable Objects via named exports
-export { MyDurableObject } from './my-durable-object'
-
-const serverEntry = createServerEntry({
-  async fetch(request) {
-    return await handler.fetch(request)
-  },
-})
-
-export default {
-  ...serverEntry,
-
-  async queue(batch, env, ctx) {
-    for (const message of batch.messages) {
-      message.ack()
-    }
-  },
-
-  async scheduled(event, env, ctx) {
-    console.log('Cron triggered:', event.cron)
-  },
-}
-```
-
-**Testing locally** (with `@cloudflare/vite-plugin`):
-
-```bash
-curl "http://localhost:5173/cdn-cgi/handler/scheduled?cron=*+*+*+*+*"
-```
-
-For a comprehensive guide covering Durable Objects, Workflows, Service Bindings, and other Cloudflare-specific features, see the [Cloudflare Workers documentation for TanStack Start](https://developers.cloudflare.com/workers/framework-guides/web-apps/tanstack-start/#custom-entrypoints).
+When deploying to Cloudflare Workers, you can extend `server.ts` to handle additional Workers features like queues, scheduled events, and Durable Objects. For a comprehensive guide, see the [Cloudflare Workers documentation for TanStack Start](https://developers.cloudflare.com/workers/framework-guides/web-apps/tanstack-start/#custom-entrypoints).


### PR DESCRIPTION
Closes #6487 

  Adds documentation showing that `createServerEntry()` returns a spreadable object, enabling `server.ts` to serve as a full Cloudflare Worker entrypoint
   with:

  - SSR + Server Functions (fetch)
  - Queue Consumer + Producer
  - Cron Jobs (scheduled)
  - Other Workers features (Durable Objects, etc.)

  Tested and working in locally.
  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Cloudflare Workers guidance: two new sections showing how to extend the server entry point and server configuration to support Workers features (queues, scheduled events, Durable Objects) with examples and a link to Cloudflare Workers docs for further reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->