### PR TITLE
refactor: replace package router.state reads with granular stores

### DIFF
--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -228,7 +228,10 @@ function OnRendered() {
         ) {
           router.emit({
             type: 'onRendered',
-            ...getLocationChangeInfo(router.state),
+            ...getLocationChangeInfo(
+              router.stores.location.state,
+              router.stores.resolvedLocation.state,
+            ),
           })
           prevLocationRef.current = router.latestLocation
         }
@@ -440,7 +443,7 @@ export const Outlet = React.memo(function OutletImpl() {
   let childMatchId: string | undefined
 
   if (isServer ?? router.isServer) {
-    const matches = router.state.matches
+    const matches = router.stores.activeMatchesSnapshot.state
     const parentIndex = matchId
       ? matches.findIndex((match) => match.id === matchId)
       : -1

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -93,7 +93,10 @@ export function Transitioner() {
     if (previousIsLoading && !isLoading) {
       router.emit({
         type: 'onLoad', // When the new URL has committed, when the new matches have been loaded into state.matches
-        ...getLocationChangeInfo(router.state),
+        ...getLocationChangeInfo(
+          router.stores.location.state,
+          router.stores.resolvedLocation.state,
+        ),
       })
     }
   }, [previousIsLoading, router, isLoading])
@@ -103,14 +106,20 @@ export function Transitioner() {
     if (previousIsPagePending && !isPagePending) {
       router.emit({
         type: 'onBeforeRouteMount',
-        ...getLocationChangeInfo(router.state),
+        ...getLocationChangeInfo(
+          router.stores.location.state,
+          router.stores.resolvedLocation.state,
+        ),
       })
     }
   }, [isPagePending, previousIsPagePending, router])
 
   useLayoutEffect(() => {
     if (previousIsAnyPending && !isAnyPending) {
-      const changeInfo = getLocationChangeInfo(router.state)
+      const changeInfo = getLocationChangeInfo(
+        router.stores.location.state,
+        router.stores.resolvedLocation.state,
+      )
       router.emit({
         type: 'onResolved',
         ...changeInfo,

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -102,7 +102,7 @@ export function useLinkProps<
   //
   // For SSR parity (to avoid hydration errors), we still compute the link's
   // active status on the server, but we avoid creating any router-state
-  // subscriptions by reading from `router.state` directly.
+  // subscriptions by reading from the location store directly.
   //
   // Note: `location.hash` is not available on the server.
   // ==========================================================================
@@ -204,7 +204,7 @@ export function useLinkProps<
     const isActive = (() => {
       if (externalLink) return false
 
-      const currentLocation = router.state.location
+      const currentLocation = router.stores.location.state
 
       const exact = activeOptions?.exact ?? false
 

--- a/packages/react-router/src/ssr/RouterClient.tsx
+++ b/packages/react-router/src/ssr/RouterClient.tsx
@@ -7,7 +7,7 @@ let hydrationPromise: Promise<void | Array<Array<void>>> | undefined
 
 export function RouterClient(props: { router: AnyRouter }) {
   if (!hydrationPromise) {
-    if (!props.router.state.matches.length) {
+    if (!props.router.stores.matchesId.state.length) {
       hydrationPromise = hydrate(props.router)
     } else {
       hydrationPromise = Promise.resolve()

--- a/packages/react-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/react-router/src/ssr/renderRouterToStream.tsx
@@ -36,7 +36,7 @@ export const renderRouterToStream = async ({
       stream as unknown as ReadableStream,
     )
     return new Response(responseStream as any, {
-      status: router.state.statusCode,
+      status: router.stores.statusCode.state,
       headers: responseHeaders,
     })
   }
@@ -79,7 +79,7 @@ export const renderRouterToStream = async ({
       reactAppPassthrough,
     )
     return new Response(responseStream as any, {
-      status: router.state.statusCode,
+      status: router.stores.statusCode.state,
       headers: responseHeaders,
     })
   }

--- a/packages/react-router/src/ssr/renderRouterToString.tsx
+++ b/packages/react-router/src/ssr/renderRouterToString.tsx
@@ -21,7 +21,7 @@ export const renderRouterToString = async ({
     }
 
     return new Response(`<!DOCTYPE html>${html}`, {
-      status: router.state.statusCode,
+      status: router.stores.statusCode.state,
       headers: responseHeaders,
     })
   } catch (error) {

--- a/packages/react-router/src/useRouterState.tsx
+++ b/packages/react-router/src/useRouterState.tsx
@@ -57,7 +57,9 @@ export function useRouterState<
   // Avoid subscribing to the store (and any structural sharing work) on the server.
   const _isServer = isServer ?? router.isServer
   if (_isServer) {
-    const state = router.state as RouterState<TRouter['routeTree']>
+    const state = router.stores.__store.state as RouterState<
+      TRouter['routeTree']
+    >
     return (opts?.select ? opts.select(state) : state) as UseRouterStateResult<
       TRouter,
       TSelected

--- a/packages/react-start/src/useServerFn.ts
+++ b/packages/react-start/src/useServerFn.ts
@@ -18,7 +18,7 @@ export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
         return res
       } catch (err) {
         if (isRedirect(err)) {
-          err.options._fromLocation = router.state.location
+          err.options._fromLocation = router.stores.location.state
           return router.navigate(router.resolveRedirect(err).options)
         }
 

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -855,14 +855,14 @@ export type TrailingSlashOption =
 
 /**
  * Compute whether path, href or hash changed between previous and current
- * resolved locations in router state.
+ * resolved locations.
  */
-export function getLocationChangeInfo(routerState: {
-  resolvedLocation?: ParsedLocation
-  location: ParsedLocation
-}) {
-  const fromLocation = routerState.resolvedLocation
-  const toLocation = routerState.location
+export function getLocationChangeInfo(
+  location: ParsedLocation,
+  resolvedLocation?: ParsedLocation,
+) {
+  const fromLocation = resolvedLocation
+  const toLocation = location
   const pathChanged = fromLocation?.pathname !== toLocation.pathname
   const hrefChanged = fromLocation?.href !== toLocation.href
   const hashChanged = fromLocation?.hash !== toLocation.hash
@@ -2365,19 +2365,13 @@ export class RouterCore<
           if (!this.stores.redirect.state) {
             this.emit({
               type: 'onBeforeNavigate',
-              ...getLocationChangeInfo({
-                resolvedLocation: prevLocation,
-                location: next,
-              }),
+              ...getLocationChangeInfo(next, prevLocation),
             })
           }
 
           this.emit({
             type: 'onBeforeLoad',
-            ...getLocationChangeInfo({
-              resolvedLocation: prevLocation,
-              location: next,
-            }),
+            ...getLocationChangeInfo(next, prevLocation),
           })
 
           await loadMatches({
@@ -2582,10 +2576,7 @@ export class RouterCore<
         const resolvedViewTransitionTypes =
           typeof shouldViewTransition.types === 'function'
             ? shouldViewTransition.types(
-                getLocationChangeInfo({
-                  resolvedLocation: prevLocation,
-                  location: next,
-                }),
+                getLocationChangeInfo(next, prevLocation),
               )
             : shouldViewTransition.types
 

--- a/packages/router-ssr-query-core/src/index.ts
+++ b/packages/router-ssr-query-core/src/index.ts
@@ -140,7 +140,7 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
         ...ogMutationCacheConfig,
         onError: (error, ...rest) => {
           if (isRedirect(error)) {
-            error.options._fromLocation = router.state.location
+            error.options._fromLocation = router.stores.location.state
             return router.navigate(router.resolveRedirect(error).options)
           }
 
@@ -153,7 +153,7 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
         ...ogQueryCacheConfig,
         onError: (error, ...rest) => {
           if (isRedirect(error)) {
-            error.options._fromLocation = router.state.location
+            error.options._fromLocation = router.stores.location.state
             return router.navigate(router.resolveRedirect(error).options)
           }
 

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -197,7 +197,10 @@ function OnRendered() {
     Solid.on([location], () => {
       router.emit({
         type: 'onRendered',
-        ...getLocationChangeInfo(router.state),
+        ...getLocationChangeInfo(
+          router.stores.location.state,
+          router.stores.resolvedLocation.state,
+        ),
       })
     }),
   )

--- a/packages/solid-router/src/Transitioner.tsx
+++ b/packages/solid-router/src/Transitioner.tsx
@@ -94,7 +94,10 @@ export function Transitioner() {
     if (previousIsLoading && !currentIsLoading) {
       router.emit({
         type: 'onLoad',
-        ...getLocationChangeInfo(router.state),
+        ...getLocationChangeInfo(
+          router.stores.location.state,
+          router.stores.resolvedLocation.state,
+        ),
       })
     }
 
@@ -107,7 +110,10 @@ export function Transitioner() {
     if (previousIsPagePending && !currentIsPagePending) {
       router.emit({
         type: 'onBeforeRouteMount',
-        ...getLocationChangeInfo(router.state),
+        ...getLocationChangeInfo(
+          router.stores.location.state,
+          router.stores.resolvedLocation.state,
+        ),
       })
     }
 
@@ -118,7 +124,10 @@ export function Transitioner() {
     const currentIsAnyPending = isAnyPending()
 
     if (previousIsAnyPending && !currentIsAnyPending) {
-      const changeInfo = getLocationChangeInfo(router.state)
+      const changeInfo = getLocationChangeInfo(
+        router.stores.location.state,
+        router.stores.resolvedLocation.state,
+      )
       router.emit({
         type: 'onResolved',
         ...changeInfo,

--- a/packages/solid-router/src/ssr/RouterClient.tsx
+++ b/packages/solid-router/src/ssr/RouterClient.tsx
@@ -11,7 +11,7 @@ const Dummy = (props: { children?: JSXElement }) => <>{props.children}</>
 
 export function RouterClient(props: { router: AnyRouter }) {
   if (!hydrationPromise) {
-    if (!props.router.state.matches.length) {
+    if (!props.router.stores.matchesId.state.length) {
       hydrationPromise = hydrate(props.router)
     } else {
       hydrationPromise = Promise.resolve()

--- a/packages/solid-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/solid-router/src/ssr/renderRouterToStream.tsx
@@ -52,7 +52,7 @@ export const renderRouterToStream = async ({
     readable as unknown as ReadableStream,
   )
   return new Response(responseStream as any, {
-    status: router.state.statusCode,
+    status: router.stores.statusCode.state,
     headers: responseHeaders,
   })
 }

--- a/packages/solid-router/src/ssr/renderRouterToString.tsx
+++ b/packages/solid-router/src/ssr/renderRouterToString.tsx
@@ -32,7 +32,7 @@ export const renderRouterToString = ({
       html = html.replace(`</body>`, () => `${injectedHtml}</body>`)
     }
     return new Response(`<!DOCTYPE html>${html}`, {
-      status: router.state.statusCode,
+      status: router.stores.statusCode.state,
       headers: responseHeaders,
     })
   } catch (error) {

--- a/packages/solid-router/src/useRouterState.tsx
+++ b/packages/solid-router/src/useRouterState.tsx
@@ -35,7 +35,9 @@ export function useRouterState<
   // implementation does not provide subscribe() semantics.
   const _isServer = isServer ?? router.isServer
   if (_isServer) {
-    const state = router.state as RouterState<TRouter['routeTree']>
+    const state = router.stores.__store.state as RouterState<
+      TRouter['routeTree']
+    >
     const selected = (
       opts?.select ? opts.select(state) : state
     ) as UseRouterStateResult<TRouter, TSelected>

--- a/packages/solid-start/src/useServerFn.ts
+++ b/packages/solid-start/src/useServerFn.ts
@@ -16,7 +16,7 @@ export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
       return res
     } catch (err) {
       if (isRedirect(err)) {
-        err.options._fromLocation = router.state.location
+        err.options._fromLocation = router.stores.location.state
         return router.navigate(router.resolveRedirect(err).options)
       }
 

--- a/packages/start-client-core/src/client/hydrateStart.ts
+++ b/packages/start-client-core/src/client/hydrateStart.ts
@@ -35,7 +35,7 @@ export async function hydrateStart(): Promise<AnyRouter> {
     basepath: process.env.TSS_ROUTER_BASEPATH,
     ...{ serializationAdapters },
   })
-  if (!router.state.matches.length) {
+  if (!router.stores.matchesId.state.length) {
     await hydrate(router)
   }
 

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -116,7 +116,7 @@ function getStartResponseHeaders(opts: { router: AnyRouter }) {
     {
       'Content-Type': 'text/html; charset=utf-8',
     },
-    ...opts.router.state.matches.map((match) => {
+    ...opts.router.stores.activeMatchesSnapshot.state.map((match) => {
       return match.headers
     }),
   )

--- a/packages/vue-router/src/Match.tsx
+++ b/packages/vue-router/src/Match.tsx
@@ -253,7 +253,10 @@ const OnRendered = Vue.defineComponent({
           if (prevHref === undefined || prevHref !== currentHref) {
             router.emit({
               type: 'onRendered',
-              ...getLocationChangeInfo(router.state),
+              ...getLocationChangeInfo(
+                router.stores.location.state,
+                router.stores.resolvedLocation.state,
+              ),
             })
             prevHref = currentHref
           }

--- a/packages/vue-router/src/Transitioner.tsx
+++ b/packages/vue-router/src/Transitioner.tsx
@@ -187,7 +187,10 @@ export function useTransitionerSetup() {
         if (previousIsLoading.value.previous && !newValue) {
           router.emit({
             type: 'onLoad',
-            ...getLocationChangeInfo(router.state),
+            ...getLocationChangeInfo(
+              router.stores.location.state,
+              router.stores.resolvedLocation.state,
+            ),
           })
         }
       } catch {
@@ -203,7 +206,10 @@ export function useTransitionerSetup() {
       if (previousIsPagePending.value.previous && !newValue) {
         router.emit({
           type: 'onBeforeRouteMount',
-          ...getLocationChangeInfo(router.state),
+          ...getLocationChangeInfo(
+            router.stores.location.state,
+            router.stores.resolvedLocation.state,
+          ),
         })
       }
     } catch {
@@ -214,7 +220,7 @@ export function useTransitionerSetup() {
   Vue.watch(isAnyPending, (newValue) => {
     if (!isMounted.value) return
     try {
-      if (!newValue && router.state.status === 'pending') {
+      if (!newValue && router.stores.status.state === 'pending') {
         batch(() => {
           router.stores.status.setState(() => 'idle')
           router.stores.resolvedLocation.setState(
@@ -225,7 +231,10 @@ export function useTransitionerSetup() {
 
       // The router was pending and now it's not
       if (previousIsAnyPending.value.previous && !newValue) {
-        const changeInfo = getLocationChangeInfo(router.state)
+        const changeInfo = getLocationChangeInfo(
+          router.stores.location.state,
+          router.stores.resolvedLocation.state,
+        )
         router.emit({
           type: 'onResolved',
           ...changeInfo,

--- a/packages/vue-router/src/ssr/RouterClient.tsx
+++ b/packages/vue-router/src/ssr/RouterClient.tsx
@@ -18,7 +18,7 @@ export const RouterClient = Vue.defineComponent({
     const isHydrated = Vue.ref(false)
 
     if (!hydrationPromise) {
-      if (!props.router.state.matches.length) {
+      if (!props.router.stores.matchesId.state.length) {
         hydrationPromise = hydrate(props.router)
       } else {
         hydrationPromise = Promise.resolve()

--- a/packages/vue-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/vue-router/src/ssr/renderRouterToStream.tsx
@@ -62,7 +62,7 @@ export const renderRouterToStream = async ({
     }
 
     return new Response(`<!DOCTYPE html>${fullHtml}`, {
-      status: router.state.statusCode,
+      status: router.stores.statusCode.state,
       headers: responseHeaders,
     })
   }
@@ -78,7 +78,7 @@ export const renderRouterToStream = async ({
   )
 
   return new Response(responseStream as any, {
-    status: router.state.statusCode,
+    status: router.stores.statusCode.state,
     headers: responseHeaders,
   })
 }

--- a/packages/vue-router/src/ssr/renderRouterToString.tsx
+++ b/packages/vue-router/src/ssr/renderRouterToString.tsx
@@ -24,7 +24,7 @@ export const renderRouterToString = async ({
     }
 
     return new Response(`<!DOCTYPE html>${html}`, {
-      status: router.state.statusCode,
+      status: router.stores.statusCode.state,
       headers: responseHeaders,
     })
   } catch (error) {

--- a/packages/vue-router/src/useRouterState.tsx
+++ b/packages/vue-router/src/useRouterState.tsx
@@ -42,7 +42,9 @@ export function useRouterState<
   const _isServer = isServer ?? router.isServer
 
   if (_isServer) {
-    const state = router.state as RouterState<TRouter['routeTree']>
+    const state = router.stores.__store.state as RouterState<
+      TRouter['routeTree']
+    >
     return Vue.ref(opts?.select ? opts.select(state) : state) as Vue.Ref<
       UseRouterStateResult<TRouter, TSelected>
     >

--- a/packages/vue-start/src/useServerFn.ts
+++ b/packages/vue-start/src/useServerFn.ts
@@ -16,7 +16,7 @@ export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
       return res
     } catch (err) {
       if (isRedirect(err)) {
-        err.options._fromLocation = router.state.location
+        err.options._fromLocation = router.stores.location.state
         return router.navigate(router.resolveRedirect(err).options)
       }
 


### PR DESCRIPTION
## Summary
- replace non-test `router.state` reads across `packages/` with granular store accessors like `router.stores.location.state`, `router.stores.statusCode.state`, and match snapshot stores
- update `getLocationChangeInfo` to accept `(location, resolvedLocation?)` so framework adapters can emit router events without depending on the full state object
- align SSR helpers and start/query integrations with the granular store APIs used by the refactor-signals branch

## Testing
- not run in this environment (`node_modules`/Nx are unavailable)