### PR TITLE
docs: fix useCanGoBack link path

### DIFF
--- a/docs/router/api/router.md
+++ b/docs/router/api/router.md
@@ -37,7 +37,7 @@ title: Router API
 - Hooks
   - [`useAwaited`](./router/useAwaitedHook.md)
   - [`useBlocker`](./router/useBlockerHook.md)
-  - [`useCanGoBack`](./router//useCanGoBack.md)
+  - [`useCanGoBack`](./router/useCanGoBack.md)
   - [`useChildMatches`](./router/useChildMatchesHook.md)
   - [`useLinkProps`](./router/useLinkPropsHook.md)
   - [`useLoaderData`](./router/useLoaderDataHook.md)


### PR DESCRIPTION
Fix a typo in the Router API index where the `useCanGoBack` link path contained a double slash (`./router//useCanGoBack.md`). 

This updates it to the correct relative path so the generated docs URL stays clean and consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a broken internal documentation link path to improve navigation within the reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->