### PR TITLE
fix: resolve author from PR links in GitHub release changelog

### DIFF
--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -28,7 +28,7 @@ async function resolveUsername(email) {
   }
 }
 
-// Resolve a commit hash to a "by @username" string
+// Resolve author from a commit hash via git log
 const authorCache = {}
 async function resolveAuthorForCommit(hash) {
   if (authorCache[hash] !== undefined) return authorCache[hash]
@@ -39,29 +39,67 @@ async function resolveAuthorForCommit(hash) {
       stdio: ['pipe', 'pipe', 'ignore'],
     }).trim()
     const username = await resolveUsername(email)
-    const result = username ? ` by @${username}` : ''
-    authorCache[hash] = result
-    return result
+    authorCache[hash] = username
+    return username
   } catch {
-    authorCache[hash] = ''
-    return ''
+    authorCache[hash] = null
+    return null
   }
 }
 
-// Append author info to changelog lines that contain commit hashes
+// Resolve author from a PR number via GitHub API
+const prAuthorCache = {}
+async function resolveAuthorForPR(prNumber) {
+  if (prAuthorCache[prNumber] !== undefined) return prAuthorCache[prNumber]
+
+  if (!ghToken) {
+    prAuthorCache[prNumber] = null
+    return null
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/TanStack/router/pulls/${prNumber}`,
+      { headers: { Authorization: `token ${ghToken}` } },
+    )
+    const data = await res.json()
+    const login = data?.user?.login || null
+    prAuthorCache[prNumber] = login
+    return login
+  } catch {
+    prAuthorCache[prNumber] = null
+    return null
+  }
+}
+
+// Append author info to changelog lines that contain PR refs or commit hashes
 async function appendAuthors(content) {
   const lines = content.split('\n')
   const result = []
 
   for (const line of lines) {
-    // Match commit hash links like [`9a4d924`](url)
-    const commitMatch = line.match(/\[`([a-f0-9]{7,})`\]/)
-    if (commitMatch && line.startsWith('- ')) {
-      const author = await resolveAuthorForCommit(commitMatch[1])
-      result.push(author ? `${line}${author}` : line)
-    } else {
+    if (!line.startsWith('- ')) {
       result.push(line)
+      continue
     }
+
+    // Try PR reference first: ([#6891](url))
+    const prMatch = line.match(/\[#(\d+)\]/)
+    if (prMatch) {
+      const username = await resolveAuthorForPR(prMatch[1])
+      result.push(username ? `${line} by @${username}` : line)
+      continue
+    }
+
+    // Fall back to commit hash: [`9a4d924`](url)
+    const commitMatch = line.match(/\[`([a-f0-9]{7,})`\]/)
+    if (commitMatch) {
+      const username = await resolveAuthorForCommit(commitMatch[1])
+      result.push(username ? `${line} by @${username}` : line)
+      continue
+    }
+
+    result.push(line)
   }
 
   return result.join('\n')


### PR DESCRIPTION
Fix author attribution in GitHub release notes to handle changeset-generated changelog entries correctly

Changeset entries for actual changes use PR links, not commit hashes. The previous approach only matched commit hash links which only appear in "Updated dependencies" lines

Add resolveAuthorForPR that fetches the PR author via the GitHub API, and try PR resolution first before falling back to commit hash resolution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced changelog generation to include author attribution. Release notes now display contributor information for both pull requests and commits, with pull request-based attribution prioritized for better credit attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->