### PR TITLE
make changeset publishing more robust

### DIFF
--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -21,9 +21,9 @@ const releaseLogs = execSync(
   .filter(Boolean)
 
 // Current release commit is releaseLogs[0] (HEAD), previous is releaseLogs[1]
-const currentRelease = releaseLogs[0]
+const currentRelease = releaseLogs[0] || 'HEAD'
 const previousRelease = releaseLogs[1]
-const rangeFrom = previousRelease || currentRelease + '~1'
+const rangeFrom = previousRelease || `${currentRelease}~1`
 
 // Get commits between previous release and current release (exclude both)
 const rawLog = execSync(


### PR DESCRIPTION
few more changes to amke teh flow robust

1. --latest only for non-prereleases: prereleases won't be marked as "Latest" on GitHub
2. Robust git log range: explicitly finds both the current and previous release commits by grepping for ci: changeset release, no more fragile HEAD~1 assumptions
3. Cleaner non-conventional commit parsing: uses split(' ') instead of brittle double-indexOf, with a comment explaining what goes to "Other"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * More consistent, organized release note generation with clearer grouping of commit types and an explicit "Other" category for unrecognized entries.
  * Changelogs now include scope where available and show author usernames when resolved.
  * Release creation updated to support prerelease handling and a "latest" option for normal releases.
  * Safer cleanup for partial or failed releases to avoid leftover tags and ensure predictable state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->