### PR TITLE
docs(solid): fix broken RouterOptions link in path params guide

### DIFF
--- a/docs/router/framework/solid/guide/path-params.md
+++ b/docs/router/framework/solid/guide/path-params.md
@@ -746,7 +746,7 @@ Optional path parameters provide a powerful and flexible foundation for implemen
 
 ## Allowed Characters
 
-By default, path params are escaped with `encodeURIComponent`. If you want to allow other valid URI characters (e.g. `@` or `+`), you can specify that in your [RouterOptions](../api/router/RouterOptionsType.md#pathparamsallowedcharacters-property).
+By default, path params are escaped with `encodeURIComponent`. If you want to allow other valid URI characters (e.g. `@` or `+`), you can specify that in your [RouterOptions](https://tanstack.com/router/latest/docs/framework/solid/api/router/RouterOptionsType#pathparamsallowedcharacters-property).
 
 Example usage:
 


### PR DESCRIPTION
Fixed a broken link in the Solid “Path Params” guide: the RouterOptions reference pointed to a non-existent Solid API markdown file. This updates it to the existing RouterOptionsType doc/anchor so the link resolves and docs link-check passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the "Allowed Characters" reference for path parameter configuration to point to the official absolute URL, improving link reliability and access to the latest API docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->