### PR TITLE
ci: guard against shell injection

### DIFF
--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -2,7 +2,7 @@
 import fs from 'fs'
 import path from 'node:path'
 import { globSync } from 'node:fs'
-import { execSync } from 'node:child_process'
+import { execSync, execFileSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 
 const rootDir = path.join(import.meta.dirname, '..')
@@ -80,8 +80,9 @@ for (const relPath of allPkgJsonPaths) {
   // Get the version from the previous release commit
   if (previousRelease) {
     try {
-      const prevContent = execSync(
-        `git show ${previousRelease}:packages/${relPath}`,
+      const prevContent = execFileSync(
+        'git',
+        ['show', `${previousRelease}:packages/${relPath}`],
         { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] },
       )
       const prevPkg = JSON.parse(prevContent)


### PR DESCRIPTION
CI vulnerability surfaced by code rabbit:
- https://github.com/TanStack/query/pull/10283#discussion_r2950202389

> **Prevent shell injection by passing repository paths as command arguments.**

> relPath comes from filesystem glob results and can contain shell metacharacters. When interpolated into the execSync command string, a maliciously named package directory (e.g., query$(whoami)/package.json) would execute arbitrary commands during the release workflow. Use execFileSync with an argument array to bypass shell interpretation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release automation to improve reliability and efficiency of the release creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->