### PR TITLE
refactor(router-core): decodePath fast path when no encoded chars

### DIFF
--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -593,7 +593,6 @@ export function escapeHtml(str: string): string {
   return str.replace(HTML_ESCAPE_REGEX, (match) => HTML_ESCAPE_LOOKUP[match]!)
 }
 
-
 export function decodePath(path: string, decodeIgnore?: Array<string>): string {
   if (!path) return path
 


### PR DESCRIPTION
Most paths do not contain encoded paths and are just alphanumeric and `-_/`. We can optimize `decodePath` to return early in that case.

In our simple benchmark, this is a 3x improvement on the total time of `decodePath` from 156ms to 47ms (in a 30s run)

before
<img width="791" height="345" alt="Screenshot 2026-01-25 at 11 39 05" src="https://github.com/user-attachments/assets/d021315f-1b5f-4e2f-9d8b-0e2f019ea7d2" />


after
<img width="791" height="345" alt="Screenshot 2026-01-25 at 11 38 56" src="https://github.com/user-attachments/assets/a9e5ef93-ed62-436a-9ecb-6bfb502e9aa1" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized path decoding performance by adding an early-exit mechanism for already-decoded and safe paths, reducing unnecessary processing overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->