### PR TITLE
refactor(router-devtools-core): restore visibility into internalized cached and pending matches

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2589,7 +2589,11 @@ export class RouterCore<
 
   updateMatch: UpdateMatchFn = (id, updater) => {
     this.startTransition(() => {
-      if (this.__storeDevtoolsMatches.state.pendingMatches?.some((d) => d.id === id)) {
+      if (
+        this.__storeDevtoolsMatches.state.pendingMatches?.some(
+          (d) => d.id === id,
+        )
+      ) {
         this.__storeDevtoolsMatches.setState((s) => ({
           ...s,
           pendingMatches: s.pendingMatches?.map((d) =>
@@ -2607,7 +2611,9 @@ export class RouterCore<
         return
       }
 
-      if (this.__storeDevtoolsMatches.state.cachedMatches.some((d) => d.id === id)) {
+      if (
+        this.__storeDevtoolsMatches.state.cachedMatches.some((d) => d.id === id)
+      ) {
         this.__storeDevtoolsMatches.setState((s) => ({
           ...s,
           cachedMatches: filterRedirectedMatches(
@@ -2726,7 +2732,9 @@ export class RouterCore<
       this.__storeDevtoolsMatches.setState((s) => ({
         ...s,
         cachedMatches: filterRedirectedMatches(
-          s.cachedMatches.filter((m) => !filter(m as MakeRouteMatchUnion<this>)),
+          s.cachedMatches.filter(
+            (m) => !filter(m as MakeRouteMatchUnion<this>),
+          ),
         ),
       }))
     } else {
@@ -2783,9 +2791,7 @@ export class RouterCore<
       [
         ...this.state.matches,
         ...(this.__storeDevtoolsMatches.state.pendingMatches ?? []),
-      ].map(
-        (d) => d.id,
-      ),
+      ].map((d) => d.id),
     )
 
     const loadedMatchIds = new Set([

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -285,16 +285,19 @@ export const BaseTanStackRouterDevtoolsPanel =
       '',
     )
 
-    const [devtoolsMatches, setDevtoolsMatches] = createSignal<DevtoolsMatchesState>({
-      pendingMatches: [],
-      cachedMatches: [],
-    })
+    const [devtoolsMatches, setDevtoolsMatches] =
+      createSignal<DevtoolsMatchesState>({
+        pendingMatches: [],
+        cachedMatches: [],
+      })
     const [history, setHistory] = createSignal<Array<AnyRouteMatch>>([])
     const [hasHistoryOverflowed, setHasHistoryOverflowed] = createSignal(false)
     createEffect(() => {
       const devtoolsMatchesStore = (router() as any).__storeDevtoolsMatches as {
         state: DevtoolsMatchesState
-        subscribe: (listener: (state: DevtoolsMatchesState) => void) => () => void
+        subscribe: (
+          listener: (state: DevtoolsMatchesState) => void,
+        ) => () => void
       }
 
       invariant(

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -67,6 +67,11 @@ export interface BaseDevtoolsPanelOptions {
 
 const HISTORY_LIMIT = 15
 
+type DevtoolsMatchesState = {
+  pendingMatches?: Array<AnyRouteMatch>
+  cachedMatches: Array<AnyRouteMatch>
+}
+
 function Logo(props: any) {
   const { className, ...rest } = props
   const styles = useStyles()
@@ -102,6 +107,7 @@ function NavigateLink(props: {
 
 function RouteComp({
   routerState,
+  devtoolsMatches,
   router,
   route,
   isRoot,
@@ -133,6 +139,7 @@ function RouteComp({
       MakeRouteMatchUnion
     >
   >
+  devtoolsMatches: Accessor<DevtoolsMatchesState>
   router: Accessor<AnyRouter>
   route: AnyRoute
   isRoot?: boolean
@@ -140,12 +147,12 @@ function RouteComp({
   setActiveId: (id: string) => void
 }) {
   const styles = useStyles()
-  const matches = createMemo(() =>
-    routerState().status === 'pending'
-      ? router().matchRoutes(router().latestLocation)
-      : routerState().matches,
+  const matches = createMemo(
+    () => devtoolsMatches().pendingMatches || routerState().matches,
   )
-  const match = createMemo(() => matches().find((d) => d.routeId === route.id))
+  const match = createMemo(() =>
+    routerState().matches.find((d) => d.routeId === route.id),
+  )
 
   const param = createMemo(() => {
     try {
@@ -231,6 +238,7 @@ function RouteComp({
             .map((r) => (
               <RouteComp
                 routerState={routerState}
+                devtoolsMatches={devtoolsMatches}
                 router={router}
                 route={r}
                 activeId={activeId}
@@ -277,12 +285,32 @@ export const BaseTanStackRouterDevtoolsPanel =
       '',
     )
 
+    const [devtoolsMatches, setDevtoolsMatches] = createSignal<DevtoolsMatchesState>({
+      pendingMatches: [],
+      cachedMatches: [],
+    })
     const [history, setHistory] = createSignal<Array<AnyRouteMatch>>([])
     const [hasHistoryOverflowed, setHasHistoryOverflowed] = createSignal(false)
-    const pendingMatches = createMemo(() =>
-      routerState().status === 'pending'
-        ? router().matchRoutes(router().latestLocation)
-        : [],
+    createEffect(() => {
+      const devtoolsMatchesStore = (router() as any).__storeDevtoolsMatches as {
+        state: DevtoolsMatchesState
+        subscribe: (listener: (state: DevtoolsMatchesState) => void) => () => void
+      }
+
+      invariant(
+        devtoolsMatchesStore,
+        'No internal devtools store was found on the router instance.',
+      )
+
+      setDevtoolsMatches(devtoolsMatchesStore.state)
+      const unsubscribe = devtoolsMatchesStore.subscribe((state) => {
+        setDevtoolsMatches(state)
+      })
+      onCleanup(unsubscribe)
+    })
+
+    const pendingMatches = createMemo(
+      () => devtoolsMatches().pendingMatches ?? [],
     )
     const displayedMatches = createMemo(() =>
       pendingMatches().length ? pendingMatches() : routerState().matches,
@@ -316,7 +344,11 @@ export const BaseTanStackRouterDevtoolsPanel =
     })
 
     const activeMatch = createMemo(() => {
-      const matches = [...pendingMatches(), ...routerState().matches]
+      const matches = [
+        ...pendingMatches(),
+        ...routerState().matches,
+        ...devtoolsMatches().cachedMatches,
+      ]
       return matches.find(
         (d) => d.routeId === activeId() || d.id === activeId(),
       )
@@ -326,10 +358,14 @@ export const BaseTanStackRouterDevtoolsPanel =
       () => Object.keys(routerState().location.search).length,
     )
 
-    const explorerState = createMemo(() => {
+    const explorerState = createMemo<Record<string, unknown>>(() => {
       return {
         ...router(),
-        state: routerState(),
+        state: {
+          ...routerState(),
+          pendingMatches: devtoolsMatches().pendingMatches,
+          cachedMatches: devtoolsMatches().cachedMatches,
+        },
       }
     })
 
@@ -347,12 +383,13 @@ export const BaseTanStackRouterDevtoolsPanel =
             ] as const
           ).map((d) => (dd) => dd !== d),
         )
-          .map((key) => [key, (explorerState() as any)[key]])
+          .map((key) => [key, explorerState()[key]] as const)
           .filter(
             (d) =>
               typeof d[1] !== 'function' &&
               ![
                 '__store',
+                '__storeDevtoolsMatches',
                 'basepath',
                 'injectedHtml',
                 'subscribers',
@@ -516,6 +553,7 @@ export const BaseTanStackRouterDevtoolsPanel =
                 <Match when={currentTab() === 'routes'}>
                   <RouteComp
                     routerState={routerState}
+                    devtoolsMatches={devtoolsMatches}
                     router={router}
                     route={router().routeTree}
                     isRoot
@@ -609,6 +647,49 @@ export const BaseTanStackRouterDevtoolsPanel =
               </Switch>
             </div>
           </div>
+          {devtoolsMatches().cachedMatches.length ? (
+            <div class={styles().cachedMatchesContainer}>
+              <div class={styles().detailsHeader}>
+                <div>Cached Matches</div>
+                <div class={styles().detailsHeaderInfo}>
+                  age / staleTime / gcTime
+                </div>
+              </div>
+              <div>
+                {devtoolsMatches().cachedMatches.map((match: any) => {
+                  return (
+                    <div
+                      role="button"
+                      aria-label={`Open match details for ${match.id}`}
+                      onClick={() =>
+                        setActiveId(activeId() === match.id ? '' : match.id)
+                      }
+                      class={cx(styles().matchRow(match === activeMatch()))}
+                    >
+                      <div
+                        class={cx(
+                          styles().matchIndicator(getStatusColor(match)),
+                        )}
+                      />
+                      <NavigateLink
+                        left={
+                          <NavigateButton
+                            to={match.pathname}
+                            params={match.params}
+                            search={match.search}
+                            router={router}
+                          />
+                        }
+                        right={<AgeTicker match={match} router={router} />}
+                      >
+                        <code class={styles().matchID}>{`${match.id}`}</code>
+                      </NavigateLink>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          ) : null}
         </div>
         {activeMatch() && activeMatch()?.status ? (
           <div class={styles().thirdContainer}>
@@ -641,7 +722,11 @@ export const BaseTanStackRouterDevtoolsPanel =
                       (d: any) => d.id === activeMatch()?.id,
                     )
                       ? 'Pending'
-                      : 'Active'}
+                      : routerState().matches.find(
+                            (d: any) => d.id === activeMatch()?.id,
+                          )
+                        ? 'Active'
+                        : 'Cached'}
                   </div>
                 </div>
                 <div class={styles().matchDetailsInfoLabel}>

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -296,7 +296,10 @@ export const BaseTanStackRouterDevtoolsPanel =
       const devtoolsMatchesStore = (router() as any).__storeDevtoolsMatches as {
         state: DevtoolsMatchesState
         subscribe: (
-          listener: (state: DevtoolsMatchesState) => void,
+          listener: (state: {
+            prevVal: DevtoolsMatchesState
+            currentVal: DevtoolsMatchesState
+          }) => void,
         ) => () => void
       }
 
@@ -307,7 +310,7 @@ export const BaseTanStackRouterDevtoolsPanel =
 
       setDevtoolsMatches(devtoolsMatchesStore.state)
       const unsubscribe = devtoolsMatchesStore.subscribe((state) => {
-        setDevtoolsMatches(state)
+        setDevtoolsMatches(state.currentVal)
       })
       onCleanup(unsubscribe)
     })

--- a/packages/router-devtools-core/src/useStyles.tsx
+++ b/packages/router-devtools-core/src/useStyles.tsx
@@ -399,6 +399,11 @@ const stylesFactory = (shadowDOMTarget?: ShadowRoot) => {
       flex: 1 1 auto;
       overflow-y: auto;
     `,
+    cachedMatchesContainer: css`
+      flex: 1 1 auto;
+      overflow-y: auto;
+      max-height: 50%;
+    `,
     historyContainer: css`
       display: flex;
       flex: 1 1 auto;


### PR DESCRIPTION
after having internalized `pendingMatches` and `cachedMatches` (https://github.com/TanStack/router/pull/6673), they are not accessible outside of `router-core` anymore.

This PR restores the devtools visibility into those matches by exposing them as a separate store, that will not have the overhead of being consumed throughout the app.

In a follow-up PR, we can further reduce the overhead of reactivity by using `createServerStore` instead of actual tanstack/store when not running on the client, or not running in dev mode.