### PR TITLE
refactor(router-core): executeBeforeLoad remove dead code

### DIFF
--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -389,13 +389,6 @@ const executeBeforeLoad = (
 
   const abortController = new AbortController()
 
-  const parentMatchId = inner.matches[index - 1]?.id
-  const parentMatch = parentMatchId
-    ? inner.router.getMatch(parentMatchId)!
-    : undefined
-  const parentMatchContext =
-    parentMatch?.context ?? inner.router.options.context ?? undefined
-
   let isPending = false
   const pending = () => {
     if (isPending) return


### PR DESCRIPTION
Building match context manually has been replaced with a `buildMatchContext` function call in https://github.com/TanStack/router/pull/6070 but this variable was left over. It isn't much, but it does do a non-trivial `.getMatch()` call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal context handling during route loading to improve performance and processing efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->