### PR TITLE
Update i18n guide to include Paraglide JS link

### DIFF
--- a/docs/router/framework/react/guide/internationalization-i18n.md
+++ b/docs/router/framework/react/guide/internationalization-i18n.md
@@ -106,7 +106,7 @@ function isLocale(value?: string): value is Locale {
 
 TanStack Router is **library-agnostic**. You can integrate any i18n solution by mapping locale state to routing behavior.
 
-Below is a recommended pattern using **Paraglide**.
+Below is a recommended pattern using **[Paraglide JS](https://inlang.com/m/gerre34r/library-inlang-paraglideJs)**.
 
 ---
 


### PR DESCRIPTION
The link to the docs of Paraglide JS was missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internationalization (i18n) library integration guidance with improved reference links for better discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->