### PR TITLE
refactor(react-router): cache outlet child lookups

### DIFF
--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -440,15 +440,14 @@ export const Outlet = React.memo(function OutletImpl() {
   let childMatchId: string | undefined
 
   if (isServer ?? router.isServer) {
-    const matches = router.state.matches
-    const parentIndex = matchId
-      ? matches.findIndex((match) => match.id === matchId)
-      : -1
-    const parentMatch = parentIndex >= 0 ? matches[parentIndex] : undefined
+    const parentMatch = matchId
+      ? router.stores.activeMatchStoresById.get(matchId)?.state
+      : undefined
     routeId = parentMatch?.routeId as string | undefined
     parentGlobalNotFound = parentMatch?.globalNotFound ?? false
-    childMatchId =
-      parentIndex >= 0 ? (matches[parentIndex + 1]?.id as string) : undefined
+    childMatchId = routeId
+      ? router.stores.childMatchIdByRouteId.state[routeId]
+      : undefined
   } else {
     // Subscribe directly to the match store from the pool instead of
     // the two-level byId → matchStore pattern.
@@ -463,10 +462,9 @@ export const Outlet = React.memo(function OutletImpl() {
     ])
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    childMatchId = useStore(router.stores.matchesId, (ids) => {
-      const index = ids.findIndex((id) => id === matchId)
-      return ids[index + 1]
-    })
+    childMatchId = useStore(router.stores.childMatchIdByRouteId, (ids) =>
+      routeId ? ids[routeId] : undefined,
+    )
   }
 
   const route = routeId ? router.routesById[routeId] : undefined

--- a/packages/react-router/src/routerStores.ts
+++ b/packages/react-router/src/routerStores.ts
@@ -5,22 +5,59 @@ import {
 } from '@tanstack/router-core'
 import { isServer } from '@tanstack/router-core/isServer'
 import type { Readable } from '@tanstack/react-store'
-import type { GetStoreConfig } from '@tanstack/router-core'
+import type {
+  AnyRoute,
+  GetStoreConfig,
+  RouterReadableStore,
+  RouterStores,
+} from '@tanstack/router-core'
 
 declare module '@tanstack/router-core' {
   export interface RouterReadableStore<TValue> extends Readable<TValue> {}
+
+  export interface RouterStores<in out TRouteTree extends AnyRoute> {
+    /** Maps each active routeId to the matchId of its child in the match tree. */
+    childMatchIdByRouteId: RouterReadableStore<Record<string, string>>
+  }
 }
+
+function initRouterStores(
+  stores: RouterStores<AnyRoute>,
+  createReadonlyStore: <TValue>(
+    read: () => TValue,
+  ) => RouterReadableStore<TValue>,
+) {
+  stores.childMatchIdByRouteId = createReadonlyStore(() => {
+    const ids = stores.matchesId.state
+    const obj: Record<string, string> = {}
+
+    for (let i = 0; i < ids.length - 1; i++) {
+      const parentStore = stores.activeMatchStoresById.get(ids[i]!)
+
+      if (parentStore?.routeId) {
+        obj[parentStore.routeId] = ids[i + 1]!
+      }
+    }
+
+    return obj
+  })
+}
+
 export const getStoreFactory: GetStoreConfig = (opts) => {
   if (isServer ?? opts.isServer) {
     return {
       createMutableStore: createNonReactiveMutableStore,
       createReadonlyStore: createNonReactiveReadonlyStore,
       batch: (fn) => fn(),
+      init: (stores) =>
+        initRouterStores(stores, createNonReactiveReadonlyStore),
     }
   }
+
   return {
     createMutableStore: createStore,
     createReadonlyStore: createStore,
     batch: batch,
+    init: (stores) => initRouterStores(stores, createStore),
   }
 }


### PR DESCRIPTION
> [!NOTE]
> i'm not convinced we need this. It does yield a stable 1% client-nav improvement at the cost of more code. There might be an architecture-driven solution that would benefit all 3 adapters: 
> 1. add `depth` to each route definition, this is known at initialization
> 2. then you just need to look up that index in the matchIds array

## Summary
- add a shared `childMatchIdByRouteId` derived store in the React router store factory
- have `Outlet` read the next child match from that store on both the client and server instead of scanning `matchesId`
- leave the local test addition out of this PR per request