### PR TITLE
docs: use @tanstack/cli to create tanstack/router app

### DIFF
--- a/docs/router/quick-start.md
+++ b/docs/router/quick-start.md
@@ -35,7 +35,7 @@ TanStack Router supports both file-based and code-based route configurations. Yo
 
 The file-based approach is the recommended option for most projects. It automatically creates routes based on your file structure, giving you the best mix of performance, simplicity, and developer experience.
 
-For more details, see the [file-based routing documentation](https://tanstack.com/router/latest/docs/routing/file-based-routing) or
+For more details, see the [file-based routing documentation](./routing/file-based-routing.md) or
 
 <!-- ::start:framework -->
 
@@ -53,7 +53,7 @@ For more details, see the [file-based routing documentation](https://tanstack.co
 
 If you prefer to define routes programmatically, you can use the code-based route configuration. This approach gives you full control over routing logic.
 
-For more details, see the [code-based routing documentation](https://tanstack.com/router/latest/docs/routing/code-based-routing) or
+For more details, see the [code-based routing documentation](./routing/code-based-routing.md) or
 
 <!-- ::start:framework -->
 


### PR DESCRIPTION
upadted quickstart docs to reduce friction, since `create-tsrouter-app` is now marked as deprecated, and usage of `@tanstack/cli` is recommended now, as per warning given on project scaffold 
```bash 
Warning: create-tsrouter-app is deprecated. Use "tanstack create --router-only" or "npx @tanstack/cli create --router-only" instead.
         This defaults to router-only compatibility mode (file-based routing, no Start-specific add-ons)
```

there are still two places where create-ts-router is referenced, but they are using custom templates - `shadcn` and `start` which is not supported with new command
```bash
bunx @tanstack/cli create --router-only my-app --template code-route
│
▲  The --router-only flag enables router-only compatibility mode. Start-dependent add-ons, deployment adapters, and templates are disabled; only the base template and optional toolchain are supported.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated quick-start scaffold commands to use the unified CLI with a router-only option (Solid gets an explicit framework flag).
  * Replaced legacy CLI links with the general CLI documentation.
  * Reorganized routing guides into framework-specific (React, Solid) sections linking to live file- and code-based examples.
  * Clarified "for more details" links throughout routing docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->