### PR TITLE
refactor(vue-router): reduce Match pending churn

### DIFF
--- a/packages/vue-router/src/Match.tsx
+++ b/packages/vue-router/src/Match.tsx
@@ -59,9 +59,10 @@ export const Match = Vue.defineComponent({
       router.stores.getMatchStoreByRouteId(routeId),
       (value) => value,
     )
-    const pendingMatchIds = useStore(
-      router.stores.pendingMatchesId,
-      (ids) => ids,
+    const isPendingMatchRef = useStore(
+      router.stores.pendingRouteIds,
+      (pendingRouteIds) => Boolean(pendingRouteIds[routeId]),
+      { equal: Object.is },
     )
     const loadedAt = useStore(router.stores.loadedAt, (value) => value)
 
@@ -127,16 +128,13 @@ export const Match = Vue.defineComponent({
     // MatchInner, Outlet, and useMatch all consume this.
     Vue.provide(routeIdContext, routeId)
 
-    // Provide matchId ref for backward compat and pending check.
+    // Provide matchId ref for backward compat.
     // Derived from the reactive match state — always reflects the current matchId.
     const matchIdRef = Vue.computed(
       () => activeMatch.value?.id ?? props.matchId,
     )
     Vue.provide(matchContext, matchIdRef)
 
-    const isPendingMatchRef = Vue.computed(() =>
-      pendingMatchIds.value.includes(matchIdRef.value),
-    )
     Vue.provide(pendingMatchContext, isPendingMatchRef)
 
     return (): VNode => {


### PR DESCRIPTION
## Summary
- switch `packages/vue-router/src/Match.tsx` from `pendingMatchesId.includes(...)` to a direct `pendingRouteIds[routeId]` lookup
- keep the provided pending ref stable with `Object.is` equality so `Match` only reacts when that route's pending boolean changes
- preserve existing behavior while reducing residual churn during Vue navigations

## Testing
- CI=1 NX_DAEMON=false pnpm exec nx run @tanstack/vue-router:test:unit --outputStyle=stream --skipRemoteCache
- CI=1 NX_DAEMON=false pnpm exec nx run @tanstack/vue-router:test:types --outputStyle=stream --skipRemoteCache