### PR TITLE
docs: fix syntax error in `create-route-property-order.md`

### DIFF
--- a/docs/router/eslint/create-route-property-order.md
+++ b/docs/router/eslint/create-route-property-order.md
@@ -36,10 +36,10 @@ Examples of **incorrect** code for this rule:
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/path')({
-  loader: async ({context}) => {
+  loader: async ({ context }) => {
     await context.queryClient.ensureQueryData(getQueryOptions(context.hello))
   },
-  beforeLoad: () => ({hello: 'world'})
+  beforeLoad: () => ({ hello: 'world' }),
 })
 ```
 
@@ -54,10 +54,10 @@ export const Route = createFileRoute('/path')({
 import { createFileRoute } from '@tanstack/solid-router'
 
 export const Route = createFileRoute('/path')({
-  loader: async ({context}) => {
+  loader: async ({ context }) => {
     await context.queryClient.ensureQueryData(getQueryOptions(context.hello))
   },
-  beforeLoad: () => ({hello: 'world'})
+  beforeLoad: () => ({ hello: 'world' }),
 })
 ```
 


### PR DESCRIPTION
The comma inside the loader caused a syntax error in both examples. Because there are codeblocks for react and solid each, I missed half the change in #6699 :( Code rabbit noticed that in https://github.com/TanStack/router/pull/6699#pullrequestreview-3823979365.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code example formatting in router documentation for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->