### PR TITLE
refactor(router-core): throw redirect w/ a pre-build location doesn't need to re-parse from string

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2292,8 +2292,11 @@ export class RouterCore<
       // always uses this.origin when constructing URLs
       if (this.latestLocation.publicHref !== nextLocation.publicHref) {
         const href = this.getParsedLocationHref(nextLocation)
-
-        throw redirect({ href })
+        if (nextLocation.external) {
+          throw redirect({ href })
+        } else {
+          throw redirect({ href, _builtLocation: nextLocation })
+        }
       }
     }
 
@@ -2622,8 +2625,9 @@ export class RouterCore<
   resolveRedirect = (redirect: AnyRedirect): AnyRedirect => {
     const locationHeader = redirect.headers.get('Location')
 
-    if (!redirect.options.href) {
-      const location = this.buildLocation(redirect.options)
+    if (!redirect.options.href || redirect.options._builtLocation) {
+      const location =
+        redirect.options._builtLocation ?? this.buildLocation(redirect.options)
       const href = this.getParsedLocationHref(location)
       redirect.options.href = href
       redirect.headers.set('Location', href)


### PR DESCRIPTION
During SSR, if the href of an incoming request ends up matching and being re-written to another href (for example: adding default search params), we throw a `redirect({ href })` with that new href to force a `Response(, { headers: { Location: href } })`

When handling a thrown `redirect`, we treat `href` as any untrusted string. This is sub-optimal when it actually comes from us *just* parsing a correct internal location.

This PR proposes an internal `_builtLocation` argument that bypasses such checks and re-parsing.

before
<img width="877" height="345" alt="Screenshot 2026-01-25 at 18 59 31" src="https://github.com/user-attachments/assets/63863c5c-26ce-4cf6-86e4-e2b91c4f0e63" />

after
<img width="877" height="345" alt="Screenshot 2026-01-25 at 18 59 41" src="https://github.com/user-attachments/assets/26bdfffa-f900-4976-90d2-9dc0ec4d5108" />




