### PR TITLE
Add extraEnvironments option to TanStack Start config

### DIFF
--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -89,6 +89,7 @@ export function TanStackStartVitePluginCore(
     return bundle
   }
 
+  const extraEnvironmentNames: Array<string> = []
   const environments: Array<{ name: string; type: 'client' | 'server' }> = [
     { name: VITE_ENVIRONMENT_NAMES.client, type: 'client' },
     { name: VITE_ENVIRONMENT_NAMES.server, type: 'server' },
@@ -102,6 +103,11 @@ export function TanStackStartVitePluginCore(
       type: 'server',
     })
   }
+  if (Array.isArray(startPluginOpts?.extraEnvironments)) {
+    environments.push(...startPluginOpts.extraEnvironments)
+    extraEnvironmentNames.push(...startPluginOpts.extraEnvironments.map(e => e.name))
+  }
+
   return [
     {
       name: 'tanstack-start-core:config',
@@ -322,6 +328,13 @@ export function TanStackStartVitePluginCore(
             async buildApp(builder) {
               const client = builder.environments[VITE_ENVIRONMENT_NAMES.client]
               const server = builder.environments[VITE_ENVIRONMENT_NAMES.server]
+              const extraEnvironments = extraEnvironmentNames.map(environmentName => {
+                const environment = builder.environments[environmentName];
+                if (!environment) {
+                  throw new Error(`Environment ${environmentName} not found`);
+                }
+                return environment
+              })
 
               if (!client) {
                 throw new Error('Client environment not found')
@@ -335,6 +348,12 @@ export function TanStackStartVitePluginCore(
                 // Build the client bundle first
                 await builder.build(client)
               }
+
+              // Build extra environments
+              for(const extraEnvironment of extraEnvironments) {
+                await builder.build(extraEnvironment)
+              }
+
               if (!server.isBuilt) {
                 // Build the SSR bundle
                 await builder.build(server)

--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -268,6 +268,14 @@ const tanstackStartOptionsSchema = z
       .object({ installDevServerMiddleware: z.boolean().optional() })
       .optional(),
     importProtection: importProtectionOptionsSchema,
+    extraEnvironments: z
+      .array(
+        z.object({
+          name: z.string(),
+          type: z.enum(['client', 'server']),
+        }),
+      )
+      .optional(),
   })
   .optional()
   .default({})


### PR DESCRIPTION
## Overview

This adds the ability to add additional [vite environments](https://vite.dev/guide/api-environment) besides the default `ssr` and `client` environments to a TanStack Start build.

## Use Case

This can be used to call TanStack Server Functions from client code in an external project --- for example, an Electron app which implements an alternate front-end to your TanStack Start app.

## Usage

Pass `extraEnvironments` to the `tanstackStart()` vite plugin, containing an array of `name` (referencing a vite environment name) and `type` (either `'client'` or `'server'`).

**Example:** The following vite.config.js will generate an additional output artifact, `dist/external-api.js`, from `src/external-api.ts`, which in turn exports several Server Functions. The resulting JS file will contain the client stub for the server function.

```typescript
// vite.config.js
import { defineConfig, normalizePath } from 'vite'
import tsConfigPaths from 'vite-tsconfig-paths'
import { tanstackStart } from '@tanstack/react-start/plugin/vite'
import viteReact from '@vitejs/plugin-react'

export default defineConfig({
  server: {
    port: 3000,
  },
  environments: {
    externalAPI: {
      consumer: 'client',
      build: {
        emptyOutDir: false,
        lib: {
          entry: normalizePath('src/external-api.ts'),
          name: 'external-api',
          fileName: 'external-api',
          formats: ['es'],
        },
      },
      define: {
        'process.env.TSS_SERVER_FN_BASE': JSON.stringify('http://localhost:3000/_serverFn/'),
        'window.__TSS_START_OPTIONS__': JSON.stringify({}),
      },
    },
  },
  plugins: [
    tsConfigPaths(),
    tanstackStart({
      extraEnvironments: [
        { name: 'externalAPI', type: 'client' },
      ],
    }),
    viteReact(),
  ],
})
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extra environments support: Users can now configure additional custom environments by specifying a name and type (client or server). These extra environments will be automatically built and included in the final application build alongside standard environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->