### PR TITLE
docs: add devcontainer.json to all e2e/examples

### DIFF
--- a/e2e/react-router/basepath-file-based/.devcontainer/devcontainer.json
+++ b/e2e/react-router/basepath-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/basic-esbuild-file-based/.devcontainer/devcontainer.json
+++ b/e2e/react-router/basic-esbuild-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/basic-file-based-code-splitting/.devcontainer/devcontainer.json
+++ b/e2e/react-router/basic-file-based-code-splitting/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/basic-file-based/.devcontainer/devcontainer.json
+++ b/e2e/react-router/basic-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/basic-react-query-file-based/.devcontainer/devcontainer.json
+++ b/e2e/react-router/basic-react-query-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/basic-react-query/.devcontainer/devcontainer.json
+++ b/e2e/react-router/basic-react-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/basic-scroll-restoration/.devcontainer/devcontainer.json
+++ b/e2e/react-router/basic-scroll-restoration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/basic-virtual-file-based/.devcontainer/devcontainer.json
+++ b/e2e/react-router/basic-virtual-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
+++ b/e2e/react-router/basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/basic/.devcontainer/devcontainer.json
+++ b/e2e/react-router/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/escaped-special-strings/.devcontainer/devcontainer.json
+++ b/e2e/react-router/escaped-special-strings/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/generator-cli-only/.devcontainer/devcontainer.json
+++ b/e2e/react-router/generator-cli-only/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/i18n-paraglide/.devcontainer/devcontainer.json
+++ b/e2e/react-router/i18n-paraglide/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/js-only-file-based/.devcontainer/devcontainer.json
+++ b/e2e/react-router/js-only-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/rspack-basic-file-based/.devcontainer/devcontainer.json
+++ b/e2e/react-router/rspack-basic-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/rspack-basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
+++ b/e2e/react-router/rspack-basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/scroll-restoration-sandbox-vite/.devcontainer/devcontainer.json
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/sentry-integration/.devcontainer/devcontainer.json
+++ b/e2e/react-router/sentry-integration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-router/view-transitions/.devcontainer/devcontainer.json
+++ b/e2e/react-router/view-transitions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/basic-auth/.devcontainer/devcontainer.json
+++ b/e2e/react-start/basic-auth/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/basic-cloudflare/.devcontainer/devcontainer.json
+++ b/e2e/react-start/basic-cloudflare/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/basic-react-query/.devcontainer/devcontainer.json
+++ b/e2e/react-start/basic-react-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/basic-rsc/.devcontainer/devcontainer.json
+++ b/e2e/react-start/basic-rsc/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/basic-tsr-config/.devcontainer/devcontainer.json
+++ b/e2e/react-start/basic-tsr-config/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/basic/.devcontainer/devcontainer.json
+++ b/e2e/react-start/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/clerk-basic/.devcontainer/devcontainer.json
+++ b/e2e/react-start/clerk-basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/csp/.devcontainer/devcontainer.json
+++ b/e2e/react-start/csp/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/css-modules/.devcontainer/devcontainer.json
+++ b/e2e/react-start/css-modules/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/custom-basepath/.devcontainer/devcontainer.json
+++ b/e2e/react-start/custom-basepath/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/dev-ssr-styles/.devcontainer/devcontainer.json
+++ b/e2e/react-start/dev-ssr-styles/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/flamegraph-bench/.devcontainer/devcontainer.json
+++ b/e2e/react-start/flamegraph-bench/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/i18n-paraglide/.devcontainer/devcontainer.json
+++ b/e2e/react-start/i18n-paraglide/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/import-protection-custom-config/.devcontainer/devcontainer.json
+++ b/e2e/react-start/import-protection-custom-config/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/import-protection/.devcontainer/devcontainer.json
+++ b/e2e/react-start/import-protection/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/query-integration/.devcontainer/devcontainer.json
+++ b/e2e/react-start/query-integration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/scroll-restoration/.devcontainer/devcontainer.json
+++ b/e2e/react-start/scroll-restoration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/selective-ssr/.devcontainer/devcontainer.json
+++ b/e2e/react-start/selective-ssr/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/serialization-adapters/.devcontainer/devcontainer.json
+++ b/e2e/react-start/serialization-adapters/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/server-functions-global-middleware/.devcontainer/devcontainer.json
+++ b/e2e/react-start/server-functions-global-middleware/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/server-functions/.devcontainer/devcontainer.json
+++ b/e2e/react-start/server-functions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/server-routes-global-middleware/.devcontainer/devcontainer.json
+++ b/e2e/react-start/server-routes-global-middleware/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/server-routes/.devcontainer/devcontainer.json
+++ b/e2e/react-start/server-routes/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/spa-mode/.devcontainer/devcontainer.json
+++ b/e2e/react-start/spa-mode/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/split-base-and-basepath/.devcontainer/devcontainer.json
+++ b/e2e/react-start/split-base-and-basepath/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/static-server-functions/.devcontainer/devcontainer.json
+++ b/e2e/react-start/static-server-functions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/streaming-ssr/.devcontainer/devcontainer.json
+++ b/e2e/react-start/streaming-ssr/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/transform-asset-urls/.devcontainer/devcontainer.json
+++ b/e2e/react-start/transform-asset-urls/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/virtual-routes/.devcontainer/devcontainer.json
+++ b/e2e/react-start/virtual-routes/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/react-start/website/.devcontainer/devcontainer.json
+++ b/e2e/react-start/website/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/basepath-file-based/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/basepath-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/basic-esbuild-file-based/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/basic-esbuild-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/basic-file-based-code-splitting/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/basic-file-based-code-splitting/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/basic-file-based/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/basic-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/basic-scroll-restoration/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/basic-scroll-restoration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/basic-solid-query-file-based/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/basic-solid-query-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/basic-solid-query/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/basic-solid-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/basic-virtual-file-based/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/basic-virtual-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/basic/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/generator-cli-only/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/generator-cli-only/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/js-only-file-based/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/js-only-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/rspack-basic-file-based/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/rspack-basic-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/rspack-basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/rspack-basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/sentry-integration/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/sentry-integration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-router/view-transitions/.devcontainer/devcontainer.json
+++ b/e2e/solid-router/view-transitions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/basic-auth/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/basic-auth/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/basic-cloudflare/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/basic-cloudflare/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/basic-solid-query/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/basic-solid-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/basic-tsr-config/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/basic-tsr-config/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/basic/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/csp/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/csp/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/css-modules/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/css-modules/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/custom-basepath/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/custom-basepath/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/query-integration/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/query-integration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/scroll-restoration/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/scroll-restoration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/selective-ssr/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/selective-ssr/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/serialization-adapters/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/serialization-adapters/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/server-functions/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/server-functions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/server-routes/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/server-routes/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/spa-mode/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/spa-mode/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/virtual-routes/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/virtual-routes/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/solid-start/website/.devcontainer/devcontainer.json
+++ b/e2e/solid-start/website/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/basepath-file-based/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/basepath-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/basic-esbuild-file-based/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/basic-esbuild-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/basic-file-based-jsx/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/basic-file-based-jsx/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/basic-file-based-sfc/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/basic-file-based-sfc/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/basic-scroll-restoration/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/basic-scroll-restoration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/basic-virtual-file-based/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/basic-virtual-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/basic-vue-query-file-based/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/basic-vue-query-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/basic-vue-query/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/basic-vue-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/basic/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/generator-cli-only/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/generator-cli-only/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/js-only-file-based/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/js-only-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/rspack-basic-file-based/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/rspack-basic-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/rspack-basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/rspack-basic-virtual-named-export-config-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/scroll-restoration-sandbox-vite/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/scroll-restoration-sandbox-vite/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/sentry-integration/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/sentry-integration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-router/view-transitions/.devcontainer/devcontainer.json
+++ b/e2e/vue-router/view-transitions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/basic-auth/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/basic-auth/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/basic-cloudflare/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/basic-cloudflare/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/basic-tsr-config/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/basic-tsr-config/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/basic-vue-query/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/basic-vue-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/basic/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/css-modules/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/css-modules/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/custom-basepath/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/custom-basepath/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/query-integration/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/query-integration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/scroll-restoration/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/scroll-restoration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/selective-ssr/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/selective-ssr/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/serialization-adapters/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/serialization-adapters/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/server-functions/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/server-functions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/server-routes/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/server-routes/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/spa-mode/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/spa-mode/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/virtual-routes/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/virtual-routes/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/e2e/vue-start/website/.devcontainer/devcontainer.json
+++ b/e2e/vue-start/website/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/authenticated-routes-firebase/.devcontainer/devcontainer.json
+++ b/examples/react/authenticated-routes-firebase/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/authenticated-routes/.devcontainer/devcontainer.json
+++ b/examples/react/authenticated-routes/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic-default-search-params/.devcontainer/devcontainer.json
+++ b/examples/react/basic-default-search-params/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic-devtools-panel/.devcontainer/devcontainer.json
+++ b/examples/react/basic-devtools-panel/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/basic-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic-non-nested-devtools/.devcontainer/devcontainer.json
+++ b/examples/react/basic-non-nested-devtools/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic-react-query-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/basic-react-query-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic-react-query/.devcontainer/devcontainer.json
+++ b/examples/react/basic-react-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic-ssr-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/basic-ssr-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic-ssr-streaming-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/basic-ssr-streaming-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic-virtual-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/basic-virtual-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic-virtual-inside-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/basic-virtual-inside-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/basic/.devcontainer/devcontainer.json
+++ b/examples/react/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/deferred-data/.devcontainer/devcontainer.json
+++ b/examples/react/deferred-data/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/i18n-paraglide/.devcontainer/devcontainer.json
+++ b/examples/react/i18n-paraglide/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/kitchen-sink-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/kitchen-sink-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/kitchen-sink-react-query-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/kitchen-sink-react-query-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/kitchen-sink-react-query/.devcontainer/devcontainer.json
+++ b/examples/react/kitchen-sink-react-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/kitchen-sink/.devcontainer/devcontainer.json
+++ b/examples/react/kitchen-sink/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/large-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/large-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/location-masking/.devcontainer/devcontainer.json
+++ b/examples/react/location-masking/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/navigation-blocking/.devcontainer/devcontainer.json
+++ b/examples/react/navigation-blocking/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/quickstart-esbuild-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/quickstart-esbuild-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/quickstart-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/quickstart-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/quickstart-rspack-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/quickstart-rspack-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/quickstart-webpack-file-based/.devcontainer/devcontainer.json
+++ b/examples/react/quickstart-webpack-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/quickstart/.devcontainer/devcontainer.json
+++ b/examples/react/quickstart/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/router-monorepo-react-query/.devcontainer/devcontainer.json
+++ b/examples/react/router-monorepo-react-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/router-monorepo-simple-lazy/.devcontainer/devcontainer.json
+++ b/examples/react/router-monorepo-simple-lazy/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/router-monorepo-simple/.devcontainer/devcontainer.json
+++ b/examples/react/router-monorepo-simple/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/scroll-restoration/.devcontainer/devcontainer.json
+++ b/examples/react/scroll-restoration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/search-validator-adapters/.devcontainer/devcontainer.json
+++ b/examples/react/search-validator-adapters/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-bare/.devcontainer/devcontainer.json
+++ b/examples/react/start-bare/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-basic-auth/.devcontainer/devcontainer.json
+++ b/examples/react/start-basic-auth/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-basic-authjs/.devcontainer/devcontainer.json
+++ b/examples/react/start-basic-authjs/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-basic-cloudflare/.devcontainer/devcontainer.json
+++ b/examples/react/start-basic-cloudflare/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-basic-react-query/.devcontainer/devcontainer.json
+++ b/examples/react/start-basic-react-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-basic-rsc/.devcontainer/devcontainer.json
+++ b/examples/react/start-basic-rsc/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-basic-static/.devcontainer/devcontainer.json
+++ b/examples/react/start-basic-static/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-basic/.devcontainer/devcontainer.json
+++ b/examples/react/start-basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-bun/.devcontainer/devcontainer.json
+++ b/examples/react/start-bun/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-clerk-basic/.devcontainer/devcontainer.json
+++ b/examples/react/start-clerk-basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-convex-trellaux/.devcontainer/devcontainer.json
+++ b/examples/react/start-convex-trellaux/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-counter/.devcontainer/devcontainer.json
+++ b/examples/react/start-counter/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-i18n-paraglide/.devcontainer/devcontainer.json
+++ b/examples/react/start-i18n-paraglide/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-large/.devcontainer/devcontainer.json
+++ b/examples/react/start-large/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-material-ui/.devcontainer/devcontainer.json
+++ b/examples/react/start-material-ui/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-streaming-data-from-server-functions/.devcontainer/devcontainer.json
+++ b/examples/react/start-streaming-data-from-server-functions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-supabase-basic/.devcontainer/devcontainer.json
+++ b/examples/react/start-supabase-basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-tailwind-v4/.devcontainer/devcontainer.json
+++ b/examples/react/start-tailwind-v4/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-trellaux/.devcontainer/devcontainer.json
+++ b/examples/react/start-trellaux/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/start-workos/.devcontainer/devcontainer.json
+++ b/examples/react/start-workos/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/view-transitions/.devcontainer/devcontainer.json
+++ b/examples/react/view-transitions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/with-framer-motion/.devcontainer/devcontainer.json
+++ b/examples/react/with-framer-motion/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/with-trpc-react-query/.devcontainer/devcontainer.json
+++ b/examples/react/with-trpc-react-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/react/with-trpc/.devcontainer/devcontainer.json
+++ b/examples/react/with-trpc/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/authenticated-routes-firebase/.devcontainer/devcontainer.json
+++ b/examples/solid/authenticated-routes-firebase/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/authenticated-routes/.devcontainer/devcontainer.json
+++ b/examples/solid/authenticated-routes/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic-default-search-params/.devcontainer/devcontainer.json
+++ b/examples/solid/basic-default-search-params/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic-devtools-panel/.devcontainer/devcontainer.json
+++ b/examples/solid/basic-devtools-panel/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/basic-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic-non-nested-devtools/.devcontainer/devcontainer.json
+++ b/examples/solid/basic-non-nested-devtools/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic-solid-query-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/basic-solid-query-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic-solid-query/.devcontainer/devcontainer.json
+++ b/examples/solid/basic-solid-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic-ssr-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/basic-ssr-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic-ssr-streaming-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/basic-ssr-streaming-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic-virtual-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/basic-virtual-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic-virtual-inside-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/basic-virtual-inside-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/basic/.devcontainer/devcontainer.json
+++ b/examples/solid/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/deferred-data/.devcontainer/devcontainer.json
+++ b/examples/solid/deferred-data/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/i18n-paraglide/.devcontainer/devcontainer.json
+++ b/examples/solid/i18n-paraglide/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/kitchen-sink-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/kitchen-sink-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/kitchen-sink-solid-query-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/kitchen-sink-solid-query-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/kitchen-sink-solid-query/.devcontainer/devcontainer.json
+++ b/examples/solid/kitchen-sink-solid-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/kitchen-sink/.devcontainer/devcontainer.json
+++ b/examples/solid/kitchen-sink/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/large-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/large-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/location-masking/.devcontainer/devcontainer.json
+++ b/examples/solid/location-masking/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/navigation-blocking/.devcontainer/devcontainer.json
+++ b/examples/solid/navigation-blocking/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/quickstart-esbuild-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/quickstart-esbuild-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/quickstart-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/quickstart-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/quickstart-rspack-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/quickstart-rspack-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/quickstart-webpack-file-based/.devcontainer/devcontainer.json
+++ b/examples/solid/quickstart-webpack-file-based/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/quickstart/.devcontainer/devcontainer.json
+++ b/examples/solid/quickstart/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/router-monorepo-simple-lazy/.devcontainer/devcontainer.json
+++ b/examples/solid/router-monorepo-simple-lazy/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/router-monorepo-simple/.devcontainer/devcontainer.json
+++ b/examples/solid/router-monorepo-simple/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/router-monorepo-solid-query/.devcontainer/devcontainer.json
+++ b/examples/solid/router-monorepo-solid-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/scroll-restoration/.devcontainer/devcontainer.json
+++ b/examples/solid/scroll-restoration/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/search-validator-adapters/.devcontainer/devcontainer.json
+++ b/examples/solid/search-validator-adapters/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-basic-auth/.devcontainer/devcontainer.json
+++ b/examples/solid/start-basic-auth/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-basic-authjs/.devcontainer/devcontainer.json
+++ b/examples/solid/start-basic-authjs/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-basic-cloudflare/.devcontainer/devcontainer.json
+++ b/examples/solid/start-basic-cloudflare/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-basic-netlify/.devcontainer/devcontainer.json
+++ b/examples/solid/start-basic-netlify/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-basic-nitro/.devcontainer/devcontainer.json
+++ b/examples/solid/start-basic-nitro/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-basic-solid-query/.devcontainer/devcontainer.json
+++ b/examples/solid/start-basic-solid-query/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-basic-static/.devcontainer/devcontainer.json
+++ b/examples/solid/start-basic-static/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-bun/.devcontainer/devcontainer.json
+++ b/examples/solid/start-bun/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-convex-better-auth/.devcontainer/devcontainer.json
+++ b/examples/solid/start-convex-better-auth/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-counter/.devcontainer/devcontainer.json
+++ b/examples/solid/start-counter/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-i18n-paraglide/.devcontainer/devcontainer.json
+++ b/examples/solid/start-i18n-paraglide/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-large/.devcontainer/devcontainer.json
+++ b/examples/solid/start-large/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-streaming-data-from-server-functions/.devcontainer/devcontainer.json
+++ b/examples/solid/start-streaming-data-from-server-functions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-supabase-basic/.devcontainer/devcontainer.json
+++ b/examples/solid/start-supabase-basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/start-tailwind-v4/.devcontainer/devcontainer.json
+++ b/examples/solid/start-tailwind-v4/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/view-transitions/.devcontainer/devcontainer.json
+++ b/examples/solid/view-transitions/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/with-framer-motion/.devcontainer/devcontainer.json
+++ b/examples/solid/with-framer-motion/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/solid/with-trpc/.devcontainer/devcontainer.json
+++ b/examples/solid/with-trpc/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/vue/basic-file-based-jsx/.devcontainer/devcontainer.json
+++ b/examples/vue/basic-file-based-jsx/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/vue/basic-file-based-sfc/.devcontainer/devcontainer.json
+++ b/examples/vue/basic-file-based-sfc/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}

--- a/examples/vue/basic/.devcontainer/devcontainer.json
+++ b/examples/vue/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24"
+}


### PR DESCRIPTION
Context
- #6970 

Similar to
- #6971 

This adds a devcontainer config to each example/e2e, which makes the codesandboxes on tanstack.com work correctly (otherwise they use a too old node 20.12).

The only working example right now is Start / Solid / Basic , because it has the devcontainer config.