### PR TITLE
fix(router-core): don't set isServer if NODE_ENV test

### DIFF
--- a/packages/router-core/src/isServer/server.ts
+++ b/packages/router-core/src/isServer/server.ts
@@ -1,1 +1,1 @@
-export const isServer = true
+export const isServer = process.env.NODE_ENV === 'test' ? undefined : true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced server environment detection to properly handle test environments separately from production configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->