### PR TITLE
docs: Add missing mask option to documentation

### DIFF
--- a/docs/router/api/router/RouterOptionsType.md
+++ b/docs/router/api/router/RouterOptionsType.md
@@ -290,7 +290,7 @@ When both `basepath` and `rewrite` are configured, they are automatically compos
 - Type: `boolean`
 - Optional
 - Defaults to `false`
-- If `true`, route masks will, by default, be removed when the page is reloaded. This can be overridden on a per-mask basis by setting the `unmaskOnReload` option on the mask, or on a per-navigation basis by setting the `unmaskOnReload` option in the `Navigate` options.
+- If `true`, route masks will, by default, be removed when the page is reloaded. This can be overridden on a per-mask basis by setting `unmaskOnReload` on the mask, or on a per-navigation basis by setting `mask.unmaskOnReload` in [`NavigateOptions`](./NavigateOptionsType.md).
 
 ### `Wrap` property
 

--- a/docs/router/api/router/RouterType.md
+++ b/docs/router/api/router/RouterType.md
@@ -81,7 +81,7 @@ Builds a new parsed location object that can be used later to navigate to a new 
     - `unmaskOnReload`
       - Type: `boolean`
       - Optional
-      - If `true`, the route mask will be removed when the page is reloaded. This can be overridden on a per-navigation basis by setting the `unmaskOnReload` option in the `Navigate` options.
+      - If `true`, the route mask will be removed when the page is reloaded. This can be overridden on a per-navigation basis by setting `mask.unmaskOnReload` in [`NavigateOptions`](./NavigateOptionsType.md).
 
 ### `.commitLocation` method
 

--- a/docs/router/api/router/ToMaskOptionsType.md
+++ b/docs/router/api/router/ToMaskOptionsType.md
@@ -3,12 +3,18 @@ id: ToMaskOptionsType
 title: ToMaskOptions type
 ---
 
-The `ToMaskOptions` type extends the [`ToOptions`](./ToOptionsType.md) type and describes additional options available when using route masks.
+The `ToMaskOptions` type includes the same destination fields as [`ToOptions`](./ToOptionsType.md), excluding `mask`, and adds options specific to route masking.
 
 ```tsx
-type ToMaskOptions = ToOptions & {
-  unmaskOnReload?: boolean
-}
+type ToMaskOptions = {
+  from?: ValidRoutePath | string
+  to?: ValidRoutePath | string
+  hash?: true | string | ((prev?: string) => string)
+  state?: true | HistoryState | ((prev: HistoryState) => HistoryState)
+} & SearchParamOptions &
+  PathParamOptions & {
+    unmaskOnReload?: boolean
+  }
 ```
 
 - [`ToOptions`](./ToOptionsType.md)

--- a/docs/router/api/router/ToOptionsType.md
+++ b/docs/router/api/router/ToOptionsType.md
@@ -3,7 +3,7 @@ id: ToOptionsType
 title: ToOptions type
 ---
 
-The `ToOptions` type contains several properties that can be used to describe a router destination.
+The `ToOptions` type contains several properties that can be used to describe a router destination, including `mask` for route masking.
 
 ```tsx
 type ToOptions = {
@@ -12,7 +12,8 @@ type ToOptions = {
   hash?: true | string | ((prev?: string) => string)
   state?: true | HistoryState | ((prev: HistoryState) => HistoryState)
 } & SearchParamOptions &
-  PathParamOptions
+  PathParamOptions &
+  MaskOptions
 
 type SearchParamOptions = {
   search?: true | TToSearch | ((prev: TFromSearch) => TToSearch)
@@ -23,5 +24,9 @@ type PathParamOptions = {
     | true
     | Record<string, TPathParam>
     | ((prev: TFromParams) => TToParams)
+}
+
+type MaskOptions = {
+  mask?: ToMaskOptions<TRouter, TMaskFrom, TMaskTo>
 }
 ```

--- a/docs/router/guide/navigation.md
+++ b/docs/router/guide/navigation.md
@@ -45,6 +45,27 @@ type ToOptions<
   state?:
     | Record<string, any>
     | ((prevState: Record<string, unknown>) => Record<string, unknown>)
+  // `mask` is another navigation object used to mask the URL shown in the browser for this navigation.
+  mask?: ToMaskOptions<TRouteTree>
+}
+
+type ToMaskOptions<TRouteTree extends AnyRoute = AnyRoute> = {
+  // `from`, `to`, `params`, `search`, `hash`, and `state` behave the same as in `ToOptions`.
+  // `mask` itself is not allowed inside `ToMaskOptions`.
+  from?: string
+  to: string
+  params:
+    | Record<string, unknown>
+    | ((prevParams: Record<string, unknown>) => Record<string, unknown>)
+  search:
+    | Record<string, unknown>
+    | ((prevSearch: Record<string, unknown>) => Record<string, unknown>)
+  hash?: string | ((prevHash: string) => string)
+  state?:
+    | Record<string, any>
+    | ((prevState: Record<string, unknown>) => Record<string, unknown>)
+  // If true, the URL will unmask on page reload.
+  unmaskOnReload?: boolean
 }
 ```
 
@@ -85,6 +106,8 @@ export type NavigateOptions<
 }
 ```
 
+`NavigateOptions` includes all `ToOptions` fields, including `mask`.
+
 ### `LinkOptions` Interface
 
 Anywhere an actual `<a>` tag the `LinkOptions` interface which extends `NavigateOptions` will be available:
@@ -112,6 +135,8 @@ export type LinkOptions<
   disabled?: boolean
 }
 ```
+
+Since `LinkOptions` extends `NavigateOptions`, it also supports `mask`.
 
 ## Navigation API
 


### PR DESCRIPTION
closes #6446

This PR improves the docs around route masking and navigation options, in response to #6446.
`router.navigate()` already supports masked navigation, but that support was not easy to find in the docs because mask was not explicitly surfaced in docs.

  ## Changes

- Added mask to the documented ToOptions shape (via MaskOptions).
- Updated ToMaskOptions docs to clarify that it:
    - uses the same destination fields as ToOptions
    - does not allow nested mask
    - adds optional unmaskOnReload
- Updated wording in RouterOptionsType and RouterType to show the per-navigation override as mask.unmaskOnReload in NavigateOptions.
- Updated navigation.md to explicitly state:
    - ToOptions includes mask
    - NavigateOptions includes all ToOptions fields
    - LinkOptions also supports mask through NavigateOptions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified route-masking navigation docs: added a distinct mask option for navigation, introduced an explicit ToMaskOptions shape listing destination fields and masking-specific flags, and updated guidance to reference unmaskOnReload as a mask-level setting (including where to override).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->