### PR TITLE
fix(start-static-server-functions): adjust start peerDeps to workspace:^

### DIFF
--- a/packages/start-static-server-functions/package.json
+++ b/packages/start-static-server-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/start-static-server-functions",
-  "version": "1.166.8",
+  "version": "1.166.9",
   "description": "Modern and scalable routing for React applications",
   "author": "Tanner Linsley",
   "license": "MIT",
@@ -66,8 +66,8 @@
     "vite": "*"
   },
   "peerDependencies": {
-    "@tanstack/react-start": "workspace:*",
-    "@tanstack/solid-start": "workspace:*"
+    "@tanstack/react-start": "workspace:^",
+    "@tanstack/solid-start": "workspace:^"
   },
   "peerDependenciesMeta": {
     "@tanstack/react-start": {


### PR DESCRIPTION
adjust peerDeps from exact version:

```
  "peerDependencies": {
    "@tanstack/react-start": "workspace:*",
    "@tanstack/solid-start": "workspace:*" 
  },
```

to allow minor/patch changes

```
  "peerDependencies": {
    "@tanstack/react-start": "workspace:^",
    "@tanstack/solid-start": "workspace:^"
  },
```

Without this change, if changesets see a a patch bump to solid-start it could cause a major bump to this package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch release with updated peer dependency version constraints for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->