### PR TITLE
build(router-devtools-core): forward compat to vite 8

### DIFF
--- a/packages/router-devtools-core/vite.config.ts
+++ b/packages/router-devtools-core/vite.config.ts
@@ -15,7 +15,7 @@ const merged = mergeConfig(
   }),
 )
 
-merged.build.rollupOptions.output.manualChunks = false
+merged.build.rollupOptions.output.manualChunks = undefined
 merged.build.rollupOptions.output.preserveModules = false
 
 export default merged


### PR DESCRIPTION
In vite 8 (rolldown), manualChunks strictly requires a function or undefined. Setting it to false throws TypeError: manualChunks is not a function, breaking the build. We can already now with vite 7 change false to undefined, so taht the vite-ecosystem-ci will work.