### PR TITLE
test: add onRendered event coverage for param and search updates

### DIFF
--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -885,6 +885,56 @@ describe('router emits events during rendering', () => {
     unsub()
   })
 
+  it('should emit the "onRendered" event when a route renders, after navigation, and after param/search updates', async () => {
+    const { router } = createTestRouter({
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      scrollRestoration: true,
+    })
+
+    const mockOnRendered = vi.fn()
+    const unsub = router.subscribe('onRendered', mockOnRendered)
+    await act(() => router.load())
+
+    await waitFor(() => expect(mockOnRendered).toBeCalledTimes(0))
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => expect(mockOnRendered).toBeCalledTimes(1))
+    expect(mockOnRendered.mock.calls[0]?.[0]?.toLocation.pathname).toBe('/')
+
+    await act(() =>
+      router.navigate({ to: '/posts/$slug', params: { slug: 'first' } }),
+    )
+
+    await waitFor(() => expect(mockOnRendered).toBeCalledTimes(2))
+    expect(mockOnRendered.mock.calls[1]?.[0]?.toLocation.pathname).toBe(
+      '/posts/first',
+    )
+
+    await act(() =>
+      router.navigate({ to: '/posts/$slug', params: { slug: 'second' } }),
+    )
+
+    await waitFor(() => expect(mockOnRendered).toBeCalledTimes(3))
+    expect(mockOnRendered.mock.calls[2]?.[0]?.toLocation.pathname).toBe(
+      '/posts/second',
+    )
+
+    await act(() =>
+      router.navigate({
+        to: '/posts/$slug',
+        params: { slug: 'second' },
+        search: { root: 'search-change' },
+      }),
+    )
+
+    await waitFor(() => expect(mockOnRendered).toBeCalledTimes(4))
+    expect(mockOnRendered.mock.calls[3]?.[0]?.toLocation.search.root).toBe(
+      'search-change',
+    )
+
+    unsub()
+  })
+
   it('during initial load, should emit the "onBeforeRouteMount" and "onResolved" events in the correct order', async () => {
     const mockOnBeforeRouteMount = vi.fn()
     const mockOnResolved = vi.fn()

--- a/packages/solid-router/tests/router.test.tsx
+++ b/packages/solid-router/tests/router.test.tsx
@@ -837,6 +837,50 @@ describe('router emits events during rendering', () => {
     unsub()
   })
 
+  it('should emit the "onRendered" event when a route renders, after navigation, and after param/search updates', async () => {
+    const { router } = createTestRouter({
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      scrollRestoration: true,
+    })
+
+    const mockOnRendered = vi.fn()
+    const unsub = router.subscribe('onRendered', mockOnRendered)
+    await router.load()
+
+    await waitFor(() => expect(mockOnRendered).toBeCalledTimes(0))
+    render(() => <RouterProvider router={router} />)
+
+    await waitFor(() => expect(mockOnRendered).toBeCalledTimes(1))
+    expect(mockOnRendered.mock.calls[0]?.[0]?.toLocation.pathname).toBe('/')
+
+    await router.navigate({ to: '/posts/$slug', params: { slug: 'first' } })
+
+    await waitFor(() => expect(mockOnRendered).toBeCalledTimes(2))
+    expect(mockOnRendered.mock.calls[1]?.[0]?.toLocation.pathname).toBe(
+      '/posts/first',
+    )
+
+    await router.navigate({ to: '/posts/$slug', params: { slug: 'second' } })
+
+    await waitFor(() => expect(mockOnRendered).toBeCalledTimes(3))
+    expect(mockOnRendered.mock.calls[2]?.[0]?.toLocation.pathname).toBe(
+      '/posts/second',
+    )
+
+    await router.navigate({
+      to: '/posts/$slug',
+      params: { slug: 'second' },
+      search: { root: 'search-change' },
+    })
+
+    await waitFor(() => expect(mockOnRendered).toBeCalledTimes(4))
+    expect(mockOnRendered.mock.calls[3]?.[0]?.toLocation.search.root).toBe(
+      'search-change',
+    )
+
+    unsub()
+  })
+
   it('during initial load, should emit the "onBeforeRouteMount" and "onResolved" events in the correct order', async () => {
     const mockOnBeforeRouteMount = vi.fn()
     const mockOnResolved = vi.fn()


### PR DESCRIPTION
## Summary
- add `onRendered` event tests in React, Solid, and Vue router suites
- verify the event fires on initial render, route navigation, path param changes, and search param changes
- assert emitted `toLocation` data for both pathname and search updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the `onRendered` event behavior across router packages, validating event emissions during initial render, navigation, and parameter/search updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->