### PR TITLE
test: cover vue Link transition slot state

### DIFF
--- a/packages/vue-router/tests/link.test.tsx
+++ b/packages/vue-router/tests/link.test.tsx
@@ -4668,6 +4668,79 @@ describe('Link', () => {
     expect(window.location.pathname).toBe('/posts')
   })
 
+  test('Link slot receives isTransitioning during pending navigation', async () => {
+    let resolvePostsLoader: (() => void) | undefined
+
+    const postsLoaderPromise = new Promise<void>((resolve) => {
+      resolvePostsLoader = resolve
+    })
+
+    const rootRoute = createRootRoute({
+      component: () =>
+        Vue.h(Vue.Fragment, null, [
+          Vue.h(
+            Link,
+            { to: '/posts', 'data-testid': 'posts-link' },
+            {
+              default: ({ isTransitioning }: { isTransitioning: boolean }) => (
+                <>
+                  <span data-testid="slot-transition-state">
+                    {isTransitioning ? 'transitioning' : 'idle'}
+                  </span>
+                  <span>Posts</span>
+                </>
+              ),
+            },
+          ),
+          Vue.h(Outlet),
+        ]),
+    })
+
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <h1>Index page</h1>,
+    })
+
+    const postsRoute = createRoute({
+      ssr: false,
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      loader: () => postsLoaderPromise,
+      component: () => <h1>Posts page</h1>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+      history,
+    })
+
+    render(<RouterProvider router={router} />)
+
+    await screen.findByRole('heading', { name: 'Index page' })
+
+    const postsLink = await screen.findByTestId('posts-link')
+    const transitionState = await screen.findByTestId('slot-transition-state')
+
+    expect(transitionState).toHaveTextContent('idle')
+    expect(postsLink).not.toHaveAttribute('data-transitioning')
+
+    fireEvent.click(postsLink)
+
+    await waitFor(() => expect(resolvePostsLoader).toBeDefined())
+    await waitFor(() =>
+      expect(transitionState).toHaveTextContent('transitioning'),
+    )
+    expect(postsLink).toHaveAttribute('data-transitioning', 'transitioning')
+
+    resolvePostsLoader?.()
+
+    await screen.findByRole('heading', { name: 'Posts page' })
+
+    await waitFor(() => expect(transitionState).toHaveTextContent('idle'))
+    expect(postsLink).not.toHaveAttribute('data-transitioning')
+  })
+
   describe('when preloading a link, `preload` should be', () => {
     async function runTest({
       expectedPreload,


### PR DESCRIPTION
## Summary
- add a Vue router regression test covering `Link` slot propagation of `isTransitioning` during a pending navigation
- assert both the slot state and `data-transitioning` flip while the target route loader is unresolved
- document the current regression boundary by using a case that passes on `main` and fails on `refactor-signals`

## Testing
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/vue-router:test:unit --outputStyle=stream --skipRemoteCache -- tests/link.test.tsx -t "Link slot receives isTransitioning during pending navigation"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Link component slot functionality during navigation transitions. Tests verify that the transitioning state is properly reflected in the slot during pending navigation, and that the state correctly reverts after navigation completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->