### PR TITLE
fix: re-export PathParamError class from @tanstack/router-core

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -271,7 +271,7 @@ export type {
 
 export { createRouter, Router } from './router'
 
-export { lazyFn, SearchParamError } from '@tanstack/router-core'
+export { lazyFn, PathParamError, SearchParamError } from '@tanstack/router-core'
 
 export { RouterProvider, RouterContextProvider } from './RouterProvider'
 export type { RouterProps } from './RouterProvider'


### PR DESCRIPTION
Re-add `PathParamError` re-exported from `@tanstack/router-core` alongside the already existing `SearchParamError` export.

The removal happened last week: https://github.com/TanStack/router/commit/d6af3a28c350ce7290ddff43723d6be9387bcd21#diff-d59f1a00dff1823e6f16ddf621c708682b1acc37566b17d047bbe4263a580058R238-R274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `PathParamError` is now publicly exported from the main package, making it directly available for import. This allows applications to reference and handle route parameter errors more explicitly (e.g., for better error handling or user feedback) without changing existing behavior. No other public APIs were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->