### PR TITLE
docs: update migrate from next docs to working example

### DIFF
--- a/docs/start/framework/react/migrate-from-next-js.md
+++ b/docs/start/framework/react/migrate-from-next-js.md
@@ -89,15 +89,15 @@ import { defineConfig } from 'vite'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import { nitro } from "nitro/vite";
+import { nitro } from 'nitro/vite'
 
 export default defineConfig({
   server: {
     port: 3000,
   },
   resolve: {
-      // Enables Vite to resolve imports using path aliases.
-      tsconfigPaths: true,
+    // Enables Vite to resolve imports using path aliases.
+    tsconfigPaths: true,
   },
   plugins: [
     tailwindcss(),


### PR DESCRIPTION
Current example is a bit out of date with the new Vite 8 release, and it is not fully working because it is missing the `nitro` dependency.

- Added `nitro` as a dependency and included it in the Vite configuration. This is required to run the application after build. Without it it will just do a silent 0 exit without any output.
- Removed the `vite-tsconfig-paths` dependency in favor of path alias support introduced in Vite v8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated React migration guide with a streamlined Vite setup and clearer example configuration.
  * Replaced an external path-alias plugin with Vite’s built-in tsconfig path resolution and simplified related Tailwind dev dependency instructions.
  * Added guidance and an example for integrating a Vite-compatible deployment plugin into the project setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->