### PR TITLE
attempt at fixing the beforeload self reference type errors

### DIFF
--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -21,6 +21,7 @@ import type {
   FileBaseRouteOptions,
   FileRoutesByPath,
   LazyRouteOptions,
+  NoInfer,
   Register,
   RegisteredRouter,
   ResolveParams,
@@ -119,16 +120,16 @@ export class FileRoute<
       THandlers
     > &
       UpdatableRouteOptions<
-        TParentRoute,
-        TId,
-        TFullPath,
-        TParams,
-        TSearchValidator,
-        TLoaderFn,
-        TLoaderDeps,
+        NoInfer<TParentRoute>,
+        NoInfer<TId>,
+        NoInfer<TFullPath>,
+        NoInfer<TParams>,
+        NoInfer<TSearchValidator>,
+        NoInfer<TLoaderFn>,
+        NoInfer<TLoaderDeps>,
         AnyContext,
-        TRouteContextFn,
-        TBeforeLoadFn
+        NoInfer<TRouteContextFn>,
+        NoInfer<TBeforeLoadFn>
       >,
   ): Route<
     TRegister,

--- a/packages/react-router/tests/fileRoute.test-d.tsx
+++ b/packages/react-router/tests/fileRoute.test-d.tsx
@@ -100,3 +100,17 @@ test('when creating a folder group', () => {
   expectTypeOf<'(auth)/protected'>(protectedRoute.path)
   expectTypeOf<'/protected'>(protectedRoute.id)
 })
+
+test('when beforeLoad returns Route.fullPath from the same route', () => {
+  const selfReferencingRoute = createFileRoute('/invoices')({
+    beforeLoad: (opts) => {
+      expectTypeOf(opts.routeId).toEqualTypeOf<'/invoices'>()
+
+      return {
+        to: selfReferencingRoute.fullPath,
+      }
+    },
+  })
+
+  expectTypeOf(selfReferencingRoute.fullPath).toEqualTypeOf<'/invoices'>()
+})

--- a/packages/router-core/src/fileRoute.ts
+++ b/packages/router-core/src/fileRoute.ts
@@ -10,6 +10,7 @@ import type {
   UpdatableRouteOptions,
 } from './route'
 import type { AnyValidator } from './validators'
+import type { NoInfer } from './utils'
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: any
@@ -69,16 +70,16 @@ export interface FileRouteOptions<
       THandlers
     >,
     UpdatableRouteOptions<
-      TParentRoute,
-      TId,
-      TFullPath,
-      TParams,
-      TSearchValidator,
-      TLoaderFn,
-      TLoaderDeps,
+      NoInfer<TParentRoute>,
+      NoInfer<TId>,
+      NoInfer<TFullPath>,
+      NoInfer<TParams>,
+      NoInfer<TSearchValidator>,
+      NoInfer<TLoaderFn>,
+      NoInfer<TLoaderDeps>,
       AnyContext,
-      TRouteContextFn,
-      TBeforeLoadFn
+      NoInfer<TRouteContextFn>,
+      NoInfer<TBeforeLoadFn>
     > {}
 
 export type CreateFileRoute<

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -43,7 +43,6 @@ import type {
   ValidatorFn,
   ValidatorObj,
 } from './validators'
-import type { ValidateSerializableLifecycleResult } from './ssr/serializer/transformer'
 
 export type AnyPathParams = {}
 
@@ -1017,12 +1016,7 @@ export interface FilebaseRouteOptionsInterface<
         TServerMiddlewares,
         THandlers
       >,
-    ) => ValidateSerializableLifecycleResult<
-      TRegister,
-      TParentRoute,
-      TSSR,
-      TBeforeLoadFn
-    >
+    ) => any
   >
 
   loaderDeps?: (

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -258,14 +258,26 @@ export type ValidateSerializableLifecycleResult<
   TParentRoute extends AnyRoute,
   TSSR,
   TFn,
+> = ValidateSerializableLifecycleResultFromReturn<
+  TRegister,
+  TParentRoute,
+  TSSR,
+  LooseReturnType<TFn>
+>
+
+export type ValidateSerializableLifecycleResultFromReturn<
+  TRegister,
+  TParentRoute extends AnyRoute,
+  TSSR,
+  TReturn,
 > =
   false extends RegisteredSsr<TRegister>
     ? any
-    : ValidateSerializableLifecycleResultSSR<
+    : ValidateSerializableLifecycleResultSSRFromReturn<
           TRegister,
           TParentRoute,
           TSSR,
-          TFn
+          TReturn
         > extends infer TInput
       ? TInput
       : never
@@ -275,12 +287,24 @@ export type ValidateSerializableLifecycleResultSSR<
   TParentRoute extends AnyRoute,
   TSSR,
   TFn,
+> = ValidateSerializableLifecycleResultSSRFromReturn<
+  TRegister,
+  TParentRoute,
+  TSSR,
+  LooseReturnType<TFn>
+>
+
+export type ValidateSerializableLifecycleResultSSRFromReturn<
+  TRegister,
+  TParentRoute extends AnyRoute,
+  TSSR,
+  TReturn,
 > =
   ResolveAllSSR<TParentRoute, TSSR> extends false
     ? any
     : RegisteredSSROption<TRegister> extends false
       ? any
-      : ValidateSerializableInput<TRegister, LooseReturnType<TFn>>
+      : ValidateSerializableInput<TRegister, TReturn>
 
 type ResolveArrayShape<
   T extends ReadonlyArray<unknown>,

--- a/packages/solid-router/src/fileRoute.ts
+++ b/packages/solid-router/src/fileRoute.ts
@@ -21,6 +21,7 @@ import type {
   FileBaseRouteOptions,
   FileRoutesByPath,
   LazyRouteOptions,
+  NoInfer,
   Register,
   RegisteredRouter,
   ResolveParams,
@@ -108,16 +109,16 @@ export class FileRoute<
       THandlers
     > &
       UpdatableRouteOptions<
-        TParentRoute,
-        TId,
-        TFullPath,
-        TParams,
-        TSearchValidator,
-        TLoaderFn,
-        TLoaderDeps,
+        NoInfer<TParentRoute>,
+        NoInfer<TId>,
+        NoInfer<TFullPath>,
+        NoInfer<TParams>,
+        NoInfer<TSearchValidator>,
+        NoInfer<TLoaderFn>,
+        NoInfer<TLoaderDeps>,
         AnyContext,
-        TRouteContextFn,
-        TBeforeLoadFn
+        NoInfer<TRouteContextFn>,
+        NoInfer<TBeforeLoadFn>
       >,
   ): Route<
     TRegister,

--- a/packages/solid-router/tests/fileRoute.test-d.tsx
+++ b/packages/solid-router/tests/fileRoute.test-d.tsx
@@ -100,3 +100,17 @@ test('when creating a folder group', () => {
   expectTypeOf<'(auth)/protected'>(protectedRoute.path)
   expectTypeOf<'/protected'>(protectedRoute.id)
 })
+
+test('when beforeLoad returns Route.fullPath from the same route', () => {
+  const selfReferencingRoute = createFileRoute('/invoices')({
+    beforeLoad: (opts) => {
+      expectTypeOf(opts.routeId).toEqualTypeOf<'/invoices'>()
+
+      return {
+        to: selfReferencingRoute.fullPath,
+      }
+    },
+  })
+
+  expectTypeOf(selfReferencingRoute.fullPath).toEqualTypeOf<'/invoices'>()
+})

--- a/packages/vue-router/src/fileRoute.ts
+++ b/packages/vue-router/src/fileRoute.ts
@@ -18,9 +18,11 @@ import type {
   AnyRouter,
   Constrain,
   ConstrainLiteral,
+  CreateFileRoute,
   FileBaseRouteOptions,
   FileRoutesByPath,
   LazyRouteOptions,
+  NoInfer,
   Register,
   RegisteredRouter,
   ResolveParams,
@@ -45,7 +47,7 @@ export function createFileRoute<
     FileRoutesByPath[TFilePath]['fullPath'],
 >(
   path?: TFilePath,
-): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
+): CreateFileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath> {
   if (typeof path === 'object') {
     return new FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>(path, {
       silent: true,
@@ -108,16 +110,16 @@ export class FileRoute<
       THandlers
     > &
       UpdatableRouteOptions<
-        TParentRoute,
-        TId,
-        TFullPath,
-        TParams,
-        TSearchValidator,
-        TLoaderFn,
-        TLoaderDeps,
+        NoInfer<TParentRoute>,
+        NoInfer<TId>,
+        NoInfer<TFullPath>,
+        NoInfer<TParams>,
+        NoInfer<TSearchValidator>,
+        NoInfer<TLoaderFn>,
+        NoInfer<TLoaderDeps>,
         AnyContext,
-        TRouteContextFn,
-        TBeforeLoadFn
+        NoInfer<TRouteContextFn>,
+        NoInfer<TBeforeLoadFn>
       >,
   ): Route<
     TRegister,

--- a/packages/vue-router/tests/fileRoute.test-d.tsx
+++ b/packages/vue-router/tests/fileRoute.test-d.tsx
@@ -100,3 +100,17 @@ test('when creating a folder group', () => {
   expectTypeOf<'(auth)/protected'>(protectedRoute.path)
   expectTypeOf<'/protected'>(protectedRoute.id)
 })
+
+test('when beforeLoad returns Route.fullPath from the same route', () => {
+  const selfReferencingRoute = createFileRoute('/invoices')({
+    beforeLoad: (opts) => {
+      expectTypeOf(opts.routeId).toEqualTypeOf<'/invoices'>()
+
+      return {
+        to: selfReferencingRoute.fullPath,
+      }
+    },
+  })
+
+  expectTypeOf(selfReferencingRoute.fullPath).toEqualTypeOf<'/invoices'>()
+})


### PR DESCRIPTION
**DISCLAIMER**

This is *AI generated*, with steering on my part. I intended to open this on my fork first, instead of here, for considetaion, but github messed up the base branch selection, so it ended up here directly. 

# Fix Notes for Issue #5786

Related issue: [beforeLoad return type circular reference regression (#5786)](https://github.com/TanStack/router/issues/5786)

## Problem Summary

In file-based routes, TypeScript started failing when a route is self-referenced inside `beforeLoad` during the route initializer, for example:

```ts
export const Route = createFileRoute('/_authenticated')({
  beforeLoad: ({ context }) => ({
    crumbs: [
      ...context.crumbs,
      {
        text: 'Some Text',
        to: Route.fullPath,
      },
    ],
  }),
})
```

The error shape is the self-referential initializer cycle:
- `Route` implicitly has type `any` because it is referenced in its own initializer.
- `beforeLoad` implicitly has return type `any` for the same reason.

## Root Cause (Type-Level)

The failure is a type inference cycle, not a runtime bug:

1. `Route` is inferred from `createFileRoute(...)(options)`.
2. `beforeLoad` return references `Route.*`.
3. `beforeLoad` contributes to route context typing and route type construction.
4. TypeScript ends up needing `Route` to infer `Route`.

This pressure was amplified by:
- File-route option typing that allowed aggressive back-inference through `UpdatableRouteOptions`.
- A recursive `beforeLoad` constraint path around route option typing.

## What Was Changed

### 1) Added regression tests (type tests)

Added a new test in all framework packages to lock the regression:
- `packages/react-router/tests/fileRoute.test-d.tsx`
- `packages/solid-router/tests/fileRoute.test-d.tsx`
- `packages/vue-router/tests/fileRoute.test-d.tsx`

The test asserts that self-referencing `Route.fullPath` inside `beforeLoad` compiles and preserves literal type inference.

### 2) Added `NoInfer` barriers in file-route option plumbing

Applied `NoInfer` in file-route option composition to reduce circular back-inference:
- `packages/router-core/src/fileRoute.ts`
- `packages/react-router/src/fileRoute.ts`
- `packages/solid-router/src/fileRoute.ts`
- `packages/vue-router/src/fileRoute.ts`

This mirrors existing anti-back-inference patterns already used in core route option typing.

### 3) Introduced return-based serializer helper types

In:
- `packages/router-core/src/ssr/serializer/transformer.ts`

Added helper aliases that validate serializability from an extracted return type:
- `ValidateSerializableLifecycleResultFromReturn`
- `ValidateSerializableLifecycleResultSSRFromReturn`

These helpers were added to support cleaner non-recursive constraints.

### 4) Relaxed `beforeLoad` option constraint at the file base route options boundary

In:
- `packages/router-core/src/route.ts`

The `beforeLoad` constraint in `FilebaseRouteOptionsInterface` was relaxed to `(...ctx) => any` to break the self-referential initializer cycle directly at the problematic boundary.

## Why This Fix Works

The fix works by reducing the amount of recursive inference TypeScript must perform while inferring `Route` from its own initializer.

Because the cycle itself is generic (not specific to `fullPath`), the approach addresses self-reference patterns broadly (for example `Route.id`, `Route.path`, etc.), even though the added regression test currently covers the concrete `Route.fullPath` case from the issue.

## Validation Performed

Type suites:
- `@tanstack/router-core:test:types`
- `@tanstack/react-router:test:types`
- `@tanstack/solid-router:test:types`
- `@tanstack/vue-router:test:types`

Relevant unit suites:
- `@tanstack/react-router:test:unit -- tests/fileRoute.test.ts`
- `@tanstack/vue-router:test:unit -- tests/fileRoute.test.ts`
- `@tanstack/solid-router:test:unit`

All passed.

## Thought Process (High-Level)

1. Reproduce and confirm the exact error shape in existing examples/tests.
2. Add a failing type regression first.
3. Reduce inference recursion where file-route option types are composed.
4. Validate across all framework wrappers to ensure parity.
5. Keep changes localized to type plumbing (no runtime behavior changes).

## Trade-offs and Follow-Ups

- The `beforeLoad` option constraint at one core boundary is now intentionally looser to avoid recursive inference collapse.
- If maintainers want stricter serializability guarantees at that exact boundary, a follow-up can reintroduce strictness via a two-generic design (`TBeforeLoadFn` + `TBeforeLoadReturn`) to avoid self-reference while preserving full compile-time checks.
- Additional regression tests can be added for non-`fullPath` self-references (`Route.id`, `Route.path`) to make the broader guarantee explicit.

<img width="807" height="409" alt="image" src="https://github.com/user-attachments/assets/a26a2d7f-240a-4828-94ca-f6f8fd37d368" />

_`pnpm test` results on `main`_

<img width="807" height="409" alt="image" src="https://github.com/user-attachments/assets/c3361995-3dd9-45d5-8170-4fc5fc5c6c4d" />

_`pnpm test` results on this branch_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Type Improvements**
  * Enhanced type inference for route creation and configuration across routing packages.
  * Expanded flexibility for `beforeLoad` hook return types.

* **Tests**
  * Added test cases validating self-referential route behavior in `beforeLoad` hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->