### PR TITLE
docs: add How To section to router documentation sidebar

### DIFF
--- a/docs/router/config.json
+++ b/docs/router/config.json
@@ -323,6 +323,91 @@
       ]
     },
     {
+      "label": "How To",
+      "children": [
+        {
+          "label": "Install TanStack Router",
+          "to": "how-to/install"
+        },
+        {
+          "label": "Use Environment Variables",
+          "to": "how-to/use-environment-variables"
+        },
+        {
+          "label": "Deploy to Production",
+          "to": "how-to/deploy-to-production"
+        },
+        {
+          "label": "Set Up SSR",
+          "to": "how-to/setup-ssr"
+        },
+        {
+          "label": "Migrate from React Router",
+          "to": "how-to/migrate-from-react-router"
+        },
+        {
+          "label": "Set Up Authentication",
+          "to": "how-to/setup-authentication"
+        },
+        {
+          "label": "Integrate Auth Providers",
+          "to": "how-to/setup-auth-providers"
+        },
+        {
+          "label": "Set Up Role-Based Access Control",
+          "to": "how-to/setup-rbac"
+        },
+        {
+          "label": "Set Up Testing",
+          "to": "how-to/setup-testing"
+        },
+        {
+          "label": "Test File-Based Routing",
+          "to": "how-to/test-file-based-routing"
+        },
+        {
+          "label": "Debug Router Issues",
+          "to": "how-to/debug-router-issues"
+        },
+        {
+          "label": "Integrate Shadcn/ui",
+          "to": "how-to/integrate-shadcn-ui"
+        },
+        {
+          "label": "Integrate Material-UI",
+          "to": "how-to/integrate-material-ui"
+        },
+        {
+          "label": "Integrate Framer Motion",
+          "to": "how-to/integrate-framer-motion"
+        },
+        {
+          "label": "Integrate Chakra UI",
+          "to": "how-to/integrate-chakra-ui"
+        },
+        {
+          "label": "Set Up Basic Search Params",
+          "to": "how-to/setup-basic-search-params"
+        },
+        {
+          "label": "Navigate with Search Params",
+          "to": "how-to/navigate-with-search-params"
+        },
+        {
+          "label": "Validate Search Params",
+          "to": "how-to/validate-search-params"
+        },
+        {
+          "label": "Arrays, Objects & Dates in Search Params",
+          "to": "how-to/arrays-objects-dates-search-params"
+        },
+        {
+          "label": "Share Search Params Across Routes",
+          "to": "how-to/share-search-params-across-routes"
+        }
+      ]
+    },
+    {
       "label": "Router Examples",
       "children": [],
       "frameworks": [


### PR DESCRIPTION
The `docs/router/how-to/` directory contains 20 focused how-to guides covering installation, authentication, testing, UI library integration, and search parameter patterns, but they are not accessible from the documentation sidebar navigation.

This adds a "How To" section to `config.json` between the "ESLint" and "Router Examples" sections, listing all published guides. The guides were already live and individually accessible via direct URL (e.g. `/router/latest/docs/how-to/test-file-based-routing`), but users had no way to discover them through the sidebar.

Guides included:
- Installation, environment variables, deployment, SSR
- Authentication: basic setup, provider integration, RBAC
- Testing: code-based routing, file-based routing, debugging
- UI integration: Shadcn/ui, Material-UI, Framer Motion, Chakra UI
- Search params: basics, navigation, validation, complex types, sharing across routes

Fixes #6801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "How To" section with guides covering installation, deployment, SSR setup, authentication, testing, debugging, UI framework integrations (Shadcn/ui, Material-UI, Framer Motion, Chakra UI), and search parameter management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->