### PR TITLE
fix: handle `unknown` in `ValidateSerializable` type

### DIFF
--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -72,8 +72,9 @@ export interface CreateSerializationAdapterOptions<
   fromSerializable: (value: TOutput) => TInput
 }
 
-export type ValidateSerializable<T, TSerializable> =
-  T extends ReadonlyArray<unknown>
+export type ValidateSerializable<T, TSerializable> = unknown extends T
+  ? T
+  : T extends ReadonlyArray<unknown>
     ? ResolveArrayShape<T, TSerializable, 'input'>
     : T extends TSerializable
       ? T


### PR DESCRIPTION
`ValidateSerializable` recursively validates that a type is serializable. When it encounters an index signature with `unknown` values (e.g. `[x: string]: unknown` from Zod v4's `z.looseObject()`), it falls through to the mapped type branch `{ [K in keyof T]: ValidateSerializable<T[K], TSerializable> }`, which resolves `ValidateSerializable<unknown, Serializable>` to `{}`.

This causes the validated type to become `{ [x: string]: {} }`, which is incompatible with the original `{ [x: string]: unknown }` since `unknown` is not assignable to `{}`. As a result, schemas using `z.looseObject()` or `z.object().passthrough()` in Zod v4 fail type checking when passed to `createServerFn().inputValidator()`.

The fix adds an early `unknown extends T ? T` check to short-circuit recursion — `unknown` should pass through as-is since it semantically means "any value is possible" and cannot be meaningfully validated at the type level.

This was previously masked by Zod v3, which inferred `[x: string]: any` for passthrough objects. Since `any` is assignable to `{}`, the bug never surfaced.

Fixes #6626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type validation handling for serialization in server-side rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->