### PR TITLE
docs: Updated typo in internationalization-i18n.md

### DIFF
--- a/docs/router/framework/react/guide/internationalization-i18n.md
+++ b/docs/router/framework/react/guide/internationalization-i18n.md
@@ -25,8 +25,8 @@ This pattern relies exclusively on TanStack Router features. It is suitable when
 
 Optional path parameters are ideal for implementing locale-aware routing without duplicating routes.
 
-```ts
-;/{-$locale}/abotu
+```
+/{-$locale}/about
 ```
 
 This single route matches:


### PR DESCRIPTION
Optional path parameters typescript example had a typo (/abotu not /about).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a typographical error in the internationalization (i18n) guide, correcting an example route to improve clarity in multilingual routing examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->