### PR TITLE
Enhance useAuth with hydration support for tanstack start authentication example

### DIFF
--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -126,6 +126,7 @@ Share authentication state across your application:
 ```tsx
 // contexts/auth.tsx
 import { createContext, useContext, ReactNode } from 'react'
+import { useHydrated } from '@tanstack/react-router' 
 import { useServerFn } from '@tanstack/react-start'
 import { getCurrentUserFn } from '../server/auth'
 
@@ -155,7 +156,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
 export function useAuth() {
   const context = useContext(AuthContext)
+  const { data: user, isLoading, refetch } = useServerFn(getCurrentUserFn)
+  const hydrated = useHydrated()
+
   if (!context) {
+    if (!hydrated) {
+      return {
+        user,
+        isLoading,
+        refetch,
+      }
+    }
     throw new Error('useAuth must be used within AuthProvider')
   }
   return context


### PR DESCRIPTION
This is a real issue during development. HMR is followed subsequently by SSR at that time hydration isn't completed and it throws error. But if we check hydration completion and retrieve data independently things work smoothly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication context behavior has been enhanced to better handle application startup scenarios and initialization phases. The system now provides more reliable access to authentication state during the app's loading process and prevents errors that could interrupt the user experience, ensuring a smoother and more stable authentication flow during page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->