### PR TITLE
fix: add `@tanstack/start-client-core` to stub packages

### DIFF
--- a/packages/start-plugin-core/src/start-compiler-plugin/compiler.ts
+++ b/packages/start-plugin-core/src/start-compiler-plugin/compiler.ts
@@ -455,6 +455,14 @@ export class StartCompiler {
         ['createClientOnlyFn', 'ClientOnlyFn'],
       ]),
     )
+    this.knownRootImports.set(
+      '@tanstack/start-client-core',
+      new Map<string, Kind>([
+        ['createIsomorphicFn', 'IsomorphicFn'],
+        ['createServerOnlyFn', 'ServerOnlyFn'],
+        ['createClientOnlyFn', 'ClientOnlyFn'],
+      ]),
+    )
 
     await Promise.all(
       this.options.lookupConfigurations.map(async (config) => {


### PR DESCRIPTION
Fixes #6583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized compiler import resolution for TanStack Start client-core library functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->