### PR TITLE
refactor(react-router): Match component performance w/ single router state select

### DIFF
--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -43,7 +43,7 @@ export const Match = React.memo(function MatchImpl({
         ssr: match.ssr,
         _displayPending: match._displayPending,
         resetKey: s.loadedAt,
-        parentRouteId: s.matches[matchIndex - 1]?.routeId as string
+        parentRouteId: s.matches[matchIndex - 1]?.routeId as string,
       }
     },
     structuralSharing: true as any,
@@ -128,7 +128,8 @@ export const Match = React.memo(function MatchImpl({
           </ResolvedCatchBoundary>
         </ResolvedSuspenseBoundary>
       </matchContext.Provider>
-      {matchState.parentRouteId === rootRouteId && router.options.scrollRestoration ? (
+      {matchState.parentRouteId === rootRouteId &&
+      router.options.scrollRestoration ? (
         <>
           <OnRendered />
           <ScrollRestoration />


### PR DESCRIPTION
In the `<Match>` component, we need both
- the id of the match itself
- the id of the parent of the match

For both, we need to iterate the matches array. We can do this in a single iteration, and reduce the use of `useRouterState` from 3 calls to 1.

before
<img width="877" height="345" alt="Screenshot 2026-01-25 at 23 12 55" src="https://github.com/user-attachments/assets/ffc119e8-0583-4a00-9416-bfd8852dc39c" />



after
<img width="877" height="345" alt="Screenshot 2026-01-25 at 23 13 00" src="https://github.com/user-attachments/assets/5c73b657-0bb1-4f2b-8c1a-db5e24a39811" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized route matching performance through improved algorithm efficiency.
  * Consolidated internal state management to reduce redundant operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->