### PR TITLE
refactor(router-core): startViewTransition performance improved by avoiding 'delete'

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2487,7 +2487,8 @@ export class RouterCore<
       this.shouldViewTransition ?? this.options.defaultViewTransition
 
     // Reset the view transition flag
-    delete this.shouldViewTransition
+    this.shouldViewTransition = undefined
+
     // Attempt to start a view transition (or just apply the changes if we can't)
     if (
       shouldViewTransition &&


### PR DESCRIPTION
We know `delete` is very slow and should be reserved for user-facing objects. But in `startViewTransition` we were using it for an internal flag. Just resetting the flag to `undefined` works the same way, with a nice performance improvement.

This function is called on every request and every navigation, so it's definitely worth it.

before
<img width="877" height="345" alt="Screenshot 2026-01-25 at 21 40 19" src="https://github.com/user-attachments/assets/77dee722-98d3-4158-b5ba-b010ec93cc61" />




after
<img width="877" height="345" alt="Screenshot 2026-01-25 at 21 40 55" src="https://github.com/user-attachments/assets/8b69a796-82ac-442a-88fa-120af4298220" />




