### PR TITLE
test/docs: clarify exact link matching with includeSearch

### DIFF
--- a/docs/router/guide/navigation.md
+++ b/docs/router/guide/navigation.md
@@ -611,6 +611,8 @@ export interface ActiveOptions {
   // Defaults to `false`
   includeHash?: boolean // Defaults to false
   // If true, the link will only be active if the current URL search params inclusively match the `search` prop
+  // When `exact` is `true`, this still defaults to `true`.
+  // Set this to `false` to ignore search params for exact path matching.
   // Defaults to `true`
   includeSearch?: boolean
   // This modifies the `includeSearch` behavior.
@@ -659,7 +661,7 @@ This will ensure that the link is not active when you are a child route.
 A few more options to be aware of:
 
 - If you want to include the hash in your matching, you can pass the `includeHash: true` option
-- If you do **not** want to include the search params in your matching, you can pass the `includeSearch: false` option
+- If you do **not** want to include the search params in your matching, you can pass the `includeSearch: false` option, including when `exact: true` is set
 
 ### Passing `isActive` to children
 

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -229,6 +229,88 @@ describe('Link', () => {
     expect(postsLink).not.toHaveAttribute('data-status', 'active')
   })
 
+  test('when exact is true and includeSearch is false, search params are ignored', async () => {
+    const RootComponent = () => {
+      return (
+        <>
+          <Link
+            to="/a"
+            activeOptions={{ exact: true, includeSearch: false }}
+            activeProps={{ className: 'active' }}
+            inactiveProps={{ className: 'inactive' }}
+          >
+            A exact includeSearch false
+          </Link>
+          <Link
+            to="/a/b"
+            activeOptions={{ exact: true, includeSearch: false }}
+            activeProps={{ className: 'active' }}
+            inactiveProps={{ className: 'inactive' }}
+          >
+            AB exact includeSearch false
+          </Link>
+          <Outlet />
+        </>
+      )
+    }
+
+    const rootRoute = createRootRoute({
+      component: RootComponent,
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <h1>Index</h1>,
+    })
+    const aRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/a',
+      validateSearch: (search: Record<string, unknown>) => ({
+        foo: search.foo as string | undefined,
+      }),
+      component: () => <h1>A</h1>,
+    })
+    const abRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/a/b',
+      component: () => <h1>AB</h1>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, aRoute, abRoute]),
+      history,
+    })
+
+    render(<RouterProvider router={router} />)
+
+    const aLink = await screen.findByRole('link', {
+      name: 'A exact includeSearch false',
+    })
+    const abLink = await screen.findByRole('link', {
+      name: 'AB exact includeSearch false',
+    })
+
+    await act(() => history.push('/a?foo=bar'))
+
+    await waitFor(() => {
+      expect(aLink).toHaveClass('active')
+    })
+
+    expect(aLink).toHaveClass('active')
+    expect(aLink).not.toHaveClass('inactive')
+    expect(abLink).toHaveClass('inactive')
+    expect(abLink).not.toHaveClass('active')
+
+    await act(() => fireEvent.click(abLink))
+
+    await waitFor(() => {
+      expect(abLink).toHaveClass('active')
+    })
+
+    expect(aLink).toHaveClass('inactive')
+    expect(aLink).not.toHaveClass('active')
+  })
+
   describe('when the current route has a search fields with undefined values', () => {
     async function runTest(opts: { explicitUndefined: boolean | undefined }) {
       const rootRoute = createRootRoute()

--- a/packages/router-core/src/link.ts
+++ b/packages/router-core/src/link.ts
@@ -647,6 +647,7 @@ export interface ActiveOptions {
   includeHash?: boolean
   /**
    * If true, the link will only be active if the current URL search params inclusively match the `search` prop
+   * When `exact` is `true`, this still defaults to `true`. Set this to `false` to ignore search params for exact path matching.
    * @default true
    */
   includeSearch?: boolean


### PR DESCRIPTION
## Summary
- add regression tests in React and Solid link suites for activeOptions with exact: true and includeSearch: false
- verify exact path XOR behavior while ignoring search params
- clarify includeSearch docs/comments for the exact: true case

## Testing
- not run (per request)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated router navigation guide with clarifications on exact path matching behavior and search parameter handling in ActiveOptions.

* **Tests**
  * Added test coverage for link active state determination when exact matching is enabled and search parameters are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->