### PR TITLE
docs: fix syntax error in `create-route-property-order.md`

### DIFF
--- a/docs/router/eslint/create-route-property-order.md
+++ b/docs/router/eslint/create-route-property-order.md
@@ -78,10 +78,10 @@ Examples of **correct** code for this rule:
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/path')({
-  beforeLoad: () => ({hello: 'world'}),
-  loader: async ({context}) => {
-    await context.queryClient.ensureQueryData(getQueryOptions(context.hello));
-  }
+  beforeLoad: () => ({ hello: 'world' }),
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(getQueryOptions(context.hello))
+  },
 })
 ```
 
@@ -96,10 +96,10 @@ export const Route = createFileRoute('/path')({
 import { createFileRoute } from '@tanstack/solid-router'
 
 export const Route = createFileRoute('/path')({
-  beforeLoad: () => ({hello: 'world'}),
-  loader: async ({context}) => {
-    await context.queryClient.ensureQueryData(getQueryOptions(context.hello));
-  }
+  beforeLoad: () => ({ hello: 'world' }),
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(getQueryOptions(context.hello))
+  },
 })
 ```
 


### PR DESCRIPTION
The comma inside the loader caused a syntax error in both examples.