### PR TITLE
refactor(solid-router): replace useMatch __pick with equals

### DIFF
--- a/packages/solid-router/src/useLoaderDeps.tsx
+++ b/packages/solid-router/src/useLoaderDeps.tsx
@@ -37,11 +37,11 @@ export function useLoaderDeps<
 >(
   opts: UseLoaderDepsOptions<TRouter, TFrom, TSelected>,
 ): Accessor<UseLoaderDepsResult<TRouter, TFrom, TSelected>> {
-  const { select, ...rest } = opts
   return useMatch({
-    ...rest,
+    ...opts,
+    equals: opts.select ? undefined : Object.is,
     select: (s) => {
-      return select ? select(s.loaderDeps) : s.loaderDeps
+      return opts.select ? opts.select(s.loaderDeps) : s.loaderDeps
     },
   }) as Accessor<UseLoaderDepsResult<TRouter, TFrom, TSelected>>
 }

--- a/packages/solid-router/src/useMatch.tsx
+++ b/packages/solid-router/src/useMatch.tsx
@@ -13,8 +13,6 @@ import type {
   ThrowOrOptional,
 } from '@tanstack/router-core'
 
-type MatchPick = 'search' | 'params' | '_strictParams'
-
 export interface UseMatchBaseOptions<
   TRouter extends AnyRouter,
   TFrom,
@@ -27,7 +25,9 @@ export interface UseMatchBaseOptions<
   ) => TSelected
   shouldThrow?: TThrow
   /** @internal */
-  __pick?: MatchPick
+  equals?:
+    | false
+    | ((prev: TSelected | undefined, next: TSelected | undefined) => boolean)
 }
 
 export type UseMatchRoute<out TFrom> = <
@@ -114,13 +114,11 @@ export function useMatch<
         return undefined
       }
 
-      if (opts.__pick) {
-        return selectedMatch[opts.__pick]
-      }
-
-      return opts.select ? opts.select(selectedMatch as any) : selectedMatch
+      return (
+        opts.select ? opts.select(selectedMatch as any) : selectedMatch
+      ) as any
     },
     undefined,
-    { equals: opts.__pick ? Object.is : shallow },
+    { equals: opts.equals ?? shallow },
   ) as any
 }

--- a/packages/solid-router/src/useParams.tsx
+++ b/packages/solid-router/src/useParams.tsx
@@ -1,6 +1,4 @@
-import * as Solid from 'solid-js'
 import { useMatch } from './useMatch'
-import { shallow } from './store'
 import type { Accessor } from 'solid-js'
 import type {
   AnyRouter,
@@ -62,29 +60,14 @@ export function useParams<
 ): Accessor<
   ThrowOrOptional<UseParamsResult<TRouter, TFrom, TStrict, TSelected>, TThrow>
 > {
-  const params = useMatch({
+  return useMatch({
     from: opts.from!,
     strict: opts.strict,
     shouldThrow: opts.shouldThrow,
-    __pick: opts.strict === false ? 'params' : '_strictParams',
-  }) as Accessor<any>
-
-  if (!opts.select) {
-    return params
-  }
-
-  const select = opts.select
-
-  return Solid.createMemo(
-    () => {
-      const selectedParams = params()
-      if (selectedParams === undefined) {
-        return undefined
-      }
-
-      return select(selectedParams)
+    equals: opts.select ? undefined : Object.is,
+    select: (match: any) => {
+      const params = opts.strict === false ? match.params : match._strictParams
+      return opts.select ? opts.select(params) : params
     },
-    undefined,
-    { equals: shallow },
-  ) as Accessor<any>
+  }) as Accessor<any>
 }

--- a/packages/solid-router/src/useSearch.tsx
+++ b/packages/solid-router/src/useSearch.tsx
@@ -1,6 +1,4 @@
-import * as Solid from 'solid-js'
 import { useMatch } from './useMatch'
-import { shallow } from './store'
 import type { Accessor } from 'solid-js'
 import type {
   AnyRouter,
@@ -62,29 +60,14 @@ export function useSearch<
 ): Accessor<
   ThrowOrOptional<UseSearchResult<TRouter, TFrom, TStrict, TSelected>, TThrow>
 > {
-  const search = useMatch({
+  return useMatch({
     from: opts.from!,
     strict: opts.strict,
     shouldThrow: opts.shouldThrow,
-    __pick: 'search',
-  }) as Accessor<any>
-
-  if (!opts.select) {
-    return search
-  }
-
-  const select = opts.select
-
-  return Solid.createMemo(
-    () => {
-      const selectedSearch = search()
-      if (selectedSearch === undefined) {
-        return undefined
-      }
-
-      return select(selectedSearch)
+    equals: opts.select ? undefined : Object.is,
+    select: (match: any) => {
+      const search = match.search
+      return opts.select ? opts.select(search) : search
     },
-    undefined,
-    { equals: shallow },
-  ) as any
+  }) as any
 }


### PR DESCRIPTION
## Summary
- remove the internal `__pick` path from Solid `useMatch` and replace it with an internal `equals` option
- route internal `useSearch`, `useParams`, and `useLoaderDeps` through normal selectors while preserving the `Object.is` fast path for unselected values
- simplify the Solid selector wiring without changing the default shallow comparison for public selected values

## Testing
- CI=1 NX_DAEMON=false pnpm nx run @tanstack/solid-router:test:types --outputStyle=stream --skipRemoteCache
- CI=1 NX_DAEMON=false pnpm nx run @tanstack/solid-router:test:unit --outputStyle=stream --skipRemoteCache