### PR TITLE
fix(react-router): avoid Link rerenders from location selector

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useStore } from '@tanstack/react-store'
+import { shallow, useStore } from '@tanstack/react-store'
 import { flushSync } from 'react-dom'
 import {
   deepEqual,
@@ -379,11 +379,15 @@ export function useLinkProps<
 
   // Subscribe to current location for active-state checks and relative-link resolution.
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const currentLocation = useStore(router.stores.location, (location) => ({
-    pathname: location.pathname,
-    search: location.search,
-    hash: location.hash,
-  }))
+  const currentLocation = useStore(
+    router.stores.location,
+    (location) => ({
+      pathname: location.pathname,
+      search: location.search,
+      hash: location.hash,
+    }),
+    shallow,
+  )
   // Subscribe to current leaf match identity for relative-link resolution.
   // This avoids broad match-array subscriptions while still invalidating href
   // computation when the leaf route/params context changes.


### PR DESCRIPTION
## Summary
- use `shallow` equality for the React `Link` location selector so location store updates do not force rerenders when `pathname`, `search`, and `hash` are unchanged
- keep the change scoped to `packages/react-router/src/link.tsx` for the `refactor-signals` branch

## Testing
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:unit --outputStyle=stream --skipRemoteCache -- tests/link.test.tsx -t \"does not rerender memoized links when only location state changes\"`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:eslint --outputStyle=stream --skipRemoteCache`