### PR TITLE
docs: update the scratch guide to be compatible with Vite 8^

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -80,7 +80,7 @@ Alternatively, you can also use `@vitejs/plugin-react-swc`.
 and some TypeScript:
 
 ```shell
-npm i -D typescript @types/react @types/react-dom @types/node vite-tsconfig-paths
+npm i -D typescript @types/react @types/react-dom @types/node
 ```
 
 ## Update Configuration Files
@@ -103,7 +103,6 @@ Then configure TanStack Start's Vite plugin in `vite.config.ts`:
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite'
-import tsConfigPaths from 'vite-tsconfig-paths'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
 
@@ -111,8 +110,10 @@ export default defineConfig({
   server: {
     port: 3000,
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
   plugins: [
-    tsConfigPaths(),
     tanstackStart(),
     // react's vite plugin must come after start's vite plugin
     viteReact(),

--- a/docs/start/framework/solid/build-from-scratch.md
+++ b/docs/start/framework/solid/build-from-scratch.md
@@ -65,7 +65,7 @@ npm i solid-js vite-plugin-solid
 and some TypeScript:
 
 ```shell
-npm i -D typescript @types/node vite-tsconfig-paths
+npm i -D typescript @types/node
 ```
 
 ## Update Configuration Files
@@ -88,7 +88,6 @@ Then configure TanStack Start's Vite plugin in `vite.config.ts`:
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite'
-import tsConfigPaths from 'vite-tsconfig-paths'
 import { tanstackStart } from '@tanstack/solid-start/plugin/vite'
 import viteSolid from 'vite-plugin-solid'
 
@@ -96,8 +95,10 @@ export default defineConfig({
   server: {
     port: 3000,
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
   plugins: [
-    tsConfigPaths(),
     tanstackStart(),
     // solid's vite plugin must come after start's vite plugin
     viteSolid({ ssr: true }),


### PR DESCRIPTION
Vite 8 is out. and by following the **build from scratch** guide and runing the command `npm i vite` it install v 8^.

Vite 8 introduce this option `resolve.tsconfigPaths` and so no need for the plugin `vite-tsconfig-paths` anymore.

I skipped two files intentionlly containing same snippet `migrate-from-next-js.md` and `tailwindd-integration.md` because I don't know if it compatible with it yet. 

Let me know if I should also update those files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React and Solid framework build-from-scratch guides with revised Vite build configuration instructions.
  * Removed vite-tsconfig-paths plugin dependency from installation steps.
  * Documentation now demonstrates path alias resolution using Vite's native configuration option in place of external plugin.
  * Changes reflected across both React and Solid framework setup guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->