### PR TITLE
chore: mark eslint peer dependency as optional

### DIFF
--- a/packages/eslint-plugin-router/package.json
+++ b/packages/eslint-plugin-router/package.json
@@ -61,5 +61,10 @@
   },
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
see https://github.com/TanStack/router/discussions/6706

This is to consider other linters like Oxlint that can consume ESLint plugins directly, so ESLint doesn't have to be installed for these projects.

Would it be worth mentioning Oxlint as an additional supported linter in the docs?

UPDATE: see https://github.com/TanStack/router/discussions/6706#discussioncomment-15865975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to mark ESLint as an optional peer dependency, allowing greater flexibility for users who may not require it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->