### PR TITLE
fix(solid-router): wrap root Outlet child with CatchBoundary

### DIFF
--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -388,6 +388,11 @@ export const Outlet = () => {
   const shouldShowNotFound = () =>
     childMatchStatus() !== 'redirected' && parentGlobalNotFound()
 
+  const rootErrorComponent = () =>
+    router.routesById[rootRouteId]?.options.errorComponent ??
+    router.options.defaultErrorComponent
+  const rootResetKey = useRouterState({ select: (s) => s.loadedAt })
+
   return (
     <Solid.Show
       when={!shouldShowNotFound() && childMatchId()}
@@ -398,20 +403,33 @@ export const Outlet = () => {
       }
     >
       {(matchIdAccessor) => {
-        // Use a memo to avoid stale accessor errors while keeping reactivity
         const currentMatchId = Solid.createMemo(() => matchIdAccessor())
+
+        const childMatch = () => <Match matchId={currentMatchId()} />
 
         return (
           <Solid.Show
             when={routeId() === rootRouteId}
-            fallback={<Match matchId={currentMatchId()} />}
+            fallback={childMatch()}
           >
             <Solid.Suspense
               fallback={
                 <Dynamic component={router.options.defaultPendingComponent} />
               }
             >
-              <Match matchId={currentMatchId()} />
+              {rootErrorComponent() ? (
+                <CatchBoundary
+                  getResetKey={() => rootResetKey()}
+                  errorComponent={rootErrorComponent()!}
+                  onCatch={(error) => {
+                    if (isNotFound(error)) throw error
+                  }}
+                >
+                  {childMatch()}
+                </CatchBoundary>
+              ) : (
+                childMatch()
+              )}
             </Solid.Suspense>
           </Solid.Show>
         )


### PR DESCRIPTION
When `shellComponent` renders `<Outlet />` directly (the natural pattern) instead of `{props.children}`, the root's `CatchBoundary` from `Match` is never placed in the render tree. Errors re-thrown from a child route's `errorComponent` have no parent boundary to propagate to — the page goes blank.

## Fix

Unconditionally wrap the root Outlet's child `<Match>` with a `CatchBoundary` using the root's `errorComponent`. The extra boundary is harmless when `shellComponent` does render `{props.children}` — the inner `CatchBoundary` (from `Match`) catches first.

**1 file changed, +21 −3** — `packages/solid-router/src/Match.tsx`

## Verification

- All 775 existing unit tests pass (`pnpm vitest run`)
- E2E reproduction: https://github.com/ljho01/tanstack-solid-router-error-mre
  - **React**: 3/3 pass (baseline)
  - **Solid unpatched**: 1/3 pass (bug)
  - **Solid with this fix**: 3/3 pass

Closes #6845

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling at the root level with improved error recovery and boundary management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->