### PR TITLE
Redirect function should always be thrown

### DIFF
--- a/docs/router/api/router/redirectFunction.md
+++ b/docs/router/api/router/redirectFunction.md
@@ -3,7 +3,7 @@ id: redirectFunction
 title: redirect function
 ---
 
-The `redirect` function returns a new `Redirect` object that can be either returned or thrown from places like a Route's `beforeLoad` or `loader` callbacks to trigger _redirect_ to a new location.
+The `redirect` function returns a new `Redirect` object that can be thrown from places like a Route's `beforeLoad` or `loader` callbacks to trigger _redirect_ to a new location.
 
 ## redirect options
 


### PR DESCRIPTION
Clarified usage of the redirect function in documentation.

References: https://github.com/TanStack/router/issues/978#issuecomment-3979702373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated redirect function documentation to clarify that the Redirect object should be thrown from route handlers (beforeLoad/loader) to trigger redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->