### PR TITLE
fix: skip missing CSS modules in cache during style collection

### DIFF
--- a/packages/start-plugin-core/src/dev-server-plugin/dev-styles.ts
+++ b/packages/start-plugin-core/src/dev-server-plugin/dev-styles.ts
@@ -104,9 +104,8 @@ export async function collectDevStyles(
     if (dep.file && isCssModulesFile(dep.file)) {
       const css = cssModulesCache[normalizeCssModuleCacheKey(dep.file)]
       if (!css) {
-        throw new Error(
-          `[tanstack-start] Missing CSS module in cache: ${dep.file}`,
-        )
+        // skip this module - it may not be a real CSS module or it may not have been transformed yet
+        continue
       }
       styles.set(dep.url, css)
       continue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS module cache handling in the development server. Missing CSS module entries are now gracefully skipped instead of causing errors, allowing the development process to continue uninterrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->