### PR TITLE
refactor(router-core): buildLocation can skip second interpolatePath if no params.parse function in the branch

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1805,6 +1805,7 @@ export class RouterCore<
       const interpolatedNextTo = interpolatePath({
         path: nextTo,
         params: nextParams,
+        decoder: this.pathParamsDecoder,
         server: this.isServer,
       }).interpolatedPath
 
@@ -1833,11 +1834,13 @@ export class RouterCore<
       }
 
       // If there are any params, we need to stringify them
+      let changedParams = false
       if (Object.keys(nextParams).length > 0) {
         for (const route of destRoutes) {
           const fn =
             route.options.params?.stringify ?? route.options.stringifyParams
           if (fn) {
+            changedParams = true
             Object.assign(nextParams, fn(nextParams))
           }
         }
@@ -1848,12 +1851,14 @@ export class RouterCore<
           // This preserves the original parameter syntax including optional parameters
           nextTo
         : decodePath(
-            interpolatePath({
-              path: nextTo,
-              params: nextParams,
-              decoder: this.pathParamsDecoder,
-              server: this.isServer,
-            }).interpolatedPath,
+            !changedParams
+              ? interpolatedNextTo
+              : interpolatePath({
+                  path: nextTo,
+                  params: nextParams,
+                  decoder: this.pathParamsDecoder,
+                  server: this.isServer,
+                }).interpolatedPath,
           )
 
       // Resolve the next search


### PR DESCRIPTION
in `buildLocation` we call
- `interpolatePath` to get a string to match
- `getMatchedRoutes` to get a route branch that matches
- `interpolatePath` to get the "real" pathname to make a URL

however if the route branch doesn't contain any `params.parse` functions, the 2nd `interpolatePath` is guaranteed to return the same string as the 1st one. So in those cases we can skip it


before
<img width="791" height="345" alt="Screenshot 2026-01-25 at 15 54 46" src="https://github.com/user-attachments/assets/2f5078bf-fdcf-4064-b59b-6065788b64d3" />




after
<img width="791" height="345" alt="Screenshot 2026-01-25 at 15 54 50" src="https://github.com/user-attachments/assets/11159f80-c028-4594-9811-e2e8ede9d89d" />




