### PR TITLE
fix(router-core): tanstack/store v0.9 requires createStore instead of new Store

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1,4 +1,4 @@
-import { Store } from '@tanstack/store'
+import { createStore } from '@tanstack/store'
 import { createBrowserHistory, parseHref } from '@tanstack/history'
 import { isServer } from '@tanstack/router-core/isServer'
 import { batch } from './utils/batch'
@@ -42,6 +42,7 @@ import {
   executeRewriteOutput,
   rewriteBasepath,
 } from './rewrite'
+import type { Store } from '@tanstack/store'
 import type { LRUCache } from './lru-cache'
 import type {
   ProcessRouteTreeResult,
@@ -1132,7 +1133,7 @@ export class RouterCore<
           getInitialRouterState(this.latestLocation),
         ) as unknown as Store<any>
       } else {
-        this.__store = new Store(getInitialRouterState(this.latestLocation))
+        this.__store = createStore(getInitialRouterState(this.latestLocation))
 
         setupScrollRestoration(this)
       }


### PR DESCRIPTION
Fix a minor migration issue where `new Store()` should now be `createStore()`. In practice this does not change anything (same code being called under the hood). It's only to better align Router with the new public API of Store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal store initialization pattern to use a factory function approach, improving code maintainability while preserving existing server and non-server initialization paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->