### PR TITLE
refactor(router-core): store updates are reserved for reactivity updates

### DIFF
--- a/docs/router/framework/react/api/router/RouterStateType.md
+++ b/docs/router/framework/react/api/router/RouterStateType.md
@@ -11,7 +11,6 @@ type RouterState = {
   isLoading: boolean
   isTransitioning: boolean
   matches: Array<RouteMatch>
-  pendingMatches: Array<RouteMatch>
   location: ParsedLocation
   resolvedLocation: ParsedLocation
 }
@@ -40,11 +39,6 @@ The `RouterState` type contains all of the properties that are available on the 
 
 - Type: [`Array<RouteMatch>`](./RouteMatchType.md)
 - An array of all of the route matches that have been resolved and are currently active.
-
-### `pendingMatches` property
-
-- Type: [`Array<RouteMatch>`](./RouteMatchType.md)
-- An array of all of the route matches that are currently pending.
 
 ### `location` property
 

--- a/docs/router/framework/react/api/router/useChildMatchesHook.md
+++ b/docs/router/framework/react/api/router/useChildMatchesHook.md
@@ -5,9 +5,6 @@ title: useChildMatches hook
 
 The `useChildMatches` hook returns all of the child [`RouteMatch`](./RouteMatchType.md) objects from the closest match down to the leaf-most match. **It does not include the current match, which can be obtained using the `useMatch` hook.**
 
-> [!IMPORTANT]
-> If the router has pending matches and they are showing their pending component fallbacks, `router.state.pendingMatches` will used instead of `router.state.matches`.
-
 ## useChildMatches options
 
 The `useChildMatches` hook accepts a single _optional_ argument, an `options` object.

--- a/docs/router/framework/react/api/router/useParentMatchesHook.md
+++ b/docs/router/framework/react/api/router/useParentMatchesHook.md
@@ -5,9 +5,6 @@ title: useParentMatches hook
 
 The `useParentMatches` hook returns all of the parent [`RouteMatch`](./RouteMatchType.md) objects from the root down to the immediate parent of the current match in context. **It does not include the current match, which can be obtained using the `useMatch` hook.**
 
-> [!IMPORTANT]
-> If the router has pending matches and they are showing their pending component fallbacks, `router.state.pendingMatches` will used instead of `router.state.matches`.
-
 ## useParentMatches options
 
 The `useParentMatches` hook accepts an optional `options` object.

--- a/packages/react-router/tests/store-updates-during-navigation.test.tsx
+++ b/packages/react-router/tests/store-updates-during-navigation.test.tsx
@@ -136,8 +136,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBeGreaterThanOrEqual(10) // WARN: this is flaky, and sometimes (rarely) is 12
-    expect(updates).toBeLessThanOrEqual(13)
+    expect(updates).toBeGreaterThanOrEqual(6) // WARN: this is flaky
+    expect(updates).toBeLessThanOrEqual(9)
   })
 
   test('redirection in preload', async () => {
@@ -155,7 +155,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(4)
+    expect(updates).toBe(3)
   })
 
   test('sync beforeLoad', async () => {
@@ -171,8 +171,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBeGreaterThanOrEqual(9) // WARN: this is flaky
-    expect(updates).toBeLessThanOrEqual(12)
+    expect(updates).toBeGreaterThanOrEqual(4) // WARN: this is flaky
+    expect(updates).toBeLessThanOrEqual(7)
   })
 
   test('nothing', async () => {
@@ -183,8 +183,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBeGreaterThanOrEqual(6) // WARN: this is flaky, and sometimes (rarely) is 9
-    expect(updates).toBeLessThanOrEqual(9)
+    expect(updates).toBeGreaterThanOrEqual(2) // WARN: this is flaky
+    expect(updates).toBeLessThanOrEqual(5)
   })
 
   test('not found in beforeLoad', async () => {
@@ -199,7 +199,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(7)
+    expect(updates).toBe(2)
   })
 
   test('hover preload, then navigate, w/ async loaders', async () => {
@@ -225,7 +225,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(16)
+    expect(updates).toBe(8)
   })
 
   test('navigate, w/ preloaded & async loaders', async () => {
@@ -241,8 +241,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBeGreaterThanOrEqual(7)
-    expect(updates).toBeLessThanOrEqual(8)
+    expect(updates).toBeGreaterThanOrEqual(2) // WARN: this is flaky
+    expect(updates).toBeLessThanOrEqual(5)
   })
 
   test('navigate, w/ preloaded & sync loaders', async () => {
@@ -258,7 +258,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(6)
+    expect(updates).toBe(3)
   })
 
   test('navigate, w/ previous navigation & async loader', async () => {
@@ -274,7 +274,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(5)
+    expect(updates).toBe(3)
   })
 
   test('preload a preloaded route w/ async loader', async () => {

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -54,6 +54,12 @@ const resolvePreload = (inner: InnerLoadContext, matchId: string): boolean => {
 /**
  * Builds the accumulated context from router options and all matches up to (and optionally including) the given index.
  * Merges __routeContext and __beforeLoadContext from each match.
+ *
+ * Note: We use inner.matches directly (which is __pendingMatches during loading)
+ * rather than looking up via router.getMatch() to ensure we always get the latest
+ * updates from updateMatch during the loading phase. This is critical because
+ * __matchesById might be rebuilt by other operations (e.g., onReady commit)
+ * which could cause timing issues in SPA mode.
  */
 const buildMatchContext = (
   inner: InnerLoadContext,
@@ -65,11 +71,9 @@ const buildMatchContext = (
   }
   const end = includeCurrentMatch ? index : index - 1
   for (let i = 0; i <= end; i++) {
-    const innerMatch = inner.matches[i]
-    if (!innerMatch) continue
-    const m = inner.router.getMatch(innerMatch.id)
-    if (!m) continue
-    Object.assign(context, m.__routeContext, m.__beforeLoadContext)
+    const match = inner.matches[i]
+    if (!match) continue
+    Object.assign(context, match.__routeContext, match.__beforeLoadContext)
   }
   return context
 }
@@ -473,16 +477,16 @@ const executeBeforeLoad = (
       handleSerialError(inner, index, beforeLoadContext, 'BEFORE_LOAD')
     }
 
-    batch(() => {
-      pending()
-      // Only store __beforeLoadContext here, don't update context yet
-      // Context will be updated in loadRouteMatch after loader completes
-      inner.updateMatch(matchId, (prev) => ({
-        ...prev,
-        __beforeLoadContext: beforeLoadContext,
-      }))
-      resolve()
-    })
+    // Execute the update synchronously to ensure the match is updated
+    // before the next beforeLoad runs. We avoid batch() here because
+    // batching reactive notifications can cause timing issues where
+    // the child route's beforeLoad runs before the parent's context is available.
+    pending()
+    inner.updateMatch(matchId, (prev) => ({
+      ...prev,
+      __beforeLoadContext: beforeLoadContext,
+    }))
+    resolve()
   }
 
   let beforeLoadContext
@@ -586,8 +590,10 @@ const getLoaderContext = (
   route: AnyRoute,
 ): LoaderFnContext => {
   const parentMatchPromise = inner.matchPromises[index - 1] as any
-  const { params, loaderDeps, abortController, cause } =
-    inner.router.getMatch(matchId)!
+  // Use inner.matches[index] directly to ensure we get the latest updates
+  // from the pending matches array during loading
+  const match = inner.matches[index]!
+  const { params, loaderDeps, abortController, cause } = match
 
   const context = buildMatchContext(inner, index)
 
@@ -866,8 +872,36 @@ export async function loadMatches(arg: {
   updateMatch: UpdateMatchFn
   sync?: boolean
 }): Promise<Array<MakeRouteMatch>> {
+  // Create a local matches index for O(1) lookup during loading
+  // This is necessary because the router's __pendingMatchesIndex may be cleared
+  // by other operations (like transitions or navigation) during async loading
+  const matchesIndex = new Map<string, number>()
+  arg.matches.forEach((match, i) => {
+    matchesIndex.set(match.id, i)
+  })
+
+  // Save the original updateMatch before wrapping
+  const originalUpdateMatch = arg.updateMatch
+
+  // Wrap updateMatch to update the local matches array directly
+  // This ensures updates are applied even if __pendingMatches is cleared
+  const localUpdateMatch: UpdateMatchFn = (id, updater) => {
+    const index = matchesIndex.get(id)
+    if (index !== undefined) {
+      const prev = arg.matches[index]!
+      const next = updater(prev)
+      if (next !== prev) {
+        arg.matches[index] = next
+      }
+    }
+    // Also call the original updateMatch to keep __matchesById in sync
+    // and handle any other side effects
+    originalUpdateMatch(id, updater)
+  }
+
   const inner: InnerLoadContext = Object.assign(arg, {
     matchPromises: [],
+    updateMatch: localUpdateMatch,
   })
 
   // make sure the pending component is immediately rendered when hydrating a match that is not SSRed

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -521,7 +521,6 @@ export interface RouterState<
   isLoading: boolean
   isTransitioning: boolean
   matches: Array<TRouteMatch>
-  pendingMatches?: Array<TRouteMatch>
   cachedMatches: Array<TRouteMatch>
   location: ParsedLocation<FullSearchSchema<TRouteTree>>
   resolvedLocation?: ParsedLocation<FullSearchSchema<TRouteTree>>
@@ -935,6 +934,15 @@ export class RouterCore<
   viewTransitionPromise?: ControlledPromise<true>
   isScrollRestoring = false
   isScrollRestorationSetup = false
+  private __pendingMatches?: Array<AnyRouteMatch>
+  private __pendingMatchesIndex?: Map<string, number>
+  private __matchesIndex?: Map<string, number>
+  private __matchesIndexFor?: Array<AnyRouteMatch>
+  private __cachedMatchesIndex?: Map<string, number>
+  private __cachedMatchesIndexFor?: Array<AnyRouteMatch>
+  private __queuedMatchUpdates = new Map<string, AnyRouteMatch>()
+  private __queuedCachedMatchUpdates = new Map<string, AnyRouteMatch>()
+  private __matchFlushScheduled = false
 
   // Must build in constructor
   __store!: Store<RouterState<TRouteTree>>
@@ -1743,7 +1751,7 @@ export class RouterCore<
       (match) => match.isFetching === 'loader',
     )
     const matchesToCancelArray = new Set([
-      ...(this.state.pendingMatches ?? []),
+      ...(this.__pendingMatches ?? []),
       ...currentPendingMatches,
       ...currentLoadingMatches,
     ])
@@ -2320,6 +2328,8 @@ export class RouterCore<
 
     // Match the routes
     const pendingMatches = this.matchRoutes(this.latestLocation)
+    this.__pendingMatches = pendingMatches
+    this.rebuildPendingMatchesIndex(pendingMatches)
 
     // Ingest the new matches
     this.__store.setState((s) => ({
@@ -2328,7 +2338,6 @@ export class RouterCore<
       statusCode: 200,
       isLoading: true,
       location: this.latestLocation,
-      pendingMatches,
       // If a cached moved to pendingMatches, remove it from cachedMatches
       cachedMatches: s.cachedMatches.filter(
         (d) => !pendingMatches.some((e) => e.id === d.id),
@@ -2370,14 +2379,13 @@ export class RouterCore<
           await loadMatches({
             router: this,
             sync: opts?.sync,
-            matches: this.state.pendingMatches as Array<AnyRouteMatch>,
+            matches: this.__pendingMatches ?? [],
             location: next,
             updateMatch: this.updateMatch,
-            // eslint-disable-next-line @typescript-eslint/require-await
-            onReady: async () => {
+            onReady: () => {
               // Wrap batch in framework-specific transition wrapper (e.g., Solid's startTransition)
               this.startTransition(() => {
-                this.startViewTransition(async () => {
+                this.startViewTransition(() => {
                   // this.viewTransitionPromise = createControlledPromise<true>()
 
                   // Commit the pending matches. If a previous match was
@@ -2389,7 +2397,10 @@ export class RouterCore<
                   batch(() => {
                     this.__store.setState((s) => {
                       const previousMatches = s.matches
-                      const newMatches = s.pendingMatches || s.matches
+                      const newMatches =
+                        this.__pendingMatches && this.__pendingMatches.length
+                          ? this.__pendingMatches
+                          : s.matches
 
                       exitingMatches = previousMatches.filter(
                         (match) => !newMatches.some((d) => d.id === match.id),
@@ -2407,7 +2418,6 @@ export class RouterCore<
                         isLoading: false,
                         loadedAt: Date.now(),
                         matches: newMatches,
-                        pendingMatches: undefined,
                         /**
                          * When committing new matches, cache any exiting matches that are still usable.
                          * Routes that resolved with `status: 'error'` or `status: 'notFound'` are
@@ -2425,6 +2435,8 @@ export class RouterCore<
                     })
                     this.clearExpiredCache()
                   })
+                  this.__pendingMatches = undefined
+                  this.rebuildPendingMatchesIndex(undefined)
 
                   //
                   ;(
@@ -2440,8 +2452,10 @@ export class RouterCore<
                       )
                     })
                   })
+                  return Promise.resolve()
                 })
               })
+              return Promise.resolve()
             },
           })
         } catch (err) {
@@ -2562,34 +2576,179 @@ export class RouterCore<
     }
   }
 
-  updateMatch: UpdateMatchFn = (id, updater) => {
-    this.startTransition(() => {
-      const matchesKey = this.state.pendingMatches?.some((d) => d.id === id)
-        ? 'pendingMatches'
-        : this.state.matches.some((d) => d.id === id)
-          ? 'matches'
-          : this.state.cachedMatches.some((d) => d.id === id)
-            ? 'cachedMatches'
-            : ''
+  private rebuildPendingMatchesIndex = (
+    matches: Array<AnyRouteMatch> | undefined,
+  ) => {
+    if (!matches) {
+      this.__pendingMatchesIndex = undefined
+      return
+    }
+    const index = new Map<string, number>()
+    matches.forEach((match, i) => {
+      index.set(match.id, i)
+    })
+    this.__pendingMatchesIndex = index
+  }
 
-      if (matchesKey) {
-        this.__store.setState((s) => ({
-          ...s,
-          [matchesKey]: s[matchesKey]?.map((d) =>
-            d.id === id ? updater(d) : d,
-          ),
-        }))
+  private getMatchesIndex = (
+    matches: Array<AnyRouteMatch>,
+    kind: 'matches' | 'cachedMatches',
+  ): Map<string, number> => {
+    if (kind === 'matches') {
+      if (this.__matchesIndexFor !== matches || !this.__matchesIndex) {
+        const index = new Map<string, number>()
+        matches.forEach((match, i) => {
+          index.set(match.id, i)
+        })
+        this.__matchesIndex = index
+        this.__matchesIndexFor = matches
       }
+      return this.__matchesIndex
+    }
+    if (
+      this.__cachedMatchesIndexFor !== matches ||
+      !this.__cachedMatchesIndex
+    ) {
+      const index = new Map<string, number>()
+      matches.forEach((match, i) => {
+        index.set(match.id, i)
+      })
+      this.__cachedMatchesIndex = index
+      this.__cachedMatchesIndexFor = matches
+    }
+    return this.__cachedMatchesIndex
+  }
+
+  private queueMatchUpdate = (
+    kind: 'matches' | 'cachedMatches',
+    id: string,
+    match: AnyRouteMatch,
+  ) => {
+    if (kind === 'matches') {
+      this.__queuedMatchUpdates.set(id, match)
+    } else {
+      this.__queuedCachedMatchUpdates.set(id, match)
+    }
+
+    if (this.__matchFlushScheduled) return
+    this.__matchFlushScheduled = true
+    Promise.resolve().then(() => {
+      this.__matchFlushScheduled = false
+      if (
+        this.__queuedMatchUpdates.size === 0 &&
+        this.__queuedCachedMatchUpdates.size === 0
+      ) {
+        return
+      }
+      const queuedMatches = new Map(this.__queuedMatchUpdates)
+      const queuedCached = new Map(this.__queuedCachedMatchUpdates)
+      this.__queuedMatchUpdates.clear()
+      this.__queuedCachedMatchUpdates.clear()
+      this.startTransition(() => {
+        this.__store.setState((s) => {
+          let nextMatches = s.matches
+          let nextCachedMatches = s.cachedMatches
+
+          if (queuedMatches.size) {
+            const index = this.getMatchesIndex(s.matches, 'matches')
+            nextMatches = s.matches.slice()
+            queuedMatches.forEach((match, queuedId) => {
+              const matchIndex = index.get(queuedId)
+              if (matchIndex !== undefined) {
+                nextMatches[matchIndex] = match
+              }
+            })
+          }
+
+          if (queuedCached.size) {
+            const index = this.getMatchesIndex(s.cachedMatches, 'cachedMatches')
+            nextCachedMatches = s.cachedMatches.slice()
+            queuedCached.forEach((match, queuedId) => {
+              const matchIndex = index.get(queuedId)
+              if (matchIndex !== undefined) {
+                nextCachedMatches[matchIndex] = match
+              }
+            })
+          }
+
+          if (
+            nextMatches === s.matches &&
+            nextCachedMatches === s.cachedMatches
+          ) {
+            return s
+          }
+
+          return {
+            ...s,
+            matches: nextMatches,
+            cachedMatches: nextCachedMatches,
+          }
+        })
+      })
     })
   }
 
+  private updateMatchInternal = (id: string, updater: (prev: any) => any) => {
+    const pendingIndex = this.__pendingMatchesIndex?.get(id)
+    if (pendingIndex !== undefined && this.__pendingMatches) {
+      const prev = this.__pendingMatches[pendingIndex]!
+      const next = updater(prev)
+      if (next !== prev) {
+        this.__pendingMatches[pendingIndex] = next
+      }
+      return
+    }
+
+    const matchesIndex = this.getMatchesIndex(
+      this.state.matches,
+      'matches',
+    ).get(id)
+    if (matchesIndex !== undefined) {
+      const prev = this.state.matches[matchesIndex]!
+      const next = updater(prev)
+      if (next !== prev) {
+        this.queueMatchUpdate('matches', id, next)
+      }
+      return
+    }
+
+    const cachedIndex = this.getMatchesIndex(
+      this.state.cachedMatches,
+      'cachedMatches',
+    ).get(id)
+    if (cachedIndex !== undefined) {
+      const prev = this.state.cachedMatches[cachedIndex]!
+      const next = updater(prev)
+      if (next !== prev) {
+        this.queueMatchUpdate('cachedMatches', id, next)
+      }
+    }
+  }
+
+  updateMatch: UpdateMatchFn = (id, updater) => {
+    this.updateMatchInternal(id, updater)
+  }
+
   getMatch: GetMatchFn = (matchId: string): AnyRouteMatch | undefined => {
-    const findFn = (d: { id: string }) => d.id === matchId
-    return (
-      this.state.cachedMatches.find(findFn) ??
-      this.state.pendingMatches?.find(findFn) ??
-      this.state.matches.find(findFn)
-    )
+    const pendingIndex = this.__pendingMatchesIndex?.get(matchId)
+    if (pendingIndex !== undefined && this.__pendingMatches) {
+      return this.__pendingMatches[pendingIndex]
+    }
+    const matchesIndex = this.getMatchesIndex(
+      this.state.matches,
+      'matches',
+    ).get(matchId)
+    if (matchesIndex !== undefined) {
+      return this.state.matches[matchesIndex]
+    }
+    const cachedIndex = this.getMatchesIndex(
+      this.state.cachedMatches,
+      'cachedMatches',
+    ).get(matchId)
+    if (cachedIndex !== undefined) {
+      return this.state.cachedMatches[cachedIndex]
+    }
+    return undefined
   }
 
   /**
@@ -2624,11 +2783,15 @@ export class RouterCore<
       return d
     }
 
+    if (this.__pendingMatches) {
+      this.__pendingMatches = this.__pendingMatches.map(invalidate)
+      this.rebuildPendingMatchesIndex(this.__pendingMatches)
+    }
+
     this.__store.setState((s) => ({
       ...s,
       matches: s.matches.map(invalidate),
       cachedMatches: s.cachedMatches.map(invalidate),
-      pendingMatches: s.pendingMatches?.map(invalidate),
     }))
 
     this.shouldViewTransition = false
@@ -2734,7 +2897,7 @@ export class RouterCore<
     })
 
     const activeMatchIds = new Set(
-      [...this.state.matches, ...(this.state.pendingMatches ?? [])].map(
+      [...this.state.matches, ...(this.__pendingMatches ?? [])].map(
         (d) => d.id,
       ),
     )
@@ -2902,7 +3065,6 @@ export function getInitialRouterState(
     resolvedLocation: undefined,
     location,
     matches: [],
-    pendingMatches: [],
     cachedMatches: [],
     statusCode: 200,
   }

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -142,6 +142,8 @@ export async function hydrate(router: AnyRouter): Promise<any> {
       matches,
     }
   })
+  // Rebuild internal match lookup maps after directly setting matches
+  ;(router as any).rebuildMatchesById()
 
   // Allow the user to handle custom hydration data
   await router.options.hydrate?.(dehydratedData)

--- a/packages/router-core/tests/load.test.ts
+++ b/packages/router-core/tests/load.test.ts
@@ -83,9 +83,8 @@ describe('beforeLoad skip or exec', () => {
     const router = setup({ beforeLoad })
     const navigation = router.navigate({ to: '/foo' })
     expect(beforeLoad).toHaveBeenCalledTimes(1)
-    expect(router.state.pendingMatches).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
-    )
+    expect(router.state.status).toBe('pending')
+    expect(router.getMatch('/foo/foo')).toBeDefined()
     await navigation
     expect(router.state.location.pathname).toBe('/foo')
     expect(router.state.matches).toEqual(
@@ -265,9 +264,8 @@ describe('loader skip or exec', () => {
     const router = setup({ loader })
     const navigation = router.navigate({ to: '/foo' })
     expect(loader).toHaveBeenCalledTimes(1)
-    expect(router.state.pendingMatches).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
-    )
+    expect(router.state.status).toBe('pending')
+    expect(router.getMatch('/foo/foo')).toBeDefined()
     await navigation
     expect(router.state.location.pathname).toBe('/foo')
     expect(router.state.matches).toEqual(
@@ -548,6 +546,7 @@ describe('params.parse notFound', () => {
     const testRoute = new BaseRoute({
       getParentRoute: () => rootRoute,
       path: '/test/$id',
+      notFoundComponent: () => 'Not Found' as any,
       params: {
         parse: ({ id }: { id: string }) => {
           const parsed = parseInt(id, 10)
@@ -566,9 +565,7 @@ describe('params.parse notFound', () => {
 
     await router.load()
 
-    const match = router.state.pendingMatches?.find(
-      (m) => m.routeId === testRoute.id,
-    )
+    const match = router.state.matches.find((m) => m.routeId === testRoute.id)
 
     expect(match?.status).toBe('notFound')
   })

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -140,9 +140,7 @@ function RouteComp({
   setActiveId: (id: string) => void
 }) {
   const styles = useStyles()
-  const matches = createMemo(
-    () => routerState().pendingMatches || routerState().matches,
-  )
+  const matches = createMemo(() => routerState().matches)
   const match = createMemo(() =>
     routerState().matches.find((d) => d.routeId === route.id),
   )
@@ -308,11 +306,7 @@ export const BaseTanStackRouterDevtoolsPanel =
     })
 
     const activeMatch = createMemo(() => {
-      const matches = [
-        ...(routerState().pendingMatches ?? []),
-        ...routerState().matches,
-        ...routerState().cachedMatches,
-      ]
+      const matches = [...routerState().matches, ...routerState().cachedMatches]
       return matches.find(
         (d) => d.routeId === activeId() || d.id === activeId(),
       )
@@ -521,10 +515,7 @@ export const BaseTanStackRouterDevtoolsPanel =
                 </Match>
                 <Match when={currentTab() === 'matches'}>
                   <div>
-                    {(routerState().pendingMatches?.length
-                      ? routerState().pendingMatches
-                      : routerState().matches
-                    )?.map((match: any, _i: any) => {
+                    {routerState().matches.map((match: any, _i: any) => {
                       return (
                         <div
                           role="button"
@@ -679,15 +670,11 @@ export const BaseTanStackRouterDevtoolsPanel =
                 <div class={styles().matchDetailsInfoLabel}>
                   <div>State:</div>
                   <div class={styles().matchDetailsInfo}>
-                    {routerState().pendingMatches?.find(
+                    {routerState().cachedMatches.find(
                       (d: any) => d.id === activeMatch()?.id,
                     )
-                      ? 'Pending'
-                      : routerState().matches.find(
-                            (d: any) => d.id === activeMatch()?.id,
-                          )
-                        ? 'Active'
-                        : 'Cached'}
+                      ? 'Cached'
+                      : 'Active'}
                   </div>
                 </div>
                 <div class={styles().matchDetailsInfoLabel}>

--- a/packages/router-plugin/src/core/route-hmr-statement.ts
+++ b/packages/router-plugin/src/core/route-hmr-statement.ts
@@ -29,10 +29,7 @@ function handleRouteUpdate(
   // TODO: how to rebuild the tree if we add a new route?
   walkReplaceSegmentTree(newRoute, router.processedTree.segmentTree)
   const filter = (m: AnyRouteMatch) => m.routeId === oldRoute.id
-  if (
-    router.state.matches.find(filter) ||
-    router.state.pendingMatches?.find(filter)
-  ) {
+  if (router.state.matches.find(filter)) {
     router.invalidate({ filter })
   }
   function walkReplaceSegmentTree(

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@true.tsx
@@ -26,7 +26,7 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(newRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        if (router.state.matches.find(filter) || router.state.pendingMatches?.find(filter)) {
+        if (router.state.matches.find(filter)) {
           router.invalidate({
             filter
           });

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/function-declaration@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/function-declaration@true.tsx
@@ -26,7 +26,7 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(newRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        if (router.state.matches.find(filter) || router.state.pendingMatches?.find(filter)) {
+        if (router.state.matches.find(filter)) {
           router.invalidate({
             filter
           });

--- a/packages/router-plugin/tests/add-hmr/snapshots/solid/arrow-function@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/solid/arrow-function@true.tsx
@@ -25,7 +25,7 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(newRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        if (router.state.matches.find(filter) || router.state.pendingMatches?.find(filter)) {
+        if (router.state.matches.find(filter)) {
           router.invalidate({
             filter
           });

--- a/packages/solid-router/src/useMatch.tsx
+++ b/packages/solid-router/src/useMatch.tsx
@@ -84,14 +84,11 @@ export function useMatch<
       )
 
       if (match === undefined) {
-        // During navigation transitions, check if the match exists in pendingMatches
-        const pendingMatch = state.pendingMatches?.find((d: any) =>
-          opts.from ? opts.from === d.routeId : d.id === nearestMatchId(),
-        )
-
         // Determine if we should throw an error
         const shouldThrowError =
-          !pendingMatch && !state.isTransitioning && (opts.shouldThrow ?? true)
+          !state.isLoading &&
+          !state.isTransitioning &&
+          (opts.shouldThrow ?? true)
 
         return { match: undefined, shouldThrowError }
       }

--- a/packages/solid-router/tests/index.test.tsx
+++ b/packages/solid-router/tests/index.test.tsx
@@ -69,7 +69,6 @@ test('index true=true', () => {
 //     })
 
 //     const promise = router.mount()
-//     expect(router.store.pendingMatches[0].id).toBe('/')
 
 //     await promise
 //     expect(router.state.matches[0].id).toBe('/')
@@ -92,7 +91,6 @@ test('index true=true', () => {
 
 //     let promise = router.mount()
 
-//     expect(router.store.pendingMatches[0].id).toBe('/a')
 //     await promise
 //     expect(router.state.matches[0].id).toBe('/a')
 //   })
@@ -122,7 +120,6 @@ test('index true=true', () => {
 
 //     let promise = router.mount()
 
-//     expect(router.store.pendingMatches[1].id).toBe('/a/b')
 //     await promise
 //     expect(router.state.matches[1].id).toBe('/a/b')
 //   })
@@ -144,14 +141,11 @@ test('index true=true', () => {
 
 //     let promise = router.mount()
 
-//     expect(router.store.pendingMatches[0].id).toBe('/')
-
 //     await promise
 //     expect(router.state.matches[0].id).toBe('/')
 
 //     promise = router.navigate({ to: 'a' })
 //     expect(router.state.matches[0].id).toBe('/')
-//     expect(router.store.pendingMatches[0].id).toBe('a')
 
 //     await promise
 //     expect(router.state.matches[0].id).toBe('a')

--- a/packages/solid-router/tests/store-updates-during-navigation.test.tsx
+++ b/packages/solid-router/tests/store-updates-during-navigation.test.tsx
@@ -136,8 +136,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBeGreaterThanOrEqual(10) // WARN: this is flaky, and sometimes (rarely) is 12
-    expect(updates).toBeLessThanOrEqual(13)
+    expect(updates).toBeGreaterThanOrEqual(6) // WARN: this is flaky
+    expect(updates).toBeLessThanOrEqual(9)
   })
 
   test('redirection in preload', async () => {
@@ -173,7 +173,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Solid has different update counts than React due to different reactivity
-    expect(updates).toBe(8)
+    expect(updates).toBe(5)
   })
 
   test('nothing', async () => {
@@ -184,8 +184,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBeGreaterThanOrEqual(6) // WARN: this is flaky
-    expect(updates).toBeLessThanOrEqual(10)
+    expect(updates).toBeGreaterThanOrEqual(2) // WARN: this is flaky
+    expect(updates).toBeLessThanOrEqual(5)
   })
 
   test('not found in beforeLoad', async () => {
@@ -200,7 +200,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(7)
+    expect(updates).toBe(2)
   })
 
   test('hover preload, then navigate, w/ async loaders', async () => {
@@ -226,7 +226,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(16)
+    expect(updates).toBe(7)
   })
 
   test('navigate, w/ preloaded & async loaders', async () => {
@@ -242,8 +242,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBeGreaterThanOrEqual(9) // WARN: this is flaky, and sometimes (rarely) is 12
-    expect(updates).toBeLessThanOrEqual(13)
+    expect(updates).toBeGreaterThanOrEqual(2) // WARN: this is flaky
+    expect(updates).toBeLessThanOrEqual(5)
   })
 
   test('navigate, w/ preloaded & sync loaders', async () => {
@@ -260,7 +260,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Solid has one fewer update than React due to different reactivity
-    expect(updates).toBe(7)
+    expect(updates).toBe(3)
   })
 
   test('navigate, w/ previous navigation & async loader', async () => {
@@ -276,7 +276,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(5)
+    expect(updates).toBe(3)
   })
 
   test('preload a preloaded route w/ async loader', async () => {
@@ -294,6 +294,6 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(2)
+    expect(updates).toBe(3)
   })
 })

--- a/packages/solid-router/tests/store-updates-during-navigation.test.tsx
+++ b/packages/solid-router/tests/store-updates-during-navigation.test.tsx
@@ -156,7 +156,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Solid has different update counts than React due to different reactivity
-    expect(updates).toBe(6)
+    expect(updates).toBe(4)
   })
 
   test('sync beforeLoad', async () => {
@@ -173,7 +173,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Solid has different update counts than React due to different reactivity
-    expect(updates).toBe(5)
+    expect(updates).toBe(4)
   })
 
   test('nothing', async () => {
@@ -294,6 +294,6 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(3)
+    expect(updates).toBe(1)
   })
 })

--- a/packages/vue-router/src/useMatch.tsx
+++ b/packages/vue-router/src/useMatch.tsx
@@ -92,7 +92,7 @@ export function useMatch<
         shouldThrowError: false,
       }
     },
-  } as any) as Vue.Ref<{ match: any; shouldThrowError: boolean }>
+  })
 
   // Computed that throws when appropriate
   const result = Vue.computed(() => {

--- a/packages/vue-router/src/useMatch.tsx
+++ b/packages/vue-router/src/useMatch.tsx
@@ -70,57 +70,46 @@ export function useMatch<
 > {
   const nearestMatchId = opts.from ? injectDummyMatch() : injectMatch()
 
-  // Store to track pending error for deferred throwing
-  const pendingError = Vue.ref<Error | null>(null)
-
-  // Select the match from router state
-  const matchSelection = useRouterState({
+  // Select the match from router state, returning match and whether to throw
+  const matchState = useRouterState({
     select: (state: any) => {
       const match = state.matches.find((d: any) =>
         opts.from ? opts.from === d.routeId : d.id === nearestMatchId.value,
       )
 
       if (match === undefined) {
-        // During navigation transitions, check if the match exists in pendingMatches
-        const pendingMatch = state.pendingMatches?.find((d: any) =>
-          opts.from ? opts.from === d.routeId : d.id === nearestMatchId.value,
-        )
+        // Determine if we should throw an error
+        const shouldThrowError =
+          !state.isLoading &&
+          !state.isTransitioning &&
+          (opts.shouldThrow ?? true)
 
-        // If there's a pending match or we're transitioning, return undefined without throwing
-        if (pendingMatch || state.isTransitioning) {
-          pendingError.value = null
-          return undefined
-        }
-
-        // Store the error to throw later if shouldThrow is enabled
-        if (opts.shouldThrow ?? true) {
-          pendingError.value = new Error(
-            `Invariant failed: Could not find ${opts.from ? `an active match from "${opts.from}"` : 'a nearest match!'}`,
-          )
-        }
-
-        return undefined
+        return { match: undefined, shouldThrowError }
       }
 
-      pendingError.value = null
-      return opts.select ? opts.select(match) : match
+      return {
+        match: opts.select ? opts.select(match) : match,
+        shouldThrowError: false,
+      }
     },
-  } as any)
+  } as any) as Vue.Ref<{ match: any; shouldThrowError: boolean }>
 
-  // Throw the error if we have one - this happens after the selector runs
-  // Using a computed so the error is thrown when the return value is accessed
+  // Computed that throws when appropriate
   const result = Vue.computed(() => {
-    // Check for pending error first
-    if (pendingError.value) {
-      throw pendingError.value
+    const state = matchState.value
+    if (state.shouldThrowError) {
+      throw new Error(
+        `Invariant failed: Could not find ${opts.from ? `an active match from "${opts.from}"` : 'a nearest match!'}`,
+      )
     }
-    return matchSelection.value
+    return state.match
   })
 
-  // Also immediately throw if there's already an error from initial render
-  // This ensures errors are thrown even if the returned ref is never accessed
-  if (pendingError.value) {
-    throw pendingError.value
+  // Also immediately check for initial render throw
+  if (matchState.value.shouldThrowError) {
+    throw new Error(
+      `Invariant failed: Could not find ${opts.from ? `an active match from "${opts.from}"` : 'a nearest match!'}`,
+    )
   }
 
   return result as any

--- a/packages/vue-router/tests/index.test.tsx
+++ b/packages/vue-router/tests/index.test.tsx
@@ -69,7 +69,6 @@ test('index true=true', () => {
 //     })
 
 //     const promise = router.mount()
-//     expect(router.store.pendingMatches[0].id).toBe('/')
 
 //     await promise
 //     expect(router.state.matches[0].id).toBe('/')
@@ -92,7 +91,6 @@ test('index true=true', () => {
 
 //     let promise = router.mount()
 
-//     expect(router.store.pendingMatches[0].id).toBe('/a')
 //     await promise
 //     expect(router.state.matches[0].id).toBe('/a')
 //   })
@@ -122,7 +120,6 @@ test('index true=true', () => {
 
 //     let promise = router.mount()
 
-//     expect(router.store.pendingMatches[1].id).toBe('/a/b')
 //     await promise
 //     expect(router.state.matches[1].id).toBe('/a/b')
 //   })
@@ -144,14 +141,11 @@ test('index true=true', () => {
 
 //     let promise = router.mount()
 
-//     expect(router.store.pendingMatches[0].id).toBe('/')
-
 //     await promise
 //     expect(router.state.matches[0].id).toBe('/')
 
 //     promise = router.navigate({ to: 'a' })
 //     expect(router.state.matches[0].id).toBe('/')
-//     expect(router.store.pendingMatches[0].id).toBe('a')
 
 //     await promise
 //     expect(router.state.matches[0].id).toBe('a')

--- a/packages/vue-router/tests/store-updates-during-navigation.test.tsx
+++ b/packages/vue-router/tests/store-updates-during-navigation.test.tsx
@@ -138,7 +138,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Vue has different update counts than React/Solid due to different reactivity
-    expect(updates).toBe(27)
+    expect(updates).toBe(18)
   })
 
   test('redirection in preload', async () => {
@@ -157,7 +157,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Vue has different update counts than React/Solid due to different reactivity
-    expect(updates).toBe(10)
+    expect(updates).toBe(6)
   })
 
   test('sync beforeLoad', async () => {
@@ -174,7 +174,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Vue has different update counts than React/Solid due to different reactivity
-    expect(updates).toBe(25)
+    expect(updates).toBe(12)
   })
 
   test('nothing', async () => {
@@ -187,8 +187,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // Any change that increases this number should be investigated.
     // Note: Vue has different update counts than React/Solid due to different reactivity
     // Vue's reactivity model may cause slightly more updates due to computed refs
-    expect(updates).toBeGreaterThanOrEqual(14) // WARN: this is flaky
-    expect(updates).toBeLessThanOrEqual(26)
+    expect(updates).toBeGreaterThanOrEqual(6) // WARN: this is flaky
+    expect(updates).toBeLessThanOrEqual(14)
   })
 
   test('not found in beforeLoad', async () => {
@@ -204,7 +204,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Vue has different update counts than React/Solid due to different reactivity
-    expect(updates).toBe(22)
+    expect(updates).toBe(7)
   })
 
   test('hover preload, then navigate, w/ async loaders', async () => {
@@ -231,7 +231,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Vue has different update counts than React/Solid due to different reactivity
-    expect(updates).toBe(38)
+    expect(updates).toBe(17)
   })
 
   test('navigate, w/ preloaded & async loaders', async () => {
@@ -248,7 +248,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Vue has different update counts than React/Solid due to different reactivity
-    expect(updates).toBe(18)
+    expect(updates).toBe(6)
   })
 
   test('navigate, w/ preloaded & sync loaders', async () => {
@@ -265,7 +265,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Vue has different update counts than React/Solid due to different reactivity
-    expect(updates).toBe(16)
+    expect(updates).toBe(6)
   })
 
   test('navigate, w/ previous navigation & async loader', async () => {
@@ -282,7 +282,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
     // Note: Vue has different update counts than React/Solid due to different reactivity
-    expect(updates).toBe(12)
+    expect(updates).toBe(6)
   })
 
   test('preload a preloaded route w/ async loader', async () => {


### PR DESCRIPTION
This PR proposes that we don't expose the `pendingMatches`. These are updated many times during the loading process, when in reality what we want is "nothing while it loads, and then mount the routes". Each store update triggers *every router hook on the page* every time, and some navigations can cause *many* store updates because of the presence of `pendingMatches` in the store.


SSR benchmark (not the main target of this PR)

before
```
[1] 92k requests in 30.01s, 817 MB read
[1] 
[1] === SSR Benchmark Results ===
[1] Total requests: 71923
[1] Requests/sec: 2398
[1] Latency (avg): 2.75ms
[1] Latency (p99): 8ms
[1] Throughput: 25.98 MB/s
```


after

```
[1] 97k requests in 30.01s, 870 MB read
[1] 
[1] === SSR Benchmark Results ===
[1] Total requests: 76597
[1] Requests/sec: 2553.77
[1] Latency (avg): 2.66ms
[1] Latency (p99): 8ms
[1] Throughput: 27.67 MB/s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the public pendingMatches field from RouterState — rely on remaining router state fields and public helpers.

* **Documentation**
  * Removed guidance and examples referencing pendingMatches across framework docs and hooks.

* **New Features**
  * Added optional route configuration to supply a custom notFound component.

* **Devtools**
  * State views now reflect matches and cachedMatches only; pendingMatches is no longer shown.

* **Tests**
  * Updated assertions and expected update counts to align with public observation patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->