### PR TITLE
refactor(router-core): improve server store performance by removing getter/setter

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -907,19 +907,14 @@ type RouterStateStore<TState> = {
 function createServerStore<TState>(
   initialState: TState,
 ): RouterStateStore<TState> {
-  let state = initialState
-
-  return {
-    get state() {
-      return state
-    },
-    set state(next) {
-      state = next
-    },
+  const store = {
+    state: initialState,
     setState: (updater: (prev: TState) => TState) => {
-      state = updater(state)
+      store.state = updater(store.state)
     },
   } as RouterStateStore<TState>
+
+  return store
 }
 
 export class RouterCore<


### PR DESCRIPTION
Compared to direct property access, getters / setters have a non-negligible performance cost. In the case of `createServerStore` we can significantly improve the performance of the store by using direct property access to the state.

before

<img width="791" height="345" alt="Screenshot 2026-01-25 at 09 59 45" src="https://github.com/user-attachments/assets/322e6408-8130-4b1d-a993-05272b569de2" />


after

<img width="791" height="345" alt="Screenshot 2026-01-25 at 09 59 40" src="https://github.com/user-attachments/assets/dcc73585-a864-40f1-83a1-ca5b25fbf04a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management implementation in the router core. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->