### PR TITLE
fix(ci): harden bundle-size PR workflow trust boundaries

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -3,7 +3,6 @@ name: Bundle Size
 on:
   # We use `pull_request_target` to split trust boundaries across jobs:
   # - `benchmark-pr` checks out PR merge code and runs it as untrusted with read-only permissions.
-  # - `capture` runs trusted base-repo code, captures metadata, and passes outputs to other trusted jobs.
   # - `comment-pr` runs trusted base-repo code with limited write access to upsert the PR comment.
   pull_request_target:
   push:
@@ -22,6 +21,8 @@ jobs:
     name: Benchmark PR
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    outputs:
+      current_json_b64: ${{ steps.capture.outputs.current_json_b64 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.1
@@ -36,44 +37,18 @@ jobs:
       - name: Measure Bundle Size
         run: pnpm nx run tanstack-router-e2e-bundle-size:build --outputStyle=stream --skipRemoteCache
 
-      - name: Upload Benchmark Outputs
-        uses: actions/upload-artifact@v4
-        with:
-          name: bundle-size-current-json
-          path: e2e/bundle-size/results/current.json
-          if-no-files-found: error
-          retention-days: 1
-
-  capture:
-    name: Capture PR Metadata
-    if: github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
-    needs: benchmark-pr
-    outputs:
-      current_json_b64: ${{ steps.capture.outputs.current_json_b64 }}
-      base_sha: ${{ steps.capture.outputs.base_sha }}
-      pr_number: ${{ steps.capture.outputs.pr_number }}
-    steps:
-      - name: Download Benchmark Outputs
-        uses: actions/download-artifact@v4
-        with:
-          name: bundle-size-current-json
-          path: e2e/bundle-size/results
-
       - name: Capture Benchmark Outputs
         id: capture
         run: |
           {
             echo "current_json_b64=$(base64 -w 0 < e2e/bundle-size/results/current.json)"
-            echo "base_sha=${{ github.event.pull_request.base.sha }}"
-            echo "pr_number=${{ github.event.pull_request.number }}"
           } >> "$GITHUB_OUTPUT"
 
   comment-pr:
     name: Upsert PR Comment
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
-    needs: capture
+    needs: benchmark-pr
     permissions:
       contents: read
       pull-requests: write
@@ -86,7 +61,7 @@ jobs:
 
       - name: Restore Benchmark Outputs
         env:
-          CURRENT_JSON_B64: ${{ needs.capture.outputs.current_json_b64 }}
+          CURRENT_JSON_B64: ${{ needs.benchmark-pr.outputs.current_json_b64 }}
         run: |
           mkdir -p e2e/bundle-size/results
           node -e "const fs=require('node:fs'); fs.writeFileSync('e2e/bundle-size/results/current.json', Buffer.from(process.env.CURRENT_JSON_B64 || '', 'base64'))"
@@ -109,7 +84,7 @@ jobs:
             --current e2e/bundle-size/results/current.json \
             --history e2e/bundle-size/results/history-data.js \
             --output e2e/bundle-size/results/pr-comment.md \
-            --base-sha "${{ needs.capture.outputs.base_sha }}" \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
             --dashboard-url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/benchmarks/bundle-size/"
 
       - name: Upsert Sticky PR Comment
@@ -117,7 +92,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/benchmarks/common/upsert-pr-comment.mjs \
-            --pr "${{ needs.capture.outputs.pr_number }}" \
+            --pr "${{ github.event.pull_request.number }}" \
             --body-file e2e/bundle-size/results/pr-comment.md
 
   benchmark-main:


### PR DESCRIPTION
## Summary
- switch the bundle-size PR trigger from `pull_request` to `pull_request_target` and split execution into untrusted benchmark + trusted comment jobs
- restrict default workflow permissions to read-only and scope `pull-requests: write` only to the comment job
- pass benchmark outputs through job outputs so PR metadata is handled in the trusted job context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI workflow permissions and changed triggers to safer event handling.
  * Added capture/restore steps so benchmark current/base results persist reliably across jobs.
  * Introduced a dedicated job to post benchmark results to pull requests and reworked job coordination for stable PR comments.
  * Improved checkout and credential handling to reduce CI flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->