### PR TITLE
Tanstack start docs: fix nodejs link for bun

### DIFF
--- a/docs/start/framework/react/guide/hosting.md
+++ b/docs/start/framework/react/guide/hosting.md
@@ -288,7 +288,7 @@ npm run start
 ### Bun
 
 > [!IMPORTANT]
-> Currently, the Bun specific deployment guidelines only work with React 19. If you are using React 18, please refer to the [Node.js](#nodejs--railway--docker) deployment guidelines.
+> Currently, the Bun specific deployment guidelines only work with React 19. If you are using React 18, please refer to the [Node.js](#nodejs--docker) deployment guidelines.
 
 Make sure that your `react` and `react-dom` packages are set to version 19.0.0 or higher in your `package.json` file. If not, run the following command to upgrade the packages:
 


### PR DESCRIPTION
The link for the nodejs header was not updated when railway was removed from this section: This commit fixes the link so it now points to the correct section.
The other links were updated within commit [f5007fa](https://github.com/TanStack/router/commit/f5007fa1611d490bae781e2cf5bd3d8fc283e704) but this one was missed.

Old link: https://tanstack.com/start/latest/docs/framework/react/guide/hosting#nodejs--railway--docker
New link: https://tanstack.com/start/latest/docs/framework/react/guide/hosting#nodejs--docker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React hosting guidance for Bun with corrected anchor reference to the Node.js/Docker section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->