### PR TITLE
docs: Update route file name in routing concepts

### DIFF
--- a/docs/router/routing/routing-concepts.md
+++ b/docs/router/routing/routing-concepts.md
@@ -193,7 +193,7 @@ These params are then usable in your route's configuration and components! Let's
 
 # React
 
-```tsx title="src/routes/posts.tsx"
+```tsx title="src/routes/posts/$postId.tsx"
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/posts/$postId')({


### PR DESCRIPTION
The code block title `src/routes/posts.tsx` does not match against the line above `posts.$postId.tsx`

This pr fixes this typo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated routing guides with improved code examples that more accurately demonstrate dynamic route segment naming conventions in real-world implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->