### PR TITLE
fix(start-plugin-core): use duck-type check for RunnableDevEnvironment to avoid dual-package hazard

### DIFF
--- a/.changeset/fix-6982-duck-type-runnable-dev-env.md
+++ b/.changeset/fix-6982-duck-type-runnable-dev-env.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/start-plugin-core": patch
+---
+
+fix(start-plugin-core): replace isRunnableDevEnvironment instanceof check with duck-typing to avoid dual-package hazard when vite is aliased (e.g. vite-plus pnpm override)

--- a/.changeset/fix-6982-duck-type-runnable-dev-env.md
+++ b/.changeset/fix-6982-duck-type-runnable-dev-env.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/start-plugin-core": patch
+'@tanstack/start-plugin-core': patch
 ---
 
 fix(start-plugin-core): replace isRunnableDevEnvironment instanceof check with duck-typing to avoid dual-package hazard when vite is aliased (e.g. vite-plus pnpm override)

--- a/packages/start-plugin-core/src/dev-server-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/dev-server-plugin/plugin.ts
@@ -8,7 +8,12 @@ import {
   collectDevStyles,
   normalizeCssModuleCacheKey,
 } from './dev-styles'
-import type { Connect, DevEnvironment, PluginOption, RunnableDevEnvironment } from 'vite'
+import type {
+  Connect,
+  DevEnvironment,
+  PluginOption,
+  RunnableDevEnvironment,
+} from 'vite'
 import type { GetConfigFn } from '../types'
 
 export function devServerPlugin({
@@ -176,9 +181,9 @@ export function devServerPlugin({
                *  fetch(req: Request): Promise<Response>
                * }
                */
-              const serverEntry = await (serverEnv as RunnableDevEnvironment).runner.import(
-                ENTRY_POINTS.server,
-              )
+              const serverEntry = await (
+                serverEnv as RunnableDevEnvironment
+              ).runner.import(ENTRY_POINTS.server)
               const webRes = await serverEntry['default'].fetch(webReq)
 
               return sendNodeResponse(res, webRes)

--- a/packages/start-plugin-core/src/dev-server-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/dev-server-plugin/plugin.ts
@@ -1,4 +1,3 @@
-import { isRunnableDevEnvironment } from 'vite'
 import { VIRTUAL_MODULES } from '@tanstack/start-server-core'
 import { NodeRequest, sendNodeResponse } from 'srvx/node'
 import { ENTRY_POINTS, VITE_ENVIRONMENT_NAMES } from '../constants'
@@ -9,7 +8,7 @@ import {
   collectDevStyles,
   normalizeCssModuleCacheKey,
 } from './dev-styles'
-import type { Connect, DevEnvironment, PluginOption } from 'vite'
+import type { Connect, DevEnvironment, PluginOption, RunnableDevEnvironment } from 'vite'
 import type { GetConfigFn } from '../types'
 
 export function devServerPlugin({
@@ -145,7 +144,9 @@ export function devServerPlugin({
 
             // do not install middleware if SSR env in case another plugin already did
             if (
-              !isRunnableDevEnvironment(serverEnv) ||
+              // Use duck-type check instead of instanceof/isRunnableDevEnvironment to avoid
+              // dual-package hazard when vite is aliased (e.g. vite-plus pnpm override)
+              !('runner' in serverEnv) ||
               // do not check via `isFetchableDevEnvironment` since nitro does implement the `FetchableDevEnvironment` interface but not via inheritance (which this helper checks)
               'dispatchFetch' in serverEnv
             ) {
@@ -153,7 +154,7 @@ export function devServerPlugin({
             }
           }
 
-          if (!isRunnableDevEnvironment(serverEnv)) {
+          if (!('runner' in serverEnv)) {
             throw new Error(
               'cannot install vite dev server middleware for TanStack Start since the SSR environment is not a RunnableDevEnvironment',
             )
@@ -175,7 +176,7 @@ export function devServerPlugin({
                *  fetch(req: Request): Promise<Response>
                * }
                */
-              const serverEntry = await serverEnv.runner.import(
+              const serverEntry = await (serverEnv as RunnableDevEnvironment).runner.import(
                 ENTRY_POINTS.server,
               )
               const webRes = await serverEntry['default'].fetch(webReq)


### PR DESCRIPTION
## Summary

Fixes #6982

When  is aliased to another package via pnpm overrides (e.g. `vite: npm:@voidzero-dev/vite-plus-core@latest`), two different `RunnableDevEnvironment` class references exist in memory. The `isRunnableDevEnvironment()` helper uses `instanceof` which returns `false`, causing SSR middleware to never be registered and all routes returning 404.

## Changes

Replace `isRunnableDevEnvironment(serverEnv)` (instanceof-based) with a duck-type check `'runner' in serverEnv` in `packages/start-plugin-core/src/dev-server-plugin/plugin.ts`.

The `runner` property (a public getter) is unique to `RunnableDevEnvironment` — `FetchableDevEnvironment` and `DevEnvironment` don't have it. The existing `'dispatchFetch' in serverEnv` guard is preserved to correctly handle Nitro's `FetchableDevEnvironment`.

`RunnableDevEnvironment` is still imported as a **type** only (for the TypeScript cast on `serverEnv.runner.import()`), so no runtime instanceof check remains.

## Testing

- ESLint passes
- Type errors in test:types are pre-existing (missing sibling package builds in standalone test run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a compatibility issue when multiple versions or alternative distributions of the build tool were loaded in the same project, ensuring the plugin works reliably in complex dependency environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->