### PR TITLE
chore(eslint): remove package-level unused-vars overrides

### DIFF
--- a/packages/router-core/eslint.config.js
+++ b/packages/router-core/eslint.config.js
@@ -7,7 +7,6 @@ export default [
   {
     files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
     rules: {
-      'unused-imports/no-unused-vars': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
     },
   },

--- a/packages/router-ssr-query-core/eslint.config.js
+++ b/packages/router-ssr-query-core/eslint.config.js
@@ -7,7 +7,6 @@ export default [
   {
     files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
     rules: {
-      'unused-imports/no-unused-vars': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
     },
   },

--- a/packages/solid-router/eslint.config.ts
+++ b/packages/solid-router/eslint.config.ts
@@ -9,7 +9,6 @@ export default [
       solidPlugin: solidPlugin(),
     },
     rules: {
-      'unused-imports/no-unused-vars': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
     },
   },

--- a/packages/vue-router-ssr-query/eslint.config.ts
+++ b/packages/vue-router-ssr-query/eslint.config.ts
@@ -6,7 +6,6 @@ export default [
     files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
     plugins: {},
     rules: {
-      'unused-imports/no-unused-vars': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
     },
   },

--- a/packages/vue-router/eslint.config.ts
+++ b/packages/vue-router/eslint.config.ts
@@ -6,7 +6,6 @@ export default [
     files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
     plugins: {},
     rules: {
-      'unused-imports/no-unused-vars': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
     },
   },

--- a/packages/vue-start-client/eslint.config.ts
+++ b/packages/vue-start-client/eslint.config.ts
@@ -6,7 +6,6 @@ export default [
     files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
     plugins: {},
     rules: {
-      'unused-imports/no-unused-vars': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
     },
   },

--- a/packages/vue-start-server/eslint.config.ts
+++ b/packages/vue-start-server/eslint.config.ts
@@ -6,7 +6,6 @@ export default [
     files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
     plugins: {},
     rules: {
-      'unused-imports/no-unused-vars': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
     },
   },

--- a/packages/vue-start/eslint.config.ts
+++ b/packages/vue-start/eslint.config.ts
@@ -6,7 +6,6 @@ export default [
     files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
     plugins: {},
     rules: {
-      'unused-imports/no-unused-vars': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
     },
   },


### PR DESCRIPTION
## Summary
- Remove package-level `unused-imports/no-unused-vars` disables from router/start package ESLint configs.
- Keep the root ESLint behavior unchanged so packages inherit the shared unused-vars policy.
- Let CI surface any package-specific follow-up needed instead of maintaining broad local opt-outs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality enforcement configurations across multiple packages to ensure consistent development standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->