### PR TITLE
docs(start): fix ISR guide link to data loading

### DIFF
--- a/docs/start/framework/react/guide/isr.md
+++ b/docs/start/framework/react/guide/isr.md
@@ -442,5 +442,5 @@ Track key metrics:
 - [Static Prerendering](./static-prerendering.md) - Build-time page generation
 - [Hosting](./hosting.md) - CDN deployment configurations
 - [Server Functions](./server-functions.md) - Creating dynamic data endpoints
-- [Data Loading](../../router/framework/react/guide/data-loading.md) - Client-side cache control
+- [Data Loading](../../../../router/framework/react/guide/data-loading.md) - Client-side cache control
 - [Middleware](./middleware.md) - Request/response customization


### PR DESCRIPTION
Fixes a broken relative link in the TanStack Start (React) ISR guide.

- Updates the “Data Loading” link in the Related Resources section to correctly point to the Router docs.
- Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed the Data Loading reference link in the Incremental Static Regeneration (ISR) guide to ensure users can properly navigate to related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->