### PR TITLE
docs: add devcontainer to solid/start-basic example

### DIFF
--- a/examples/solid/start-basic/.devcontainer/devcontainer.json
+++ b/examples/solid/start-basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}


### PR DESCRIPTION
Similar to 
- #6970 

But this adds it to the example instead of root, to see if that helps codesandbox pick up the config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development container configuration for TypeScript/Node.js environments.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->