### PR TITLE
docs: remove react-oxc plugin suggestion(deprecated)

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -75,7 +75,7 @@ As well as React's Vite plugin:
 npm i -D @vitejs/plugin-react
 ```
 
-Alternatively, you can also use `@vitejs/plugin-react-oxc` or `@vitejs/plugin-react-swc`.
+Alternatively, you can also use `@vitejs/plugin-react-swc`.
 
 and some TypeScript:
 


### PR DESCRIPTION
The [`@vitejs/plugin-react-oxc`](https://www.npmjs.com/package/@vitejs/plugin-react-oxc) is deprecated and now the [@vitejs/plugin-react](https://www.npmjs.com/package/@vitejs/plugin-react) automatically enabled it.

>[!IMPORTANT] This package is deprecated. Please use [@vitejs/plugin-react](https://www.npmjs.com/package/@vitejs/plugin-react) instead, which automatically enables Oxc-based Fast Refresh transform on [rolldown-vite](https://vitejs.dev/guide/rolldown).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified React build configuration documentation by clarifying the recommended plugin setup for better developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->