### PR TITLE
fix(ci): use benchmark-action `name` input

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -81,7 +81,7 @@ jobs:
         uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
         with:
           tool: customSmallerIsBetter
-          benchmark-name: Bundle Size (gzip)
+          name: Bundle Size (gzip)
           output-file-path: e2e/bundle-size/results/benchmark-action.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true


### PR DESCRIPTION
## Summary
- replace deprecated/invalid `benchmark-name` input with `name` for `benchmark-action/github-action-benchmark`
- keep the same benchmark label value (`Bundle Size (gzip)`)

## Why
The publish job logs:

`Unexpected input(s) 'benchmark-name'`

`benchmark-action/github-action-benchmark@v1.20.7` expects `name`, not `benchmark-name`.

## Validation
- verified warning from run `22261828968` (job `64401257488`)
- updated workflow key only (no behavior changes beyond removing warning)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow configuration for benchmark reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->