### PR TITLE
docs: clarify that location hash excludes the leading `#`

### DIFF
--- a/packages/router-core/src/location.ts
+++ b/packages/router-core/src/location.ts
@@ -25,7 +25,8 @@ export interface ParsedLocation<TSearchObj extends AnySchema = {}> {
    */
   state: ParsedHistoryState
   /**
-   * The hash of the location, including the leading hash character.
+   * The hash of the location, excluding the leading hash character.
+   * (e.g., '123' instead of '#123')
    */
   hash: string
   /**


### PR DESCRIPTION
closes #6686 
replaces #6693

**Changes**
- Updated the JSDoc comment for the `hash` property to accurately reflect that it **excludes** the leading `#` character (e.g., returning `'123'` instead of `'#123'`).

This update aligns the documentation with the router's actual and intended behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified hash value representation in location documentation, including updated examples for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->