### PR TITLE
fix: remove router context caching

### DIFF
--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Matches } from './Matches'
-import { getRouterContext } from './routerContext'
+import { routerContext } from './routerContext'
 import type {
   AnyRouter,
   RegisteredRouter,
@@ -32,8 +32,6 @@ export function RouterContextProvider<
       },
     })
   }
-
-  const routerContext = getRouterContext()
 
   const provider = (
     <routerContext.Provider value={router as AnyRouter}>

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -298,10 +298,6 @@ export { useNavigate, Navigate } from './useNavigate'
 export { useParams } from './useParams'
 export { useSearch } from './useSearch'
 
-export {
-  getRouterContext, // SSR
-} from './routerContext'
-
 export { useRouteContext } from './useRouteContext'
 export { useRouter } from './useRouter'
 export { useRouterState } from './useRouterState'

--- a/packages/react-router/src/routerContext.tsx
+++ b/packages/react-router/src/routerContext.tsx
@@ -1,24 +1,4 @@
 import * as React from 'react'
 import type { AnyRouter } from '@tanstack/router-core'
 
-declare global {
-  interface Window {
-    __TSR_ROUTER_CONTEXT__?: React.Context<AnyRouter>
-  }
-}
-
-const routerContext = React.createContext<AnyRouter>(null!)
-
-export function getRouterContext() {
-  if (typeof document === 'undefined') {
-    return routerContext
-  }
-
-  if (window.__TSR_ROUTER_CONTEXT__) {
-    return window.__TSR_ROUTER_CONTEXT__
-  }
-
-  window.__TSR_ROUTER_CONTEXT__ = routerContext as any
-
-  return routerContext
-}
+export const routerContext = React.createContext<AnyRouter>(null!)

--- a/packages/react-router/src/useRouter.tsx
+++ b/packages/react-router/src/useRouter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import warning from 'tiny-warning'
-import { getRouterContext } from './routerContext'
+import { routerContext } from './routerContext'
 import type { AnyRouter, RegisteredRouter } from '@tanstack/router-core'
 
 /**
@@ -16,7 +16,7 @@ import type { AnyRouter, RegisteredRouter } from '@tanstack/router-core'
 export function useRouter<TRouter extends AnyRouter = RegisteredRouter>(opts?: {
   warn?: boolean
 }): TRouter {
-  const value = React.useContext(getRouterContext())
+  const value = React.useContext(routerContext)
   warning(
     !((opts?.warn ?? true) && !value),
     'useRouter must be used inside a <RouterProvider> component!',

--- a/packages/solid-router/src/RouterProvider.tsx
+++ b/packages/solid-router/src/RouterProvider.tsx
@@ -1,4 +1,4 @@
-import { getRouterContext } from './routerContext'
+import { routerContext } from './routerContext'
 import { SafeFragment } from './SafeFragment'
 import { Matches } from './Matches'
 import type {
@@ -27,8 +27,6 @@ export function RouterContextProvider<
       ...rest.context,
     },
   })
-
-  const routerContext = getRouterContext()
 
   const OptionalWrapper = router.options.Wrap || SafeFragment
 

--- a/packages/solid-router/src/index.tsx
+++ b/packages/solid-router/src/index.tsx
@@ -304,10 +304,6 @@ export { useNavigate, Navigate } from './useNavigate'
 export { useParams } from './useParams'
 export { useSearch } from './useSearch'
 
-export {
-  getRouterContext, // SSR
-} from './routerContext'
-
 export { useRouteContext } from './useRouteContext'
 export { useRouter } from './useRouter'
 export { useRouterState } from './useRouterState'

--- a/packages/solid-router/src/routerContext.tsx
+++ b/packages/solid-router/src/routerContext.tsx
@@ -1,26 +1,6 @@
 import * as Solid from 'solid-js'
 import type { AnyRouter } from '@tanstack/router-core'
 
-declare global {
-  interface Window {
-    __TSR_ROUTER_CONTEXT__?: Solid.Context<AnyRouter>
-  }
-}
-
-const routerContext = Solid.createContext<AnyRouter>(
+export const routerContext = Solid.createContext<AnyRouter>(
   null as unknown as AnyRouter,
 )
-
-export function getRouterContext() {
-  if (typeof document === 'undefined') {
-    return routerContext
-  }
-
-  if (window.__TSR_ROUTER_CONTEXT__) {
-    return window.__TSR_ROUTER_CONTEXT__
-  }
-
-  window.__TSR_ROUTER_CONTEXT__ = routerContext as any
-
-  return routerContext
-}

--- a/packages/solid-router/src/useRouter.tsx
+++ b/packages/solid-router/src/useRouter.tsx
@@ -1,12 +1,12 @@
 import * as Solid from 'solid-js'
 import warning from 'tiny-warning'
-import { getRouterContext } from './routerContext'
+import { routerContext } from './routerContext'
 import type { AnyRouter, RegisteredRouter } from '@tanstack/router-core'
 
 export function useRouter<TRouter extends AnyRouter = RegisteredRouter>(opts?: {
   warn?: boolean
 }): TRouter {
-  const value = Solid.useContext(getRouterContext() as any)
+  const value = Solid.useContext(routerContext as any)
   warning(
     !((opts?.warn ?? true) && !value),
     'useRouter must be used inside a <RouterProvider> component!',

--- a/packages/vue-router/src/index.tsx
+++ b/packages/vue-router/src/index.tsx
@@ -298,10 +298,6 @@ export { useNavigate, Navigate } from './useNavigate'
 export { useParams } from './useParams'
 export { useSearch } from './useSearch'
 
-export {
-  getRouterContext, // SSR
-} from './routerContext'
-
 export { useRouteContext } from './useRouteContext'
 export { useRouter } from './useRouter'
 export { useRouterState } from './useRouterState'

--- a/packages/vue-router/src/routerContext.tsx
+++ b/packages/vue-router/src/routerContext.tsx
@@ -1,49 +1,22 @@
 import * as Vue from 'vue'
 import type { AnyRouter } from '@tanstack/router-core'
 
-// Create a router context symbol
-export const RouterSymbol = Symbol(
+export const routerContext = Symbol(
   'TanStackRouter',
 ) as Vue.InjectionKey<AnyRouter>
-
-declare global {
-  interface Window {
-    __TSR_ROUTER_CONTEXT__?: Vue.InjectionKey<AnyRouter>
-  }
-}
-
-/**
- * Gets the router context, handling server-side rendering
- * and ensuring a single instance across the application
- */
-export function getRouterContext(): Vue.InjectionKey<AnyRouter> {
-  if (typeof document === 'undefined') {
-    // For SSR, return the symbol directly
-    return RouterSymbol
-  }
-
-  // In the browser, check if we have a cached context
-  if (window.__TSR_ROUTER_CONTEXT__) {
-    return window.__TSR_ROUTER_CONTEXT__
-  }
-
-  // Create and cache the context
-  window.__TSR_ROUTER_CONTEXT__ = RouterSymbol
-  return RouterSymbol
-}
 
 /**
  * Provides the router to all child components
  */
 export function provideRouter(router: AnyRouter): void {
-  Vue.provide(getRouterContext(), router)
+  Vue.provide(routerContext, router)
 }
 
 /**
  * Injects the router from the component tree
  */
 export function injectRouter(): AnyRouter {
-  const router = Vue.inject<AnyRouter | null>(getRouterContext(), null)
+  const router = Vue.inject<AnyRouter | null>(routerContext, null)
   if (!router) {
     throw new Error(
       'No TanStack Router found in component tree. Did you forget to add a RouterProvider component?',

--- a/packages/vue-router/src/useRouter.tsx
+++ b/packages/vue-router/src/useRouter.tsx
@@ -1,12 +1,12 @@
 import * as Vue from 'vue'
 import warning from 'tiny-warning'
-import { getRouterContext } from './routerContext'
+import { routerContext } from './routerContext'
 import type { AnyRouter, RegisteredRouter } from '@tanstack/router-core'
 
 export function useRouter<TRouter extends AnyRouter = RegisteredRouter>(opts?: {
   warn?: boolean
 }): TRouter {
-  const value = Vue.inject(getRouterContext() as any, null)
+  const value = Vue.inject(routerContext as any, null)
   warning(
     !((opts?.warn ?? true) && !value),
     'useRouter must be used inside a <RouterProvider> component!',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed a context accessor from the public API across React, Solid, and Vue router packages.

* **Improvements**
  * Simplified context provisioning by removing global caching mechanisms and streamlining how router context is accessed internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->