### PR TITLE
docs: update import statements for TanStack Router Vite plugin

### DIFF
--- a/docs/router/framework/react/how-to/setup-ssr.md
+++ b/docs/router/framework/react/how-to/setup-ssr.md
@@ -142,7 +142,7 @@ hydrateRoot(document, <RouterClient router={router} />)
 // vite.config.ts
 import path from 'node:path'
 import url from 'node:url'
-import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
+import { tanstackRouter } from '@tanstack/router-plugin/vite'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
@@ -151,7 +151,7 @@ const __dirname = path.dirname(__filename)
 
 export default defineConfig(({ isSsrBuild }) => ({
   plugins: [
-    TanStackRouterVite({
+    tanstackRouter({
       autoCodeSplitting: true,
     }),
     react(),
@@ -407,7 +407,7 @@ For streaming SSR, update your Vite config:
 // vite.config.ts
 export default defineConfig(({ isSsrBuild }) => ({
   plugins: [
-    TanStackRouterVite({
+    tanstackRouter({
       autoCodeSplitting: true,
       enableStreaming: true, // Enable streaming support
     }),

--- a/docs/router/framework/react/how-to/test-file-based-routing.md
+++ b/docs/router/framework/react/how-to/test-file-based-routing.md
@@ -38,11 +38,11 @@ Create `vitest.config.ts` with file-based routing support:
 ```ts
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
+import { tanstackRouter } from '@tanstack/router-plugin/vite'
 
 export default defineConfig({
   plugins: [
-    TanStackRouterVite({
+    tanstackRouter({
       // Configure for test environment
       routesDirectory: './src/routes',
       generatedRouteTree: './src/routeTree.gen.ts',
@@ -898,7 +898,7 @@ Error: Cannot find module '../routeTree.gen'
 // vitest.config.ts
 export default defineConfig({
   plugins: [
-    TanStackRouterVite(), // Ensure this runs before tests
+    tanstackRouter(), // Ensure this runs before tests
     react(),
   ],
   test: {

--- a/docs/router/framework/react/how-to/use-environment-variables.md
+++ b/docs/router/framework/react/how-to/use-environment-variables.md
@@ -436,13 +436,13 @@ export const Route = createFileRoute('/api-data')({
 // vite.config.ts
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { tanstackRouter } from '@tanstack/router-plugin/vite'
 
 export default defineConfig({
   plugins: [
     react(),
-    // TanStackRouterVite generates route tree and enables file-based routing
-    TanStackRouterVite(),
+    // tanstackRouter generates route tree and enables file-based routing
+    tanstackRouter(),
   ],
   // Environment variables are handled automatically
   // Custom environment variable handling:


### PR DESCRIPTION
Updates the React Router documentation examples to use the current TanStack Router Vite plugin import (tanstackRouter from @tanstack/router-plugin/vite) and updates plugin usage in sample vite.config.ts / vitest.config.ts snippets accordingly.

SSR setup docs: replaced TanStackRouterVite example usage with tanstackRouter(...) in Vite config snippets.
File-based routing testing docs: updated vitest.config.ts example to use tanstackRouter(...) and aligned the “ensure this runs before tests” snippet.
Environment variables docs: corrected the Vite plugin import and ensured examples consistently reference @tanstack/router-plugin/vite.

Scope / Impact
Documentation-only change (no runtime code changes).
Improves correctness and consistency across multiple React Router “how-to” guides.

Testing
Not applicable (docs update only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React SSR, file-based routing, and environment variable setup guides to reflect the latest Vite plugin configuration changes and import paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->