### PR TITLE
test: add selective ssr nested pending repros

### DIFF
--- a/e2e/solid-start/selective-ssr/src/routeTree.gen.ts
+++ b/e2e/solid-start/selective-ssr/src/routeTree.gen.ts
@@ -11,6 +11,8 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as PostsRouteImport } from './routes/posts'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as PostsPendingInheritRouteImport } from './routes/posts.pending-inherit'
+import { Route as PostsPendingDataOnlyComponentRouteImport } from './routes/posts.pending-data-only-component'
 import { Route as PostsPostIdRouteImport } from './routes/posts.$postId'
 
 const PostsRoute = PostsRouteImport.update({
@@ -23,6 +25,17 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PostsPendingInheritRoute = PostsPendingInheritRouteImport.update({
+  id: '/pending-inherit',
+  path: '/pending-inherit',
+  getParentRoute: () => PostsRoute,
+} as any)
+const PostsPendingDataOnlyComponentRoute =
+  PostsPendingDataOnlyComponentRouteImport.update({
+    id: '/pending-data-only-component',
+    path: '/pending-data-only-component',
+    getParentRoute: () => PostsRoute,
+  } as any)
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
   id: '/$postId',
   path: '/$postId',
@@ -33,24 +46,46 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/posts': typeof PostsRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
+  '/posts/pending-data-only-component': typeof PostsPendingDataOnlyComponentRoute
+  '/posts/pending-inherit': typeof PostsPendingInheritRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/posts': typeof PostsRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
+  '/posts/pending-data-only-component': typeof PostsPendingDataOnlyComponentRoute
+  '/posts/pending-inherit': typeof PostsPendingInheritRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/posts': typeof PostsRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
+  '/posts/pending-data-only-component': typeof PostsPendingDataOnlyComponentRoute
+  '/posts/pending-inherit': typeof PostsPendingInheritRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/posts' | '/posts/$postId'
+  fullPaths:
+    | '/'
+    | '/posts'
+    | '/posts/$postId'
+    | '/posts/pending-data-only-component'
+    | '/posts/pending-inherit'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/posts' | '/posts/$postId'
-  id: '__root__' | '/' | '/posts' | '/posts/$postId'
+  to:
+    | '/'
+    | '/posts'
+    | '/posts/$postId'
+    | '/posts/pending-data-only-component'
+    | '/posts/pending-inherit'
+  id:
+    | '__root__'
+    | '/'
+    | '/posts'
+    | '/posts/$postId'
+    | '/posts/pending-data-only-component'
+    | '/posts/pending-inherit'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -74,6 +109,20 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/posts/pending-inherit': {
+      id: '/posts/pending-inherit'
+      path: '/pending-inherit'
+      fullPath: '/posts/pending-inherit'
+      preLoaderRoute: typeof PostsPendingInheritRouteImport
+      parentRoute: typeof PostsRoute
+    }
+    '/posts/pending-data-only-component': {
+      id: '/posts/pending-data-only-component'
+      path: '/pending-data-only-component'
+      fullPath: '/posts/pending-data-only-component'
+      preLoaderRoute: typeof PostsPendingDataOnlyComponentRouteImport
+      parentRoute: typeof PostsRoute
+    }
     '/posts/$postId': {
       id: '/posts/$postId'
       path: '/$postId'
@@ -86,10 +135,14 @@ declare module '@tanstack/solid-router' {
 
 interface PostsRouteChildren {
   PostsPostIdRoute: typeof PostsPostIdRoute
+  PostsPendingDataOnlyComponentRoute: typeof PostsPendingDataOnlyComponentRoute
+  PostsPendingInheritRoute: typeof PostsPendingInheritRoute
 }
 
 const PostsRouteChildren: PostsRouteChildren = {
   PostsPostIdRoute: PostsPostIdRoute,
+  PostsPendingDataOnlyComponentRoute: PostsPendingDataOnlyComponentRoute,
+  PostsPendingInheritRoute: PostsPendingInheritRoute,
 }
 
 const PostsRouteWithChildren = PostsRoute._addFileChildren(PostsRouteChildren)

--- a/e2e/solid-start/selective-ssr/src/routes/index.tsx
+++ b/e2e/solid-start/selective-ssr/src/routes/index.tsx
@@ -174,6 +174,42 @@ function Home() {
       <div>
         test count: <b data-testid="test-count">{links.length}</b>
       </div>
+      <div>
+        <Link
+          data-testid="nested-inherit-ssr-false-link"
+          to="/posts/pending-inherit"
+          search={{
+            root: {
+              ssr: true,
+              expected: { data: 'server', render: 'server-and-client' },
+            },
+            posts: {
+              ssr: false,
+              expected: { data: 'client', render: 'client-only' },
+            },
+          }}
+        >
+          nested inherit ssr false
+        </Link>
+      </div>
+      <div>
+        <Link
+          data-testid="nested-inherit-data-only-link"
+          to="/posts/pending-data-only-component"
+          search={{
+            root: {
+              ssr: true,
+              expected: { data: 'server', render: 'server-and-client' },
+            },
+            posts: {
+              ssr: 'data-only',
+              expected: { data: 'server', render: 'client-only' },
+            },
+          }}
+        >
+          nested inherit data only
+        </Link>
+      </div>
       <div>{links}</div>
     </>
   )

--- a/e2e/solid-start/selective-ssr/src/routes/posts.pending-data-only-component.tsx
+++ b/e2e/solid-start/selective-ssr/src/routes/posts.pending-data-only-component.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/solid-router'
+import { createResource } from 'solid-js'
+
+function PendingDataOnlyComponent() {
+  const [value] = createResource(() => new Promise<string>(() => {}))
+
+  return <div data-testid="pending-data-only-route">{value()}</div>
+}
+
+export const Route = createFileRoute('/posts/pending-data-only-component')({
+  pendingMs: 0,
+  pendingComponent: () => (
+    <div data-testid="pending-data-only-fallback">
+      Pending data-only fallback
+    </div>
+  ),
+  component: PendingDataOnlyComponent,
+})

--- a/e2e/solid-start/selective-ssr/src/routes/posts.pending-inherit.tsx
+++ b/e2e/solid-start/selective-ssr/src/routes/posts.pending-inherit.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute('/posts/pending-inherit')({
+  pendingMs: 0,
+  pendingComponent: () => (
+    <div data-testid="pending-inherit-fallback">Pending inherit fallback</div>
+  ),
+  loader: () => new Promise<never>(() => {}),
+  component: () => (
+    <div data-testid="pending-inherit-route">Pending inherit route</div>
+  ),
+})

--- a/e2e/solid-start/selective-ssr/tests/app.spec.ts
+++ b/e2e/solid-start/selective-ssr/tests/app.spec.ts
@@ -10,6 +10,35 @@ test.describe('selective ssr', () => {
     await expect(page.getByTestId('test-count')).toHaveText(`${testCount}`)
   })
 
+  test('nested inherited ssr false shows pending fallback during client nav', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    await expect(page.getByTestId('test-count')).toHaveText(`${testCount}`)
+
+    await page.getByTestId('nested-inherit-ssr-false-link').click()
+
+    await expect(page.getByTestId('posts-heading')).toContainText('posts')
+    await expect(page.getByTestId('router-status')).toContainText('pending')
+    await page.waitForTimeout(100)
+    await expect(page.getByTestId('pending-inherit-fallback')).toBeVisible()
+  })
+
+  test('nested inherited data-only shows pending fallback during client nav', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    await expect(page.getByTestId('test-count')).toHaveText(`${testCount}`)
+
+    await page.getByTestId('nested-inherit-data-only-link').click()
+
+    await expect(page.getByTestId('posts-heading')).toContainText('posts')
+    await page.waitForTimeout(100)
+    await expect(page.getByTestId('pending-data-only-fallback')).toBeVisible()
+  })
+
   for (let i = 0; i < testCount; i++) {
     test(`run test ${i}`, async ({ page }) => {
       await page.goto('/')


### PR DESCRIPTION
> [!NOTE]
> Nobody seems to have complained about this yet, so we can wait for https://github.com/TanStack/router/pull/6704 to be merged. It fixes the Solid errors. And then we'll make a separate PR for the Vue data-only one. 

This PR adds two focused browser repros for a gap between `main` and `refactor-signals`: during nested client navigation under inherited selective SSR, `main` never renders the leaf `pendingComponent`, while `refactor-signals` does.

These tests do not try to prove that `main` is definitively wrong. They are meant to make the discrepancy easy to evaluate.

## What was already covered

The existing selective-SSR suite already covers the inheritance matrix for final SSR/data behavior on full document navigations (`reloadDocument={true}`). In particular, it already covers these inherited cases:

| Case | Existing coverage | What it verifies |
| --- | --- | --- |
| `root: true`, `posts: false`, leaf inherits `posts` | Existing `selective-ssr` test matrix (`testcase-3`) | Final data/render behavior after a full reload |
| `root: true`, `posts: 'data-only'`, leaf inherits `posts` | Existing `selective-ssr` test matrix (`testcase-4`) | Final data/render behavior after a full reload |

What was not covered before this PR: whether a nested suspending leaf under those same inherited configs should show its configured `pendingComponent` during a client-side navigation.

## Cases in one view

| Case | Route config | Navigation type | Covered before this PR? | `main` | `refactor-signals` |
| --- | --- | --- | --- | --- | --- |
| Baseline inherited selective SSR | `root: true`, `posts: false`, leaf inherits `posts` | Full reload to `/posts/$postId` | Yes | Passes existing final-state assertions | Passes existing final-state assertions |
| Baseline inherited selective SSR | `root: true`, `posts: 'data-only'`, leaf inherits `posts` | Full reload to `/posts/$postId` | Yes | Passes existing final-state assertions | Passes existing final-state assertions |
| Nested pending repro | `root: true`, `posts: false`, leaf inherits `posts` | Client nav to `/posts/pending-inherit` | No - added here | Parent route renders and router becomes `pending`, but leaf fallback never appears | Leaf fallback appears |
| Nested pending repro | `root: true`, `posts: 'data-only'`, leaf inherits `posts` | Client nav to `/posts/pending-data-only-component` | No - added here | Parent route renders and router becomes `pending`, but leaf fallback never appears | Leaf fallback appears |

## Interpretation

The inheritance behavior itself is already intentional enough to have coverage. The open question is narrower: in these nested inherited selective-SSR cases, should a suspending leaf's configured `pendingComponent` be allowed to render during client navigation?

This PR exists so that question can be answered against a concrete repro instead of inferred from the broader selective-SSR matrix.

## Notes

There are neighboring transition tests in other Solid e2e apps that prefer keeping previous content visible during navigation, but they do not cover this selective-SSR nested leaf case, so they do not resolve the expected behavior here.

## Testing

- `pnpm test:eslint`
- `pnpm test:types`
- `pnpm test:unit`
- `pnpm test:e2e tests/app.spec.ts --grep \"nested inherited\"` *(fails on `main`, passes on `refactor-signals`)*