### PR TITLE
fix(react-router): correct useLoaderDeps structural sharing types

### DIFF
--- a/packages/react-router/src/useLoaderDeps.tsx
+++ b/packages/react-router/src/useLoaderDeps.tsx
@@ -37,7 +37,7 @@ export type UseLoaderDepsRoute<out TId> = <
   TStructuralSharing extends boolean = boolean,
 >(
   opts?: UseLoaderDepsBaseOptions<TRouter, TId, TSelected, TStructuralSharing> &
-    StructuralSharingOption<TRouter, TSelected, false>,
+    StructuralSharingOption<TRouter, TSelected, TStructuralSharing>,
 ) => UseLoaderDepsResult<TRouter, TId, TSelected>
 
 /**


### PR DESCRIPTION
## Summary
- fix the `UseLoaderDepsRoute` helper type so its `structuralSharing` option matches the generic type parameter it already exposes
- align the route helper typings with the existing runtime behavior in `useLoaderDeps`/`useMatch`

## Testing
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:unit --outputStyle=stream --skipRemoteCache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TypeScript type definitions for loader dependencies to support conditional structural sharing options, providing greater flexibility for configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->