### PR TITLE
docs: Fixed filenames

### DIFF
--- a/docs/router/guide/path-params.md
+++ b/docs/router/guide/path-params.md
@@ -247,7 +247,7 @@ Suffixes are defined by placing the suffix text outside the curly braces after t
 
 # React
 
-```tsx title="src/routes/files/{$fileName}.txt"
+```tsx title="src/routes/files/{$fileName}[.]txt.tsx"
 export const Route = createFileRoute('/files/{$fileName}.txt')({
   component: FileComponent,
 })
@@ -261,7 +261,7 @@ function FileComponent() {
 
 # Solid
 
-```tsx title="src/routes/files/{$fileName}.txt"
+```tsx title="src/routes/files/{$fileName}[.]txt.tsx"
 export const Route = createFileRoute('/files/{$fileName}.txt')({
   component: FileComponent,
 })
@@ -281,7 +281,7 @@ You can also combine suffixes with wildcards for more complex routing patterns:
 
 # React
 
-```tsx title="src/routes/files/{$}[.]txt"
+```tsx title="src/routes/files/{$}[.]txt.tsx"
 export const Route = createFileRoute('/files/{$fileName}[.]txt')({
   component: FileComponent,
 })
@@ -295,7 +295,7 @@ function FileComponent() {
 
 # Solid
 
-```tsx title="src/routes/files/{$}[.]txt"
+```tsx title="src/routes/files/{$}[.]txt.tsx"
 export const Route = createFileRoute('/files/{$fileName}[.]txt')({
   component: FileComponent,
 })


### PR DESCRIPTION
Fixed a few filenames in the router docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code example titles throughout the router path parameters documentation across frameworks. Modified sample filenames to include explicit .tsx file extensions and standardized suffix prefix notation. Changes enhance documentation clarity and visual alignment with actual project file structures while preserving all underlying code functionality and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->