### PR TITLE
fix(router-generator): skip generated route tree in watchChange to prevent infinite loop

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -1624,9 +1624,12 @@ ${acc.routeTree.map((child) => `${child.variableName}Route: typeof ${getResolved
 
   // only process files that are relevant for the route tree generation
   private isFileRelevantForRouteTreeGeneration(filePath: string): boolean {
-    // the generated route tree file
+    // Skip the generated route tree file itself — changes to it are caused by
+    // the generator writing its own output and must not re-trigger generation,
+    // otherwise the Vite watcher creates an infinite feedback loop:
+    // write → watchChange → isFileRelevant=true → run() → write → …
     if (filePath === this.generatedRouteTreePath) {
-      return true
+      return false
     }
 
     // files inside the routes folder


### PR DESCRIPTION
## Problem

On macOS (APFS) with ~30+ routes, the route generator enters an infinite loop on dev server startup, flooding the console with:

```
File /path/to/src/routeTree.gen.ts was modified by another process during processing.
```

This causes Vite to continuously full-page reload the browser.

## Root Cause

The feedback loop in `watchChange`:

1. Generator writes `routeTree.gen.ts` via `safeFileWrite`
2. Vite's file watcher detects the write → fires `watchChange`
3. `isFileRelevantForRouteTreeGeneration()` returns **`true`** for `generatedRouteTreePath`
4. `generator.run()` is called for the generated file
5. `safeFileWrite` detects mtime mismatch → throws `rerun`
6. Rerun is caught and re-queued → goto 4

The bug is that `isFileRelevantForRouteTreeGeneration` returned `true` for the generator's own output file.

## Fix

Return `false` for `generatedRouteTreePath` in `isFileRelevantForRouteTreeGeneration`. The generator should never re-run because its own output changed — only changes to actual route source files should trigger regeneration.

This is **Option A** from the issue analysis — the cleanest approach.

## Test

The user's documented workaround was:
```ts
server: { watch: { ignored: ['**/routeTree.gen.ts'] } }
```

This fix makes that workaround unnecessary by filtering at the generator level.

Fixes #6775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause the route generation process to enter an infinite loop when monitoring files for changes. Route generation now works more efficiently without unnecessary regeneration cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->