### PR TITLE
test: add react-router navigation speed benchmark

### DIFF
--- a/packages/react-router/tests/speed.bench.tsx
+++ b/packages/react-router/tests/speed.bench.tsx
@@ -1,0 +1,120 @@
+import { cleanup, render } from '@testing-library/react'
+import { act } from 'react'
+import { bench, describe } from 'vitest'
+import { rootRouteId } from '@tanstack/router-core'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  useParams,
+  useSearch,
+} from '../src'
+import type { NavigateOptions } from '@tanstack/router-core'
+
+function createTestRouter() {
+  function runPerfSelectorComputation(seed: number) {
+    let value = Math.trunc(seed) | 0
+
+    for (let index = 0; index < 100; index++) {
+      value = (value * 1664525 + 1013904223 + index) >>> 0
+    }
+
+    return value
+  }
+
+  const selectors = Array.from({ length: 20 }, (_, index) => index)
+
+  function Params() {
+    const params = useParams({
+      from: rootRouteId,
+      select: (params) => runPerfSelectorComputation(Number(params.id ?? 0)),
+    })
+    void params
+    return null
+  }
+
+  function Search() {
+    const search = useSearch({
+      from: rootRouteId,
+      select: (search) => runPerfSelectorComputation(Number(search.id ?? 0)),
+    })
+    void search
+    return null
+  }
+
+  function Root() {
+    return (
+      <>
+        {selectors.map((selector) => (
+          <Params key={selector} />
+        ))}
+        {selectors.map((selector) => (
+          <Search key={selector} />
+        ))}
+        <Outlet />
+      </>
+    )
+  }
+
+  const root = createRootRoute({
+    component: Root,
+  })
+
+  const route = createRoute({
+    getParentRoute: () => root,
+    path: '/$id',
+    component: () => <div />,
+  })
+
+  return createRouter({
+    history: createMemoryHistory({
+      initialEntries: ['/0'],
+    }),
+    scrollRestoration: true,
+    routeTree: root.addChildren([route]),
+  })
+}
+
+describe('speed', () => {
+  let id = 0
+  const router = createTestRouter()
+  let unsub = () => {}
+  let next: () => Promise<void>
+
+  bench('navigate', () => act(next), {
+    warmupIterations: 1000,
+    time: 10_000,
+    setup: async () => {
+      id = 0
+      let resolve = () => {}
+      unsub = router.subscribe('onRendered', () => resolve())
+
+      const navigate = (opts: NavigateOptions) =>
+        new Promise<void>((resolveNext, rejectNext) => {
+          resolve = resolveNext
+          router.navigate(opts).catch(rejectNext)
+        })
+
+      next = () => {
+        const nextId = id++
+
+        return navigate({
+          to: '/$id',
+          params: { id: nextId },
+          search: { id: nextId },
+          replace: true,
+        })
+      }
+
+      render(<RouterProvider router={router} />)
+      await act(() => router.load())
+    },
+    teardown: () => {
+      cleanup()
+      unsub()
+    },
+  })
+})


### PR DESCRIPTION
## Summary
- Add a new `tests/speed.bench.tsx` benchmark in `@tanstack/react-router` focused on navigation throughput.
- Exercise repeated `useParams` and `useSearch` selectors under navigation to stress route/search recomputation cost.
- Keep benchmark iterations stable by using `replace: true`, synchronized param/search ids, and resolving each iteration after `onRendered`.

## Testing
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:perf --outputStyle=stream --skipRemoteCache -- tests/speed.bench.tsx`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:unit --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:eslint --outputStyle=stream --skipRemoteCache -- tests/speed.bench.tsx`

## Notes
- Running full-package ESLint currently reports pre-existing errors in generated `packages/react-router/llms/rules/*.ts` files that are unrelated to this benchmark.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmark suite to measure router navigation performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->