### PR TITLE
Use @tanstack/cli for creating Tanstack Start application

### DIFF
--- a/docs/start/framework/react/getting-started.md
+++ b/docs/start/framework/react/getting-started.md
@@ -14,7 +14,7 @@ title: Getting Started
 
 Choose one of the following options to start building a _new_ TanStack Start project:
 
-- [TanStack Start CLI](./quick-start) - Just run `npm create @tanstack/start@latest`. Local, fast, and optionally customizable
+- [TanStack Start CLI](./quick-start) - Just run `npx @tanstack/cli create my-app`. Local, fast, and optionally customizable
 - [TanStack Builder](https://tanstack.com/builder) - A visual interface to configure new TanStack projects with a few clicks
 - [Quick Start Examples](./quick-start) Download or clone one of our official examples
 - [Build a project from scratch](./build-from-scratch) - A guide to building a TanStack Start project line-by-line, file-by-file.

--- a/docs/start/framework/react/quick-start.md
+++ b/docs/start/framework/react/quick-start.md
@@ -8,13 +8,13 @@ title: Quick Start
 The fastest way to get a Start project up and running is with the CLI. Just run
 
 ```
-pnpm create @tanstack/start@latest
+pnpx @tanstack/cli create my-app
 ```
 
 or
 
 ```
-npm create @tanstack/start@latest
+npx @tanstack/cli create my-app
 ```
 
 depending on your package manager of choice. You'll be prompted to add things like Tailwind, eslint, and a ton of other options.


### PR DESCRIPTION
Replace deprecated `npm create @tanstack/start@latest` with `npx @tanstack/cli create my-app`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React getting started and quick-start guides with new CLI command syntax for project creation across npm and pnpm package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->