### PR TITLE
fix(router-core): replace fatal invariant with null-check in SPA mode hydration

### DIFF
--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -255,37 +255,42 @@ export async function hydrate(router: AnyRouter): Promise<any> {
   // this will prevent that other pending components are rendered but hydration is not blocked
   if (isSpaMode) {
     const match = matches[1]
-    invariant(
-      match,
-      'Expected to find a match below the root match in SPA mode.',
-    )
-    setMatchForcePending(match)
+    // match can be undefined when hydrating a 404/error page in SPA mode (only root match exists)
+    // in that case, skip setting up pending state and let router.load() handle it
+    if (!match) {
+      console.warn(
+        'SPA hydration: no child match found below root match. This can happen during 404/error page hydration.',
+      )
+    } else {
+      setMatchForcePending(match)
 
-    match._displayPending = true
-    match._nonReactive.displayPendingPromise = loadPromise
+      match._displayPending = true
+      match._nonReactive.displayPendingPromise = loadPromise
 
-    loadPromise.then(() => {
-      batch(() => {
-        // ensure router is not in status 'pending' anymore
-        // this usually happens in Transitioner but if loading synchronously resolves,
-        // Transitioner won't be rendered while loading so it cannot track the change from loading:true to loading:false
-        if (router.__store.state.status === 'pending') {
-          router.__store.setState((s) => ({
-            ...s,
-            status: 'idle',
-            resolvedLocation: s.location,
-          }))
-        }
-        // hide the pending component once the load is finished
-        router.updateMatch(match.id, (prev) => {
-          return {
-            ...prev,
-            _displayPending: undefined,
-            displayPendingPromise: undefined,
+      loadPromise.then(() => {
+        batch(() => {
+          // ensure router is not in status 'pending' anymore
+          // this usually happens in Transitioner but if loading synchronously resolves,
+          // Transitioner won't be rendered while loading so it cannot track the change from loading:true to loading:false
+          if (router.__store.state.status === 'pending') {
+            router.__store.setState((s) => ({
+              ...s,
+              status: 'idle',
+              resolvedLocation: s.location,
+            }))
           }
+          // hide the pending component once the load is finished
+          router.updateMatch(match.id, (prev) => {
+            return {
+              ...prev,
+              _displayPending: undefined,
+              displayPendingPromise: undefined,
+            }
+          })
         })
       })
-    })
+    }
   }
   return routeChunkPromise
 }
+

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -281,10 +281,10 @@ export async function hydrate(router: AnyRouter): Promise<any> {
           }
           // hide the pending component once the load is finished
           router.updateMatch(match.id, (prev) => {
+            prev._nonReactive.displayPendingPromise = undefined
             return {
               ...prev,
               _displayPending: undefined,
-              displayPendingPromise: undefined,
             }
           })
         })

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -293,4 +293,3 @@ export async function hydrate(router: AnyRouter): Promise<any> {
   }
   return routeChunkPromise
 }
-


### PR DESCRIPTION
## Summary

Fixes #6806

## Problem

When hydrating a 404/error page in SPA mode, `matches[1]` can be `undefined` (only the root match exists). The code previously used a fatal `invariant()` that threw an uncaught error in this situation, causing a white screen of death.

This is particularly problematic in CJS environments (Cloudflare Pages/Wrangler, certain Node.js SSR setups) where the crash surfaces directly, but the underlying source is the same.

## Fix

Replace the fatal `invariant` with a graceful null-check and a `console.warn`, matching what was described in the issue. When no child match is found below the root in SPA mode, we warn and skip setting up the pending state — `router.load()` will handle the route resolution on its own.

```diff
-    invariant(
-      match,
-      'Expected to find a match below the root match in SPA mode.',
-    )
-    setMatchForcePending(match)
-    ...
+    if (!match) {
+      console.warn(
+        'SPA hydration: no child match found below root match. This can happen during 404/error page hydration.',
+      )
+    } else {
+      setMatchForcePending(match)
+      ...
+    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPA hydration to avoid crashes when loading error pages or unavailable routes (e.g., root-only/404 cases).
  * Prevented incorrect pending-state behavior and flicker when no child route is present, ensuring loading indicators only appear when appropriate.
  * Added safer handling that skips irrelevant pending logic during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->