### PR TITLE
docs(router): add "How To" section to docs navigation sidebar

### DIFF
--- a/docs/router/config.json
+++ b/docs/router/config.json
@@ -268,6 +268,101 @@
       ]
     },
     {
+      "label": "How To",
+      "children": [
+        {
+          "label": "Install TanStack Router",
+          "to": "how-to/install"
+        },
+        {
+          "label": "Use Environment Variables",
+          "to": "how-to/use-environment-variables"
+        },
+        {
+          "label": "Deploy to Production",
+          "to": "how-to/deploy-to-production"
+        },
+        {
+          "label": "Set Up SSR",
+          "to": "how-to/setup-ssr"
+        },
+        {
+          "label": "Migrate from React Router",
+          "to": "how-to/migrate-from-react-router"
+        },
+        {
+          "label": "Set Up Authentication",
+          "to": "how-to/setup-authentication"
+        },
+        {
+          "label": "Integrate Auth Providers",
+          "to": "how-to/setup-auth-providers"
+        },
+        {
+          "label": "Set Up RBAC",
+          "to": "how-to/setup-rbac"
+        },
+        {
+          "label": "Navigate with Search Params",
+          "to": "how-to/navigate-with-search-params"
+        },
+        {
+          "label": "Set Up Basic Search Params",
+          "to": "how-to/setup-basic-search-params"
+        },
+        {
+          "label": "Validate Search Params",
+          "to": "how-to/validate-search-params"
+        },
+        {
+          "label": "Arrays, Objects & Dates in Search Params",
+          "to": "how-to/arrays-objects-dates-search-params"
+        },
+        {
+          "label": "Share Search Params Across Routes",
+          "to": "how-to/share-search-params-across-routes"
+        },
+        {
+          "label": "Set Up Testing",
+          "to": "how-to/setup-testing"
+        },
+        {
+          "label": "Test File-Based Routing",
+          "to": "how-to/test-file-based-routing"
+        },
+        {
+          "label": "Debug Router Issues",
+          "to": "how-to/debug-router-issues"
+        },
+        {
+          "label": "Integrate Shadcn UI",
+          "to": "how-to/integrate-shadcn-ui"
+        },
+        {
+          "label": "Integrate Material UI",
+          "to": "how-to/integrate-material-ui"
+        },
+        {
+          "label": "Integrate Chakra UI",
+          "to": "how-to/integrate-chakra-ui"
+        },
+        {
+          "label": "Integrate Framer Motion",
+          "to": "how-to/integrate-framer-motion"
+        }
+      ],
+      "frameworks": [
+        {
+          "label": "react",
+          "children": []
+        },
+        {
+          "label": "solid",
+          "children": []
+        }
+      ]
+    },
+    {
       "label": "API",
       "children": [
         {


### PR DESCRIPTION
Fixes #6801

## Summary

The `docs/router/how-to/` directory contains 20+ focused, step-by-step guides covering authentication, search params, testing, SSR, deployment, UI library integration, and more — but none of them appeared in the docs navigation sidebar.

This PR adds a **"How To"** section to `docs/router/config.json`, positioned between "Guides" and "API", with entries for all existing how-to guides:

- Install TanStack Router
- Use Environment Variables
- Deploy to Production
- Set Up SSR
- Migrate from React Router
- Set Up Authentication / Auth Providers / RBAC
- Navigate / Set Up / Validate / Share Search Params
- Arrays, Objects & Dates in Search Params
- Set Up Testing / Test File-Based Routing
- Debug Router Issues
- Integrate Shadcn UI / Material UI / Chakra UI / Framer Motion

## Changes

- `docs/router/config.json`: add `"How To"` section with 20 entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive "How To" guides section with 20 new articles covering essential topics including installation, deployment, authentication, search parameters, testing, debugging, and integration with popular UI frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->