### PR TITLE
docs: fix duplicated word in document head management guide

### DIFF
--- a/docs/router/framework/react/guide/document-head-management.md
+++ b/docs/router/framework/react/guide/document-head-management.md
@@ -89,7 +89,7 @@ export const Route = createRootRoute({
 
 ### Single-Page Applications
 
-First, remove the `<title>` tag from the the index.html if you have set any.
+First, remove the `<title>` tag from the index.html if you have set any.
 
 ```tsx
 import { HeadContent } from '@tanstack/react-router'


### PR DESCRIPTION
Fixes a small typo in the React “Document Head Management” guide where “the” was duplicated (“from the the index.html” → “from the index.html”). Docs-only; no behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed duplicate word in React router documentation's guide on document head management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->