### PR TITLE
ci: pnpm changeset pre enter pre

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Stop Nx Agents
         if: ${{ always() && steps.changesets.outputs.has_changesets == 'true' }}
         run: npx nx-cloud stop-all-agents
+      - name: Enter Pre-Release Mode
+        if: "contains(github.ref_name, '-pre') && !hashFiles('.changeset/pre.json')"
+        run: pnpm changeset pre enter pre
       - name: Version Packages
         run: pnpm run changeset:version
         env:


### PR DESCRIPTION
if no `.changeset/pre.json` file exist, on a `*-pre` the ci will as a safety measure run `pnpm changeset pre enter pre` to avoid a stable release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow automation to better handle pre-release versioning processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->