### PR TITLE
fix: restore SSR benchmark builds on Vite 7

### DIFF
--- a/packages/start-plugin-core/src/utils.ts
+++ b/packages/start-plugin-core/src/utils.ts
@@ -1,10 +1,20 @@
 import * as vite from 'vite'
 
 /**
- * Vite 8+ uses Rolldown instead of Rollup, renaming `build.rollupOptions`
- * to `build.rolldownOptions`. Detect which bundler is in use.
+ * Vite 7 also exports `rolldownVersion`, so feature detection on that export is
+ * not enough to tell which build config key Vite expects.
  */
-export const isRolldown = 'rolldownVersion' in vite
+export function usesRolldown(viteVersion: string): boolean {
+  const viteMajorVersion = Number.parseInt(viteVersion.split('.')[0] ?? '', 10)
+
+  return Number.isFinite(viteMajorVersion) && viteMajorVersion >= 8
+}
+
+/**
+ * Vite 8+ uses Rolldown instead of Rollup, renaming `build.rollupOptions`
+ * to `build.rolldownOptions`.
+ */
+export const isRolldown = usesRolldown(vite.version)
 
 /** Returns `'rolldownOptions'` when using Rolldown, `'rollupOptions'` otherwise. */
 export const bundlerOptionsKey = isRolldown

--- a/packages/start-plugin-core/tests/utils.test.ts
+++ b/packages/start-plugin-core/tests/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest'
+
+import { getBundlerOptions, usesRolldown } from '../src/utils'
+
+describe('usesRolldown', () => {
+  test('uses rollup config keys on Vite 7', () => {
+    expect(usesRolldown('7.3.1')).toBe(false)
+  })
+
+  test('uses rolldown config keys on Vite 8', () => {
+    expect(usesRolldown('8.0.0')).toBe(true)
+  })
+
+  test('defaults to rollup config keys for unknown versions', () => {
+    expect(usesRolldown('unknown')).toBe(false)
+  })
+})
+
+describe('getBundlerOptions', () => {
+  test('prefers rolldown options when present', () => {
+    const rolldownOptions = { input: 'entry.ts' }
+
+    expect(
+      getBundlerOptions({
+        rolldownOptions,
+        rollupOptions: { input: 'legacy-entry.ts' },
+      }),
+    ).toBe(rolldownOptions)
+  })
+
+  test('falls back to rollup options', () => {
+    const rollupOptions = { input: 'entry.ts' }
+
+    expect(getBundlerOptions({ rollupOptions })).toBe(rollupOptions)
+  })
+})


### PR DESCRIPTION
## Summary
- fix Start's bundler detection so Vite 7 keeps using `rollupOptions` instead of incorrectly switching to `rolldownOptions`
- restore the SSR benchmark builds that were falling back to missing `index.html` entry resolution in React, Solid, and Vue
- add regression tests around Vite 7 vs Vite 8 detection and bundler option lookup

## Testing
- Not run in this workspace (`node_modules` is not installed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Rolldown detection to use version-based logic for more reliable identification of supported versions.

* **Tests**
  * Added comprehensive test coverage for utility functions to ensure proper behavior across different version scenarios and bundler configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->