### PR TITLE
Enhance middleware documentation with error handling details

### DIFF
--- a/docs/start/framework/react/guide/middleware.md
+++ b/docs/start/framework/react/guide/middleware.md
@@ -79,7 +79,7 @@ const loggingMiddleware = createMiddleware().server(async ({ next }) => {
 })
 ```
 
-The exception to always returning `next()` is throwing errors. By default, throwing an error will cause the router to short-circuit and return the data passed into the `Error` as a 500 HTTP error-code response. If you want to return another error code, like with an authentication middlware, you can throw the `json` helper.
+The exception to always returning `next()` is throwing errors. By default, throwing an error will cause the router to short-circuit and return the data passed into the `Error` as a 500 HTTP error-code response. If you want to return another error code, like with an authentication middleware, you can throw the `json` helper.
 
 ```tsx
 import { createMiddleware, json } from "@tanstack/react-start";
@@ -95,6 +95,7 @@ const authMiddleware = createMiddleware().server(async ({ next, request }) => {
     throw json({
       message: "you shall not pass!"
     }, {status: 401})
+  }
 
   return await next({ context: { user }}) // pass the user's information to the next middlware or server function
 })


### PR DESCRIPTION
Added explanation for error handling in middleware and provided an example of authentication middleware. I had to find this information from this discussion and not from the middleware documentation page: 

https://github.com/TanStack/router/discussions/2887

Added:
- example of using middlware for auth, throwing 500 errors, throwing 4XX errors, and passing context along
- more explicit details about what middlware can do

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded middleware docs with practical TypeScript examples showing how middleware can short‑circuit by throwing errors or returning controlled JSON responses (e.g., 401) and how to pass context to downstream middleware/server functions. Clarifies default error behavior, contrasts throwing vs. controlled responses, and augments the middleware request-flow guidance to improve real-world error-handling patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->