### PR TITLE
ci: support semver breaking changes

### DIFF
--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -123,6 +123,7 @@ const rawLog = execSync(
 ).trim()
 
 const typeOrder = [
+  'breaking',
   'feat',
   'fix',
   'perf',
@@ -133,6 +134,7 @@ const typeOrder = [
   'ci',
 ]
 const typeLabels = {
+  breaking: '⚠️ Breaking Changes',
   feat: 'Features',
   fix: 'Fix',
   perf: 'Performance',
@@ -158,11 +160,12 @@ for (const line of commits) {
   // Skip release commits
   if (subject.startsWith('ci: changeset release')) continue
 
-  // Parse conventional commit: type(scope): message
-  const conventionalMatch = subject.match(/^(\w+)(?:\(([^)]*)\))?:\s*(.*)$/)
+  // Parse conventional commit: type(scope)!: message
+  const conventionalMatch = subject.match(/^(\w+)(?:\(([^)]*)\))?(!)?:\s*(.*)$/)
   const type = conventionalMatch ? conventionalMatch[1] : 'other'
+  const isBreaking = conventionalMatch ? !!conventionalMatch[3] : false
   const scope = conventionalMatch ? conventionalMatch[2] || '' : ''
-  const message = conventionalMatch ? conventionalMatch[3] : subject
+  const message = conventionalMatch ? conventionalMatch[4] : subject
 
   // Only include user-facing change types
   if (!['feat', 'fix', 'perf', 'refactor', 'build'].includes(type)) continue
@@ -171,8 +174,9 @@ for (const line of commits) {
   const prMatch = message.match(/\(#(\d+)\)/)
   const prNumber = prMatch ? prMatch[1] : null
 
-  if (!groups[type]) groups[type] = []
-  groups[type].push({ hash, email, scope, message, prNumber })
+  const bucket = isBreaking ? 'breaking' : type
+  if (!groups[bucket]) groups[bucket] = []
+  groups[bucket].push({ hash, email, scope, message, prNumber })
 }
 
 // Build markdown grouped by conventional commit type


### PR DESCRIPTION
This pr will make a proper "Breaking Changes" section if there are any. A breaking change is marked by exlcamation mark, like `feat!:`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release notes generation to recognize and categorize breaking changes marked with an exclamation mark in conventional commit messages.
  * Breaking changes are now automatically placed in a dedicated section of generated release notes for improved visibility.
  * Extended conventional commit parsing to support the "type(scope)!: message" format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->