### PR TITLE
pre-release solid-router/start 2.0.0-alpha.0

### DIFF
--- a/.changeset/social-mails-sort.md
+++ b/.changeset/social-mails-sort.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/solid-router-ssr-query': major
+'@tanstack/solid-router-devtools': major
+'@tanstack/solid-start-client': major
+'@tanstack/solid-start-server': major
+'@tanstack/solid-router': major
+'@tanstack/solid-start': major
+---
+
+solid v2 pre-release for solid-router and start


### PR DESCRIPTION
First 2.0 alpha of

- @tanstack/solid-router-ssr-query
- @tanstack/solid-router-devtools
- @tanstack/solid-start-client
- @tanstack/solid-start-server
- @tanstack/solid-router
- @tanstack/solid-start

Note that `solid-router-ssr-query` won't work yet, as solid-query doesn't have a release with solid-v2 support yet