### PR TITLE
test: client nav benchmark can detect granular re-rendering changes

### DIFF
--- a/benchmarks/client-nav/react/speed.bench.tsx
+++ b/benchmarks/client-nav/react/speed.bench.tsx
@@ -30,7 +30,8 @@ describe('client-nav', () => {
       return navigate({
         to: '/$id',
         params: { id: nextId },
-        search: { id: nextId },
+        // update search every 2 navigations, to still test them, but also measure the impact of granular re-rendering
+        search: { id: Math.floor(nextId / 2) },
         replace: true,
       })
     }

--- a/benchmarks/client-nav/solid/speed.bench.tsx
+++ b/benchmarks/client-nav/solid/speed.bench.tsx
@@ -30,12 +30,13 @@ describe('client-nav', () => {
       })
 
     next = () => {
-      const nextId = String(id++)
+      const nextId = id++
 
       return navigate({
         to: '/$id',
         params: { id: nextId },
-        search: { id: nextId },
+        // update search every 2 navigations, to still test them, but also measure the impact of granular re-rendering
+        search: { id: Math.floor(nextId / 2) },
         replace: true,
       })
     }

--- a/benchmarks/client-nav/vue/speed.bench.tsx
+++ b/benchmarks/client-nav/vue/speed.bench.tsx
@@ -29,7 +29,8 @@ describe('client-nav', () => {
       return navigate({
         to: '/$id',
         params: { id: nextId },
-        search: { id: nextId },
+        // update search every 2 navigations, to still test them, but also measure the impact of granular re-rendering
+        search: { id: Math.floor(nextId / 2) },
         replace: true,
       })
     }


### PR DESCRIPTION
in `@benchmarks/client-nav` performance tests, 
- keep params updated every nav
- update search only every other nav

This should allow us to detect perf changes in granular re-rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated navigation benchmarks to throttle search parameter updates for more granular re-rendering testing across React, Solid, and Vue implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->