### PR TITLE
docs: replace deprecated create-tsrouter-app and create-start-app with @tanstack/cli create

### DIFF
--- a/docs/router/how-to/integrate-shadcn-ui.md
+++ b/docs/router/how-to/integrate-shadcn-ui.md
@@ -27,7 +27,7 @@ This guide covers setting up Shadcn/ui with TanStack Router, including solutions
 **Option 1: New project with TanStack Router template**
 
 ```bash
-npx create-tsrouter-app@latest my-app --template file-router --tailwind --add-ons shadcn
+npx @tanstack/cli create my-app --add-ons shadcn
 ```
 
 **Option 2: Add to existing TanStack Router project**

--- a/docs/router/how-to/setup-ssr.md
+++ b/docs/router/how-to/setup-ssr.md
@@ -10,7 +10,7 @@ title: How to Set Up Server-Side Rendering (SSR)
 ## Quick Start with TanStack Start
 
 ```bash
-npx create-tsrouter-app@latest my-app --template start
+npx @tanstack/cli create my-app
 cd my-app
 npm run dev
 ```

--- a/docs/router/quick-start.md
+++ b/docs/router/quick-start.md
@@ -9,8 +9,8 @@ The fastest way to get started with TanStack Router is to scaffold a new project
 
 <!-- ::start:tabs variant="package-managers" mode="local-install" -->
 
-react: create-tsrouter-app@latest
-solid: create-tsrouter-app@latest --framework solid
+react: npx @tanstack/cli create
+solid: npx @tanstack/cli create --framework solid
 
 <!-- ::end:tabs -->
 
@@ -25,7 +25,7 @@ The CLI will guide you through a short series of prompts to customize your setup
 Once complete, a new project will be generated with TanStack Router installed and ready to use.
 
 > [!TIP]
-> For full details on available options and templates, visit the [`create-tsrouter-app` documentation](https://github.com/TanStack/create-tsrouter-app/tree/main/cli/create-tsrouter-app).
+> For full details on available options and templates, visit the [`@tanstack/cli` documentation](https://tanstack.com/cli/latest/docs/quick-start).
 
 ## Routing Options
 
@@ -37,8 +37,8 @@ The file-based approach is the recommended option for most projects. It automati
 
 <!-- ::start:tabs variant="package-manager" mode="local-install" -->
 
-react: create-tsrouter-app@latest my-app --template file-router
-solid: create-tsrouter-app@latest my-app --framework solid --template file-router
+react: npx @tanstack/cli create my-app
+solid: npx @tanstack/cli create my-app --framework solid
 
 <!-- ::end:tabs -->
 
@@ -46,10 +46,13 @@ solid: create-tsrouter-app@latest my-app --framework solid --template file-route
 
 If you prefer to define routes programmatically, you can use the code-based route configuration. This approach gives you full control over routing logic.
 
+> [!NOTE]
+> When using `@tanstack/cli create`, you'll be prompted to choose between file-based and code-based routing during interactive setup. Select **"code-router"** when asked about the routing mode.
+
 <!-- ::start:tabs variant="package-manager" mode="local-install" -->
 
-react: create-tsrouter-app@latest my-app
-solid: create-tsrouter-app@latest my-app --framework solid
+react: npx @tanstack/cli create my-app
+solid: npx @tanstack/cli create my-app --framework solid
 
 <!-- ::end:tabs -->
 

--- a/docs/start/framework/react/tutorial/fetching-external-api.md
+++ b/docs/start/framework/react/tutorial/fetching-external-api.md
@@ -29,13 +29,13 @@ The complete code for this tutorial is available on [GitHub](https://github.com/
 First, let's create a new TanStack Start project:
 
 ```bash
-pnpx create-start-app movie-discovery
+pnpx @tanstack/cli create movie-discovery
 cd movie-discovery
 ```
 
 When this script runs, it will ask you a few setup questions. You can either pick choices that work for you or just press enter to accept the defaults.
 
-Optionally, you can pass in a `--add-on` flag to get options such as Shadcn, Clerk, Convex, TanStack Query, etc.
+Optionally, you can pass in a `--add-ons` flag to get options such as Shadcn, Clerk, Convex, TanStack Query, etc.
 
 Once setup is complete, install dependencies and start the development server:
 

--- a/docs/start/framework/react/tutorial/reading-writing-file.md
+++ b/docs/start/framework/react/tutorial/reading-writing-file.md
@@ -41,7 +41,7 @@ cd devjokes
 
 When this script runs, it will ask you a few setup questions. You can either pick choices that work for you or just press enter to accept the defaults.
 
-Optionally, you can pass in a `--add-on` flag to get options such as Shadcn, Clerk, Convex, TanStack Query, etc.
+Optionally, you can pass in a `--add-ons` flag to get options such as Shadcn, Clerk, Convex, TanStack Query, etc.
 
 Once setup is complete, install dependencies and start the development server:
 

--- a/examples/react/i18n-paraglide/index.html
+++ b/examples/react/i18n-paraglide/index.html
@@ -5,10 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-tsrouter-app"
-    />
+    <meta name="description" content="Web site created using TanStack CLI" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>Create TanStack App - i18n-paraglide</title>

--- a/examples/react/start-bun/README.md
+++ b/examples/react/start-bun/README.md
@@ -26,7 +26,7 @@ npx gitpick TanStack/router/tree/main/examples/react/start-bun start-bun
 This project was created with TanStack Start:
 
 ```bash
-bunx create-start-app@latest
+bunx @tanstack/cli create
 ```
 
 Install dependencies:

--- a/examples/solid/i18n-paraglide/index.html
+++ b/examples/solid/i18n-paraglide/index.html
@@ -5,10 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-tsrouter-app"
-    />
+    <meta name="description" content="Web site created using TanStack CLI" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>Create TanStack App - i18n-paraglide</title>

--- a/examples/solid/start-bun/README.md
+++ b/examples/solid/start-bun/README.md
@@ -15,7 +15,7 @@ An optimized production server for TanStack Start applications using Bun, implem
 This project was created with TanStack Start:
 
 ```bash
-bunx create-start-app@latest
+bunx @tanstack/cli create
 ```
 
 Install dependencies:


### PR DESCRIPTION
[The `create-tsrouter-app` and `create-start-app` CLI tools are deprecated](https://github.com/TanStack/cli/blob/daade5fa2d9e9bda92bda473d322b669bf4f9df0/cli-aliases/create-start-app/src/index.ts#L2).
This PR replaces all references with the recommended `npx @tanstack/cli create`.

Also removed obsolete flags:
- `--template` (not supported in `@tanstack/cli create`)
- `--tailwind` (always enabled since [TanStack/cli@337eeba](https://github.com/TanStack/cli/commit/337eeba))

Docs-only change. No code behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project initialization commands across tutorials, quick-starts, and READMEs to use the TanStack CLI flow.
  * Updated example snippets and guidance text to reference the current CLI docs.
  * Renamed the user-facing CLI flag from --add-on to --add-ons in examples and walkthroughs.
  * Updated site meta descriptions in example projects to reference the TanStack CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->