### PR TITLE
ci: maint branches should not have latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,13 +72,15 @@ jobs:
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           elif [[ "$BRANCH" == *-maint ]]; then
             echo "tag=maint" >> "$GITHUB_OUTPUT"
+          else
+            echo "latest=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Publish Packages
         if: steps.commit.outputs.committed == 'true'
         run: pnpm run changeset:publish ${{ steps.dist-tag.outputs.tag && format('--tag {0}', steps.dist-tag.outputs.tag) }}
       - name: Create GitHub Release
         if: steps.commit.outputs.committed == 'true'
-        run: node scripts/create-github-release.mjs ${{ steps.dist-tag.outputs.prerelease == 'true' && '--prerelease' }}
+        run: node scripts/create-github-release.mjs ${{ steps.dist-tag.outputs.prerelease == 'true' && '--prerelease' }} ${{ steps.dist-tag.outputs.latest == 'true' && '--latest' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -210,6 +210,7 @@ const tagName = `release-${date}-${time}`
 const titleDate = `${date} ${now.toISOString().slice(11, 16)}`
 
 const isPrerelease = process.argv.includes('--prerelease')
+const isLatest = process.argv.includes('--latest')
 
 const body = `Release ${titleDate}
 
@@ -238,7 +239,7 @@ if (!tagExists) {
 }
 
 const prereleaseFlag = isPrerelease ? '--prerelease' : ''
-const latestFlag = isPrerelease ? '' : ' --latest'
+const latestFlag = isLatest ? ' --latest' : ''
 const tmpFile = path.join(tmpdir(), `release-notes-${tagName}.md`)
 fs.writeFileSync(tmpFile, body)
 


### PR DESCRIPTION
This fixes such that only main branch will apply latest tag.

Presently both main and maint will add it, because neither are pre-releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to better control and identify latest release versions through explicit versioning flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->