### PR TITLE
fix: AbortError in renderToReadableStream

### DIFF
--- a/packages/react-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/react-router/src/ssr/renderRouterToStream.tsx
@@ -31,7 +31,7 @@ export const renderRouterToStream = async ({
             return
           }
 
-          console.error('Error in renderToReadableStream:', error)
+          console.error('onError in renderToReadableStream:', error)
         },
       })
 


### PR DESCRIPTION
Fixes #6069 

When running TanStack Start in production I was getting hundreds of `DOMException: The connection was closed` errors. 

This checks during `renderToReadableStream` if an error has occurred. Since this is a non-recoverable error, a `499` HTTP response is sent instead. I'm not sure if this is the best approach and welcome any feedback.

I've tested it using this reproduction (https://github.com/checkerschaf/start-domexception-aborterror/blob/main/reproduce-abort-error.ts). After this fix, no errors are logged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering error handling: aborted requests now return 499 and unexpected errors return 500.
  * Enhanced error logging and graceful handling of aborted rendering streams to avoid unhandled failures and improve diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->