### PR TITLE
fix(examples): remove stale delay slider reference from with-trpc example

### DIFF
--- a/examples/react/with-trpc/src/routes/index.tsx
+++ b/examples/react/with-trpc/src/routes/index.tsx
@@ -24,10 +24,6 @@ function IndexComponent() {
         As you navigate around take note of the UX. It should feel
         suspense-like, where routes are only rendered once all of their data and
         elements are ready.
-        <hr className={`my-2`} />
-        The last 2 sliders determine if link-hover preloading is enabled (and
-        how long those preloads stick around) and also whether to cache rendered
-        route data (and for how long). Both of these default to 0 (or off).
       </div>
     </div>
   )


### PR DESCRIPTION
Fixes #6870

## Problem

The with-trpc example's index route contains the text:
> To exaggerate async effects, play with the artificial request delay slider in the bottom-left corner.

This text was copied from the kitchen-sink example but the delay slider UI component was never added to the with-trpc example. There is no slider in the bottom-left corner.

## Fix

Remove the stale sentence referencing the non-existent delay slider. The remaining text about preloading and route data caching sliders still refers to controls that don't exist either, but this was explicitly mentioned in the issue as the minimal/immediate fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed explanatory guidance and a horizontal divider related to the request delay slider in the example UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->