### PR TITLE
Enhance useAuth with hydration support for tanstack start authentication example

### DIFF
--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -154,8 +154,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 }
 
 export function useAuth() {
+  const hydrated = useHydrated()
   const context = useContext(AuthContext)
+
   if (!context) {
+    if (!hydrated) {
+       const { data: user, isLoading, refetch } = useServerFn(getCurrentUserFn)
+       return { user, isLoading, refetch }
+    }
     throw new Error('useAuth must be used within AuthProvider')
   }
   return context


### PR DESCRIPTION
This is a real issue during development. HMR is followed subsequently by SSR at that time hydration isn't completed and it throws error. But if we check hydration completion and retrieve data independently things work smoothly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication initialization during app startup with enhanced hydration support to ensure reliable user data loading when the authentication context isn't immediately available.
  * Refined authentication error handling during app initialization by introducing server-side fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->