### PR TITLE
add internal docs for code splitting

### DIFF
--- a/packages/router-plugin/ARCHITECTURE-CODE-SPLITTING.md
+++ b/packages/router-plugin/ARCHITECTURE-CODE-SPLITTING.md
@@ -465,13 +465,13 @@ Properties in the same inner array end up in the same split module:
 
 ```ts
 // Default: 3 separate split module IDs (often 3 separate chunks)
-[['component'], ['errorComponent'], ['notFoundComponent']]
-
-// Combined: component + loader in one module, error in another
-[['component', 'loader'], ['errorComponent']]
-
-// All in one module
-[['component', 'loader', 'errorComponent', 'notFoundComponent']]
+;[['component'], ['errorComponent'], ['notFoundComponent']][
+  // Combined: component + loader in one module, error in another
+  (['component', 'loader'], ['errorComponent'])
+][
+  // All in one module
+  ['component', 'loader', 'errorComponent', 'notFoundComponent']
+]
 ```
 
 ### Configuring Groupings


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture documentation for the code-splitting system. Documentation provides in-depth reference material covering the Babel transformation pipeline, virtual file mechanisms, shared bindings discovery and extraction, code-split groupings, compiler functions, and plugin interactions. Includes detailed examples, configuration guidance, module graph diagrams illustrating various scenarios, and coverage of framework support and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->