### PR TITLE
test: add useLocation structural sharing regression coverage

### DIFF
--- a/packages/react-router/tests/useLocation.test.tsx
+++ b/packages/react-router/tests/useLocation.test.tsx
@@ -1,0 +1,92 @@
+import { useEffect } from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  useLocation,
+} from '../src'
+
+afterEach(() => {
+  window.history.replaceState(null, 'root', '/')
+  cleanup()
+})
+
+describe('useLocation', () => {
+  test('keeps a selected pathname reference stable across search and hash updates when structural sharing is enabled', async () => {
+    const effectSpy = vi.fn()
+    const pathnameSelections: Array<{ pathname: string }> = []
+
+    const rootRoute = createRootRoute({
+      component: function RootComponent() {
+        const pathnameSelection = useLocation({
+          select: (location) => ({ pathname: location.pathname }),
+        })
+
+        useEffect(() => {
+          effectSpy(pathnameSelection)
+          pathnameSelections.push(pathnameSelection)
+        }, [pathnameSelection])
+
+        return <Outlet />
+      },
+    })
+
+    const postsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      component: () => <h1>Posts</h1>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([postsRoute]),
+      history: createMemoryHistory({
+        initialEntries: ['/posts?foo=one#first'],
+      }),
+      defaultStructuralSharing: true,
+    })
+
+    render(<RouterProvider router={router} />)
+
+    expect(
+      await screen.findByRole('heading', { name: 'Posts' }),
+    ).toBeInTheDocument()
+
+    await waitFor(() => expect(effectSpy).toHaveBeenCalledTimes(1))
+
+    const initialPathnameSelection = pathnameSelections[0]
+
+    await act(() =>
+      router.navigate({
+        to: '/posts',
+        search: { foo: 'two' },
+        hash: 'first',
+      }),
+    )
+
+    await waitFor(() => {
+      expect(router.state.location.search).toEqual({ foo: 'two' })
+      expect(effectSpy).toHaveBeenCalledTimes(1)
+    })
+
+    await act(() =>
+      router.navigate({
+        to: '/posts',
+        search: { foo: 'two' },
+        hash: 'second',
+      }),
+    )
+
+    await waitFor(() => {
+      expect(router.state.location.hash).toBe('second')
+      expect(effectSpy).toHaveBeenCalledTimes(1)
+    })
+
+    expect(pathnameSelections).toHaveLength(1)
+    expect(pathnameSelections[0]).toBe(initialPathnameSelection)
+  })
+})


### PR DESCRIPTION
## Summary
- add a React Router regression test covering `useLocation` selectors with structural sharing enabled
- assert pathname-only selections keep a stable reference across search-only and hash-only navigations
- capture the behavior that passes on `main` and reproduces the regression on `refactor-signals`

## Testing
- `CI=1 NX_DAEMON=false pnpm nx affected --target=test:eslint --outputStyle=stream --skipRemoteCache --exclude=examples/**,e2e/**`
- `CI=1 NX_DAEMON=false pnpm nx affected --target=test:types --outputStyle=stream --skipRemoteCache --exclude=examples/**`
- `CI=1 NX_DAEMON=false pnpm nx affected --target=test:unit --outputStyle=stream --skipRemoteCache --exclude=examples/**,e2e/**`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:unit --outputStyle=stream --skipRemoteCache -- tests/useLocation.test.tsx`
- verified the same targeted test fails on `refactor-signals`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the useLocation hook's selector stability and behavior during navigation across different route paths and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->