### PR TITLE
refactor(vue-router): clean up match context internals

### DIFF
--- a/packages/vue-router/src/Match.tsx
+++ b/packages/vue-router/src/Match.tsx
@@ -128,8 +128,8 @@ export const Match = Vue.defineComponent({
     // MatchInner, Outlet, and useMatch all consume this.
     Vue.provide(routeIdContext, routeId)
 
-    // Provide matchId ref for backward compat.
-    // Derived from the reactive match state — always reflects the current matchId.
+    // Provide reactive nearest-match context for hooks that slice the active
+    // matches array relative to the current match.
     const matchIdRef = Vue.computed(
       () => activeMatch.value?.id ?? props.matchId,
     )

--- a/packages/vue-router/src/matchContext.tsx
+++ b/packages/vue-router/src/matchContext.tsx
@@ -1,15 +1,10 @@
 import * as Vue from 'vue'
 
-// Create a typed injection key with support for undefined values
-// This is the primary match context used throughout the router
+// Reactive nearest-match context used by hooks that work relative to the
+// current match in the tree.
 export const matchContext = Symbol('TanStackRouterMatch') as Vue.InjectionKey<
   Vue.Ref<string | undefined>
 >
-
-// Dummy match context for when we want to look up by explicit 'from' route
-export const dummyMatchContext = Symbol(
-  'TanStackRouterDummyMatch',
-) as Vue.InjectionKey<Vue.Ref<string | undefined>>
 
 // Pending match context for nearest-match lookups
 export const pendingMatchContext = Symbol(
@@ -27,35 +22,6 @@ export const dummyPendingMatchContext = Symbol(
 export const routeIdContext = Symbol(
   'TanStackRouterRouteId',
 ) as Vue.InjectionKey<string>
-
-/**
- * Provides a match ID to child components
- */
-export function provideMatch(matchId: string | undefined) {
-  Vue.provide(matchContext, Vue.ref(matchId))
-}
-
-/**
- * Retrieves the match ID from the component tree
- */
-export function injectMatch(): Vue.Ref<string | undefined> {
-  return Vue.inject(matchContext, Vue.ref(undefined))
-}
-
-/**
- * Provides a dummy match ID to child components
- */
-export function provideDummyMatch(matchId: string | undefined) {
-  Vue.provide(dummyMatchContext, Vue.ref(matchId))
-}
-
-/**
- * Retrieves the dummy match ID from the component tree
- * This only exists so we can conditionally inject a value when we are not interested in the nearest match
- */
-export function injectDummyMatch(): Vue.Ref<string | undefined> {
-  return Vue.inject(dummyMatchContext, Vue.ref(undefined))
-}
 
 /**
  * Retrieves nearest pending-match state from the component tree


### PR DESCRIPTION
## Summary
- update the Vue match context comments to describe the current nearest-match usage instead of backward-compat behavior
- remove unused internal Vue match context helpers that no longer have any call sites
- keep the cleanup scoped to Vue after checking that the equivalent React and Solid internals are still live

## Testing
- pnpm test:eslint
- pnpm test:types
- pnpm test:unit