### PR TITLE
ci: remove fork guard from bundle-size PR comment step

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -53,7 +53,6 @@ jobs:
             --dashboard-url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/benchmarks/bundle-size/"
 
       - name: Upsert Sticky PR Comment
-        if: github.event.pull_request.head.repo.fork == false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Removes the  guard from the bundle-size workflow so PR comments run for forked PRs too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow automation for improved consistency in pull request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->