### PR TITLE
fix: allow FormData union type

### DIFF
--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -468,12 +468,17 @@ export type ValidateValidatorInput<
   TMethod extends Method,
   TInputValidator,
 > = TMethod extends 'POST'
-  ? FormData extends ResolveValidatorInput<TInputValidator> 
-    ? ResolveValidatorInput<TInputValidator>
-    : ValidateSerializable<
-        ResolveValidatorInput<TInputValidator>,
+  ? Extract<ResolveValidatorInput<TInputValidator>, FormData> extends never
+    ? ValidateSerializable<
+        Exclude<ResolveValidatorInput<TInputValidator>, FormData>,
         RegisteredSerializableInput<TRegister>
       >
+    :
+        | FormData
+        | ValidateSerializable<
+            Exclude<ResolveValidatorInput<TInputValidator>, FormData>,
+            RegisteredSerializableInput<TRegister>
+          >
   : ValidateSerializable<
       ResolveValidatorInput<TInputValidator>,
       RegisteredSerializableInput<TRegister>

--- a/packages/start-client-core/src/tests/createServerFn.test-d.ts
+++ b/packages/start-client-core/src/tests/createServerFn.test-d.ts
@@ -896,8 +896,35 @@ test('createServerFn GET cannot use FormData union validator', () => {
     (input: FormData | { id: string }) => { output: 'string' }
   >
 
-  expectTypeOf(validator)
-    .parameter(0)
-    .parameter(0)
-    .not.toEqualTypeOf<FormData | { id: string }>()
+  expectTypeOf(validator).parameter(0).parameter(0).toEqualTypeOf<
+    | {
+        append: 'Function is not serializable'
+        delete: 'Function is not serializable'
+        get: 'Function is not serializable'
+        getAll: 'Function is not serializable'
+        has: 'Function is not serializable'
+        set: 'Function is not serializable'
+        forEach: 'Function is not serializable'
+        entries: 'Function is not serializable'
+        keys: 'Function is not serializable'
+        values: 'Function is not serializable'
+        [Symbol.iterator]: 'Function is not serializable'
+      }
+    | {
+        id: string
+      }
+  >()
+})
+
+test('createServerFn POST rejects FormData union with non-serializable', () => {
+  const validator = createServerFn({ method: 'POST' }).inputValidator<
+    (input: FormData | { func: () => void }) => { output: 'string' }
+  >
+
+  expectTypeOf(validator).parameter(0).parameter(0).toEqualTypeOf<
+    | FormData
+    | {
+        func: 'Function is not serializable'
+      }
+  >()
 })


### PR DESCRIPTION
Hi :wave:

This change allows serverFn inputValidator to accept either typed data or FormData while continuing to share a single input schema.

In practice, some call sites naturally work with typed objects (e.g. programmatic mutations), while others already have FormData available (e.g. form submissions). Today, supporting both requires extra boilerplate or duplicate serverFn.

My goal is to reduce friction when integrating serverFn with form-driven workflows (including TanStack DB - i like to share schema between thoses libs) while keeping type safety intact.

Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Type validation now supports FormData alongside serializable input for POST requests while preserving method-specific validation rules.

* **Tests**
  * Added cases covering FormData union behavior for POST and ensuring GET validations disallow FormData unions; added tests for non-serializable inputs in POST scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->