### PR TITLE
ci: include `chore` in release notes

### DIFF
--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -169,7 +169,8 @@ for (const line of commits) {
   const message = conventionalMatch ? conventionalMatch[4] : subject
 
   // Only include user-facing change types
-  if (!['chore', 'feat', 'fix', 'perf', 'refactor', 'build'].includes(type)) continue
+  if (!['chore', 'feat', 'fix', 'perf', 'refactor', 'build'].includes(type))
+    continue
 
   // Extract PR number if present
   const prMatch = message.match(/\(#(\d+)\)/)


### PR DESCRIPTION
with this change, the release notes include "'feat', 'fix', 'perf', 'refactor', 'build', 'chore'"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release notes generation to include chore-type commits in changelogs, expanding the types of changes that appear in future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->