### PR TITLE
fix(router-generator): avoid zod function schema for routeTreeFileFooter

### DIFF
--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -15,6 +15,10 @@ const tokenMatcherSchema = z.union([
   tokenJsonRegexSchema,
 ])
 
+const stringArrayFactorySchema = z.custom<() => Array<string>>(
+  (value) => typeof value === 'function',
+)
+
 export type TokenMatcherJson = string | z.infer<typeof tokenJsonRegexSchema>
 
 export type TokenMatcher = z.infer<typeof tokenMatcherSchema>
@@ -61,7 +65,7 @@ export const configSchema = baseConfigSchema.extend({
   routeTreeFileFooter: z
     .union([
       z.array(z.string()).optional().default([]),
-      z.function().returns(z.array(z.string())),
+      stringArrayFactorySchema,
     ])
     .optional(),
   autoCodeSplitting: z.boolean().optional(),

--- a/packages/router-generator/tests/config.test.ts
+++ b/packages/router-generator/tests/config.test.ts
@@ -30,4 +30,18 @@ describe('load config tests', () => {
       )
     },
   )
+
+  it('accepts routeTreeFileFooter as a function', () => {
+    const routeTreeFileFooter = () => ['// append']
+    const resolvedConfig = getConfig({ routeTreeFileFooter })
+
+    expect(resolvedConfig.routeTreeFileFooter).toBe(routeTreeFileFooter)
+  })
+
+  it('accepts routeTreeFileFooter as an array', () => {
+    const routeTreeFileFooter = ['// append']
+    const resolvedConfig = getConfig({ routeTreeFileFooter })
+
+    expect(resolvedConfig.routeTreeFileFooter).toEqual(routeTreeFileFooter)
+  })
 })


### PR DESCRIPTION
## Summary

Replace the `routeTreeFileFooter` function schema in `@tanstack/router-generator` with a cross-version callable guard.

The current config schema uses `z.function().returns(z.array(z.string()))`, which is a Zod v3-style function schema API and causes compatibility issues for consumers on Zod v4 in this package context.

This change narrows the fix to the actual runtime requirement for `routeTreeFileFooter`: it only needs to accept either:

- `string[]`
- a callable that returns `string[]`

At runtime, the generator only distinguishes between those two shapes:

- `Array.isArray(config.routeTreeFileFooter)`
- otherwise invoke `config.routeTreeFileFooter()`

So a typed callable guard is sufficient here and avoids consumer-side patching of installed package files.

## Changes

- replace `z.function().returns(z.array(z.string()))` with `z.custom<() => string[]>((value) => typeof value === 'function')`
- add config tests covering both array and function forms of `routeTreeFileFooter`

## Why

A downstream consumer currently has to patch the published package after install to keep their app working with Zod v4. This change removes the need for that workaround in the `router-generator` config surface.

## Verification

Ran locally:

- `pnpm --dir packages/router-generator exec vitest run tests/config.test.ts`
- `pnpm --dir packages/router-generator test:types`
- `pnpm --dir packages/router-generator test:eslint`
- `pnpm --dir packages/router-generator test:build`

All passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `routeTreeFileFooter` configuration parameter now accepts both static string arrays and factory functions that dynamically return string arrays, providing greater flexibility in defining route tree footer content at configuration time.

* **Tests**
  * Added test coverage to verify correct behavior when `routeTreeFileFooter` is provided as either a static array or a factory function, ensuring proper value preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->