### PR TITLE
Update document to reflect the TanStack Start cli update

### DIFF
--- a/docs/start/framework/react/getting-started.md
+++ b/docs/start/framework/react/getting-started.md
@@ -14,7 +14,7 @@ title: Getting Started
 
 Choose one of the following options to start building a _new_ TanStack Start project:
 
-- [TanStack Start CLI](./quick-start) - Just run `npm create @tanstack/start@latest`. Local, fast, and optionally customizable
+- [TanStack Start CLI](./quick-start) - Just run `npx @tanstack/cli create`. Local, fast, and optionally customizable
 - [TanStack Builder](https://tanstack.com/builder) - A visual interface to configure new TanStack projects with a few clicks
 - [Quick Start Examples](./quick-start) Download or clone one of our official examples
 - [Build a project from scratch](./build-from-scratch) - A guide to building a TanStack Start project line-by-line, file-by-file.


### PR DESCRIPTION
> Warning: @tanstack/create-start is deprecated. Use "tanstack create" or "npx @tanstack/cli create" instead.

# The old/exist command in the doc:
```
➜  ~ npm create @tanstack/start@latest
Need to install the following packages:
@tanstack/create-start@0.59.8
Ok to proceed? (y) y


> npx
> create-start

Warning: @tanstack/create-start is deprecated. Use "tanstack create" or "npx @tanstack/cli create" instead.
         See: https://tanstack.com/start/latest/docs/framework/react/quick-start

┌  Let's configure your TanStack Start application │
◆  What would you like to name your project?
│  _
└
```

# The new command:
```
➜  ~ npx @tanstack/cli create
Need to install the following packages:
@tanstack/cli@0.59.8
Ok to proceed? (y) y

┌  Let's configure your TanStack application
│
◆  What would you like to name your project?
│  _
└
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the React getting-started guide to include the latest TanStack Start CLI initialization command, ensuring users have access to the current recommended setup method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->