### PR TITLE
test: cover Solid SSR route error rendering

### DIFF
--- a/packages/solid-router/tests/server/errorComponent.test.tsx
+++ b/packages/solid-router/tests/server/errorComponent.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { renderToStringAsync } from 'solid-js/web'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../../src'
+
+describe('errorComponent (server)', () => {
+  it('renders the route error component when a loader throws during SSR', async () => {
+    const rootRoute = createRootRoute()
+
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      loader: () => {
+        throw new Error('loader boom')
+      },
+      component: () => <div>Index route</div>,
+      errorComponent: ({ error }) => (
+        <div data-testid="error-component">Route error: {error.message}</div>
+      ),
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({
+      routeTree,
+      history: createMemoryHistory({
+        initialEntries: ['/'],
+      }),
+      isServer: true,
+    })
+
+    await router.load()
+
+    const html = await renderToStringAsync(() => (
+      <RouterProvider router={router} />
+    ))
+
+    expect(router.state.statusCode).toBe(500)
+    expect(html).toContain('data-testid="error-component"')
+    expect(html).toContain('loader boom')
+    expect(html).not.toContain('Index route')
+  })
+})


### PR DESCRIPTION
## Summary
- add a Solid server-side regression test for a route loader throwing during SSR
- assert the response status becomes 500 and the rendered HTML contains the route error component instead of the route component
- document the current main-branch behavior so future SSR error handling changes are caught

## Validation
- `pnpm exec vitest --mode server tests/server/errorComponent.test.tsx`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/solid-router:test:eslint --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/solid-router:test:types --outputStyle=stream --skipRemoteCache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for server-side error handling in route loaders, validating that error components render correctly and appropriate status codes are returned when errors occur during server-side rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->