### PR TITLE
refactor(router): remove global file route helpers

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1,5 +1,4 @@
 import { RouterCore } from '@tanstack/router-core'
-import { createFileRoute, createLazyFileRoute } from './fileRoute'
 import { getStoreFactory } from './routerStores'
 import type { RouterHistory } from '@tanstack/history'
 import type {
@@ -117,12 +116,4 @@ export class Router<
   ) {
     super(options, getStoreFactory)
   }
-}
-
-if (typeof globalThis !== 'undefined') {
-  ;(globalThis as any).createFileRoute = createFileRoute
-  ;(globalThis as any).createLazyFileRoute = createLazyFileRoute
-} else if (typeof window !== 'undefined') {
-  ;(window as any).createFileRoute = createFileRoute
-  ;(window as any).createLazyFileRoute = createLazyFileRoute
 }

--- a/packages/solid-router/src/router.ts
+++ b/packages/solid-router/src/router.ts
@@ -1,5 +1,4 @@
 import { RouterCore } from '@tanstack/router-core'
-import { createFileRoute, createLazyFileRoute } from './fileRoute'
 import { getStoreFactory } from './routerStores'
 import type { RouterHistory } from '@tanstack/history'
 import type {
@@ -102,12 +101,4 @@ export class Router<
   ) {
     super(options, getStoreFactory)
   }
-}
-
-if (typeof globalThis !== 'undefined') {
-  ;(globalThis as any).createFileRoute = createFileRoute
-  ;(globalThis as any).createLazyFileRoute = createLazyFileRoute
-} else if (typeof window !== 'undefined') {
-  ;(window as any).createFileRoute = createFileRoute
-  ;(window as any).createLazyFileRoute = createLazyFileRoute
 }


### PR DESCRIPTION
## Summary
- remove the React and Solid router globals that were binding `createFileRoute` and `createLazyFileRoute` onto `globalThis`/`window`
- rely on the existing file-route autoimport flow instead of eagerly importing `./fileRoute` from the runtime router entrypoints
- trim a small amount of client bundle size in the React minimal bundle-size benchmark while keeping builds and shared file-route tooling tests green

## Validation
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:build --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/solid-router:build --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-plugin:test:unit --outputStyle=stream --skipRemoteCache -- tests/shared-bindings-helpers.test.ts`
- `../../node_modules/.bin/vite build` in `benchmarks/bundle-size/scenarios/react-router-minimal`

## Notes
- I did not touch the existing unrelated working tree change in `benchmarks/bundle-size/README.md`.
- In the React minimal benchmark, the main bundle moved from `278.63 kB` / `87.78 kB gzip` to `277.58 kB` / `87.58 kB gzip`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined router module initialization in React Router and Solid Router packages by removing global function assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->