### PR TITLE
ci: only include 'feat', 'fix', 'perf', 'refactor' in changelog

### DIFF
--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -164,6 +164,9 @@ for (const line of commits) {
   const scope = conventionalMatch ? conventionalMatch[2] || '' : ''
   const message = conventionalMatch ? conventionalMatch[3] : subject
 
+  // Only include user-facing change types
+  if (!['feat', 'fix', 'perf', 'refactor'].includes(type)) continue
+
   // Extract PR number if present
   const prMatch = message.match(/\(#(\d+)\)/)
   const prNumber = prMatch ? prMatch[1] : null


### PR DESCRIPTION
the github releases, it should only in it's changelog include

'feat', 'fix', 'perf', 'refactor' - conventional commits

Leaving out e.g.

chore, ci, docs, test, other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release notes now focus exclusively on user-facing changes: features, fixes, performance improvements, and refactors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->