### PR TITLE
fix(react-router, solid-router, vue-router): support other test environments

### DIFF
--- a/packages/react-router/vite.config.ts
+++ b/packages/react-router/vite.config.ts
@@ -3,7 +3,10 @@ import { tanstackViteConfig } from '@tanstack/config/vite'
 import react from '@vitejs/plugin-react'
 import packageJson from './package.json'
 
-const isTest = process.env.VITEST || process.env.NODE_TEST_CONTEXT || process.env.NODE_ENV === 'test'
+const isTest =
+  process.env.VITEST ||
+  process.env.NODE_TEST_CONTEXT ||
+  process.env.NODE_ENV === 'test'
 
 const config = defineConfig({
   plugins: [react()],

--- a/packages/solid-router/vite.config.ts
+++ b/packages/solid-router/vite.config.ts
@@ -4,7 +4,6 @@ import solid from 'vite-plugin-solid'
 import packageJson from './package.json'
 import type { ViteUserConfig } from 'vitest/config'
 
-
 const config = defineConfig(({ mode }) => {
   if (mode === 'server') {
     return {
@@ -24,7 +23,10 @@ const config = defineConfig(({ mode }) => {
     }
   }
 
-  const isTest = process.env.VITEST || process.env.NODE_TEST_CONTEXT || process.env.NODE_ENV === 'test'
+  const isTest =
+    process.env.VITEST ||
+    process.env.NODE_TEST_CONTEXT ||
+    process.env.NODE_ENV === 'test'
 
   return {
     plugins: [solid()] as ViteUserConfig['plugins'],

--- a/packages/vue-router/vite.config.ts
+++ b/packages/vue-router/vite.config.ts
@@ -8,7 +8,10 @@ import packageJson from './package.json'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
-const isTest = process.env.VITEST || process.env.NODE_TEST_CONTEXT || process.env.NODE_ENV === 'test'
+const isTest =
+  process.env.VITEST ||
+  process.env.NODE_TEST_CONTEXT ||
+  process.env.NODE_ENV === 'test'
 
 const config = defineConfig({
   plugins: [vueJsx()],


### PR DESCRIPTION
Some users are reporting that their jest tests do not work since the recent `/isServer` change. Just trying this out. But I really dislike jest too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Improved test environment detection in build configuration across router packages (react-router, solid-router, vue-router) to ensure proper module resolution during testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->