### PR TITLE
docs: add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}


### PR DESCRIPTION
Codesandboxes on tanstack.com use Node 20.12 for router/start examples, and vite prefer 20.19+

It says in codesandbox docs that they can adjust container image with dev containers:

https://codesandbox.io/docs/tutorial/getting-started-with-dev-containers

Therefore, this PR adds

`.devcontainer/devcontainer.json`

With 

```
{
  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
}
```

