### PR TITLE
fix: dedupe repeated css assets in the start manifest

### DIFF
--- a/.changeset/fair-rivers-drum.md
+++ b/.changeset/fair-rivers-drum.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+Deduplicate CSS assets in the Start manifest so shared stylesheets are not repeated within a route entry or across an active parent-child route chain.

--- a/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
@@ -31,8 +31,9 @@ interface ManifestAssetResolvers {
   getStylesheetAsset: (cssFile: string) => RouterManagedTag
 }
 
-type DedupePreloadRoute = {
+type DedupeRoute = {
   preloads?: Array<ManifestAssetLink>
+  assets?: Array<RouterManagedTag>
   children?: Array<string>
 }
 
@@ -158,7 +159,7 @@ export function buildStartManifest(options: {
     assetResolvers,
   })
 
-  dedupeNestedRoutePreloads(routes[rootRouteId]!, routes)
+  dedupeNestedRouteManifestEntries(rootRouteId, routes[rootRouteId]!, routes)
 
   // Prune routes with no assets or preloads from the manifest
   for (const routeId of Object.keys(routes)) {
@@ -418,6 +419,20 @@ export function createChunkCssAssetCollector(options: {
   const assetsByChunk = new Map<Rollup.OutputChunk, Array<RouterManagedTag>>()
   const stateByChunk = new Map<Rollup.OutputChunk, number>()
 
+  const appendAsset = (
+    assets: Array<RouterManagedTag>,
+    seenAssets: Set<string>,
+    asset: RouterManagedTag,
+  ) => {
+    const identity = getAssetIdentity(asset)
+    if (seenAssets.has(identity)) {
+      return
+    }
+
+    seenAssets.add(identity)
+    assets.push(asset)
+  }
+
   const getChunkCssAssets = (
     chunk: Rollup.OutputChunk,
   ): Array<RouterManagedTag> => {
@@ -432,9 +447,10 @@ export function createChunkCssAssetCollector(options: {
     stateByChunk.set(chunk, VISITING_CHUNK)
 
     const assets: Array<RouterManagedTag> = []
+    const seenAssets = new Set<string>()
 
     for (const cssFile of chunk.viteMetadata?.importedCss ?? []) {
-      assets.push(options.getStylesheetAsset(cssFile))
+      appendAsset(assets, seenAssets, options.getStylesheetAsset(cssFile))
     }
 
     for (let i = 0; i < chunk.imports.length; i++) {
@@ -445,7 +461,7 @@ export function createChunkCssAssetCollector(options: {
 
       const importedAssets = getChunkCssAssets(importedChunk)
       for (let j = 0; j < importedAssets.length; j++) {
-        assets.push(importedAssets[j]!)
+        appendAsset(assets, seenAssets, importedAssets[j]!)
       }
     }
 
@@ -510,12 +526,15 @@ export function buildRouteManifestRoutes(options: {
   return routes
 }
 
-export function dedupeNestedRoutePreloads(
-  route: DedupePreloadRoute,
-  routesById: Record<string, DedupePreloadRoute>,
+function dedupeNestedRouteManifestEntries(
+  routeId: string,
+  route: DedupeRoute,
+  routesById: Record<string, DedupeRoute>,
   seenPreloads = new Set<string>(),
+  seenAssets = new Set<string>(),
 ) {
   let routePreloads = route.preloads
+  let routeAssets = route.assets
 
   if (routePreloads && routePreloads.length > 0) {
     let dedupedPreloads: Array<ManifestAssetLink> | undefined
@@ -544,12 +563,49 @@ export function dedupeNestedRoutePreloads(
     }
   }
 
+  if (routeAssets && routeAssets.length > 0) {
+    let dedupedAssets: Array<RouterManagedTag> | undefined
+
+    for (let i = 0; i < routeAssets.length; i++) {
+      const asset = routeAssets[i]!
+      const identity = getAssetIdentity(asset)
+
+      if (seenAssets.has(identity)) {
+        if (dedupedAssets === undefined) {
+          dedupedAssets = routeAssets.slice(0, i)
+        }
+        continue
+      }
+
+      seenAssets.add(identity)
+
+      if (dedupedAssets) {
+        dedupedAssets.push(asset)
+      }
+    }
+
+    if (dedupedAssets) {
+      routeAssets = dedupedAssets
+      route.assets = dedupedAssets
+    }
+  }
+
   if (route.children) {
     for (const childRouteId of route.children) {
-      dedupeNestedRoutePreloads(
-        routesById[childRouteId]!,
+      const childRoute = routesById[childRouteId]
+
+      if (!childRoute) {
+        throw new Error(
+          `Route tree references child route ${childRouteId} from ${routeId}, but no route entry was found`,
+        )
+      }
+
+      dedupeNestedRouteManifestEntries(
+        childRouteId,
+        childRoute,
         routesById,
         seenPreloads,
+        seenAssets,
       )
     }
   }
@@ -557,6 +613,12 @@ export function dedupeNestedRoutePreloads(
   if (routePreloads) {
     for (let i = routePreloads.length - 1; i >= 0; i--) {
       seenPreloads.delete(resolveManifestAssetLink(routePreloads[i]!).href)
+    }
+  }
+
+  if (routeAssets) {
+    for (let i = routeAssets.length - 1; i >= 0; i--) {
+      seenAssets.delete(getAssetIdentity(routeAssets[i]!))
     }
   }
 }

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -6,7 +6,6 @@ import {
   collectDynamicImportCss,
   createChunkCssAssetCollector,
   createManifestAssetResolvers,
-  dedupeNestedRoutePreloads,
   getRouteFilePathsFromModuleIds,
   scanClientChunks,
 } from '../../src/start-manifest-plugin/manifestBuilder'
@@ -340,6 +339,51 @@ describe('createManifestAssetResolvers + createChunkCssAssetCollector', () => {
 })
 
 describe('createChunkCssAssetCollector', () => {
+  test('dedupes css from shared imported chunks', () => {
+    const chunkA = makeChunk({
+      fileName: 'a.js',
+      imports: ['b.js', 'c.js'],
+      importedCss: ['a.css'],
+    })
+    const chunkB = makeChunk({
+      fileName: 'b.js',
+      imports: ['shared.js'],
+      importedCss: ['b.css'],
+    })
+    const chunkC = makeChunk({
+      fileName: 'c.js',
+      imports: ['shared.js'],
+      importedCss: ['c.css'],
+    })
+    const sharedChunk = makeChunk({
+      fileName: 'shared.js',
+      importedCss: ['shared.css'],
+    })
+    const chunksByFileName = new Map([
+      ['a.js', chunkA],
+      ['b.js', chunkB],
+      ['c.js', chunkC],
+      ['shared.js', sharedChunk],
+    ])
+
+    const { getChunkCssAssets } = createChunkCssAssetCollector({
+      chunksByFileName,
+      getStylesheetAsset: (cssFile) => ({
+        tag: 'link',
+        attrs: { rel: 'stylesheet', href: `/${cssFile}`, type: 'text/css' },
+      }),
+    })
+
+    const assets = getChunkCssAssets(chunkA)
+
+    expect(assets.map((asset: any) => asset.attrs.href)).toEqual([
+      '/a.css',
+      '/b.css',
+      '/shared.css',
+      '/c.css',
+    ])
+  })
+
   test('handles circular chunk imports without infinite recursion', () => {
     const chunkA = makeChunk({
       fileName: 'a.js',
@@ -374,6 +418,74 @@ describe('createChunkCssAssetCollector', () => {
 })
 
 describe('buildStartManifest', () => {
+  test('dedupes route css gathered through overlapping chunk imports', () => {
+    const entryChunk = makeChunk({
+      fileName: 'entry.js',
+      isEntry: true,
+    })
+    const routeChunk = makeChunk({
+      fileName: 'route.js',
+      imports: ['branch-a.js', 'branch-b.js'],
+      moduleIds: ['/routes/about.tsx?tsr-split=component'],
+    })
+    const branchAChunk = makeChunk({
+      fileName: 'branch-a.js',
+      imports: ['shared.js'],
+      importedCss: ['branch-a.css'],
+    })
+    const branchBChunk = makeChunk({
+      fileName: 'branch-b.js',
+      imports: ['shared.js'],
+      importedCss: ['branch-b.css'],
+    })
+    const sharedChunk = makeChunk({
+      fileName: 'shared.js',
+      importedCss: ['shared.css'],
+    })
+
+    const manifest = buildStartManifest({
+      clientBundle: {
+        'entry.js': entryChunk,
+        'route.js': routeChunk,
+        'branch-a.js': branchAChunk,
+        'branch-b.js': branchBChunk,
+        'shared.js': sharedChunk,
+      },
+      routeTreeRoutes: {
+        __root__: { children: ['/about'] } as any,
+        '/about': { filePath: '/routes/about.tsx' },
+      },
+      basePath: '/assets',
+    })
+
+    expect(manifest.routes['/about']!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/branch-a.css',
+          type: 'text/css',
+        },
+      },
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/shared.css',
+          type: 'text/css',
+        },
+      },
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/branch-b.css',
+          type: 'text/css',
+        },
+      },
+    ])
+  })
+
   test('hashes css shared by route chunks and nested non-route dynamic imports', () => {
     const entryChunk = makeChunk({
       fileName: 'entry.js',
@@ -442,7 +554,7 @@ describe('buildStartManifest', () => {
     ])
   })
 
-  test('keeps entry-owned css unsuffixed when shared only with route chunks', () => {
+  test('dedupes route css already owned by ancestor routes', () => {
     const entryChunk = makeChunk({
       fileName: 'entry.js',
       isEntry: true,
@@ -490,14 +602,6 @@ describe('buildStartManifest', () => {
         attrs: {
           rel: 'stylesheet',
           href: '/assets/about.css',
-          type: 'text/css',
-        },
-      },
-      {
-        tag: 'link',
-        attrs: {
-          rel: 'stylesheet',
-          href: '/assets/main.css',
           type: 'text/css',
         },
       },
@@ -551,77 +655,357 @@ describe('buildStartManifest', () => {
   })
 })
 
-describe('dedupeNestedRoutePreloads', () => {
-  test('dedupes only along the active ancestor path', () => {
-    const routes: Manifest['routes'] = {
-      __root__: {
-        children: ['a', 'b'],
-        preloads: ['/root.js', '/shared.js'],
-      } as any,
-      a: {
-        preloads: ['/shared.js', '/a.js'],
-      },
-      b: {
-        preloads: ['/shared.js', '/b.js'],
-      },
-    }
+describe('route tree dedupe in buildStartManifest', () => {
+  test('dedupes assets and preloads only along the active ancestor path', () => {
+    const entryChunk = makeChunk({
+      fileName: 'entry.js',
+      isEntry: true,
+      imports: ['root-shared.js'],
+      importedCss: ['root.css'],
+    })
+    const rootSharedChunk = makeChunk({
+      fileName: 'root-shared.js',
+      importedCss: ['shared.css'],
+    })
+    const parentChunk = makeChunk({
+      fileName: 'parent.js',
+      imports: ['root-shared.js', 'parent-only.js'],
+      moduleIds: ['/routes/parent.tsx?tsr-split=component'],
+    })
+    const parentOnlyChunk = makeChunk({
+      fileName: 'parent-only.js',
+      importedCss: ['parent.css'],
+    })
+    const childChunk = makeChunk({
+      fileName: 'child.js',
+      imports: ['root-shared.js', 'parent-only.js', 'child-only.js'],
+      moduleIds: ['/routes/child.tsx?tsr-split=component'],
+    })
+    const childOnlyChunk = makeChunk({
+      fileName: 'child-only.js',
+      importedCss: ['child.css'],
+    })
+    const siblingChunk = makeChunk({
+      fileName: 'sibling.js',
+      imports: ['root-shared.js', 'sibling-only.js'],
+      moduleIds: ['/routes/sibling.tsx?tsr-split=component'],
+    })
+    const siblingOnlyChunk = makeChunk({
+      fileName: 'sibling-only.js',
+      importedCss: ['sibling.css'],
+    })
 
-    dedupeNestedRoutePreloads(routes.__root__!, routes)
+    const manifest = buildStartManifest({
+      clientBundle: {
+        'entry.js': entryChunk,
+        'root-shared.js': rootSharedChunk,
+        'parent.js': parentChunk,
+        'parent-only.js': parentOnlyChunk,
+        'child.js': childChunk,
+        'child-only.js': childOnlyChunk,
+        'sibling.js': siblingChunk,
+        'sibling-only.js': siblingOnlyChunk,
+      },
+      routeTreeRoutes: {
+        __root__: { children: ['/parent', '/sibling'] } as any,
+        '/parent': { filePath: '/routes/parent.tsx', children: ['/child'] },
+        '/child': { filePath: '/routes/child.tsx' },
+        '/sibling': { filePath: '/routes/sibling.tsx' },
+      },
+      basePath: '/assets',
+    })
 
-    expect(routes.__root__!.preloads).toEqual(['/root.js', '/shared.js'])
-    expect(routes.a!.preloads).toEqual(['/a.js'])
-    expect(routes.b!.preloads).toEqual(['/b.js'])
+    expect(manifest.routes.__root__!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/root.css',
+          type: 'text/css',
+        },
+      },
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/shared.css',
+          type: 'text/css',
+        },
+      },
+    ])
+    expect(manifest.routes.__root__!.preloads).toEqual([
+      '/assets/entry.js',
+      '/assets/root-shared.js',
+    ])
+    expect(manifest.routes['/parent']!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/parent.css',
+          type: 'text/css',
+        },
+      },
+    ])
+    expect(manifest.routes['/parent']!.preloads).toEqual([
+      '/assets/parent.js',
+      '/assets/parent-only.js',
+    ])
+    expect(manifest.routes['/child']!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/child.css',
+          type: 'text/css',
+        },
+      },
+    ])
+    expect(manifest.routes['/child']!.preloads).toEqual([
+      '/assets/child.js',
+      '/assets/child-only.js',
+    ])
+    expect(manifest.routes['/sibling']!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/sibling.css',
+          type: 'text/css',
+        },
+      },
+    ])
+    expect(manifest.routes['/sibling']!.preloads).toEqual([
+      '/assets/sibling.js',
+      '/assets/sibling-only.js',
+    ])
   })
 
-  test('dedupes correctly with 3+ levels of nesting', () => {
-    const routes: Manifest['routes'] = {
-      __root__: {
-        children: ['parent'],
-        preloads: ['/root.js', '/shared.js'],
-      } as any,
-      parent: {
-        children: ['child'],
-        preloads: ['/shared.js', '/parent.js'],
-      } as any,
-      child: {
-        preloads: ['/shared.js', '/parent.js', '/child.js'],
+  test('backtracking preserves reused assets and preloads for cousin routes', () => {
+    const entryChunk = makeChunk({
+      fileName: 'entry.js',
+      isEntry: true,
+    })
+    const deepChunk = makeChunk({
+      fileName: 'deep.js',
+      importedCss: ['deep.css'],
+    })
+    const aChunk = makeChunk({
+      fileName: 'a.js',
+      moduleIds: ['/routes/a.tsx?tsr-split=component'],
+    })
+    const aChildChunk = makeChunk({
+      fileName: 'a-child.js',
+      imports: ['deep.js'],
+      moduleIds: ['/routes/a-child.tsx?tsr-split=component'],
+    })
+    const bChunk = makeChunk({
+      fileName: 'b.js',
+      moduleIds: ['/routes/b.tsx?tsr-split=component'],
+    })
+    const bChildChunk = makeChunk({
+      fileName: 'b-child.js',
+      imports: ['deep.js', 'b-child-only.js'],
+      moduleIds: ['/routes/b-child.tsx?tsr-split=component'],
+    })
+    const bChildOnlyChunk = makeChunk({
+      fileName: 'b-child-only.js',
+      importedCss: ['b-child.css'],
+    })
+
+    const manifest = buildStartManifest({
+      clientBundle: {
+        'entry.js': entryChunk,
+        'deep.js': deepChunk,
+        'a.js': aChunk,
+        'a-child.js': aChildChunk,
+        'b.js': bChunk,
+        'b-child.js': bChildChunk,
+        'b-child-only.js': bChildOnlyChunk,
       },
-    }
+      routeTreeRoutes: {
+        __root__: { children: ['/a', '/b'] } as any,
+        '/a': { filePath: '/routes/a.tsx', children: ['/a-child'] },
+        '/a-child': { filePath: '/routes/a-child.tsx' },
+        '/b': { filePath: '/routes/b.tsx', children: ['/b-child'] },
+        '/b-child': { filePath: '/routes/b-child.tsx' },
+      },
+      basePath: '/assets',
+    })
 
-    dedupeNestedRoutePreloads(routes.__root__!, routes)
-
-    expect(routes.__root__!.preloads).toEqual(['/root.js', '/shared.js'])
-    expect(routes.parent!.preloads).toEqual(['/parent.js'])
-    expect(routes.child!.preloads).toEqual(['/child.js'])
+    expect(manifest.routes['/a-child']!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/deep.css',
+          type: 'text/css',
+        },
+      },
+    ])
+    expect(manifest.routes['/a-child']!.preloads).toEqual([
+      '/assets/a-child.js',
+      '/assets/deep.js',
+    ])
+    expect(manifest.routes['/b-child']!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/deep.css',
+          type: 'text/css',
+        },
+      },
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/b-child.css',
+          type: 'text/css',
+        },
+      },
+    ])
+    expect(manifest.routes['/b-child']!.preloads).toEqual([
+      '/assets/b-child.js',
+      '/assets/deep.js',
+      '/assets/b-child-only.js',
+    ])
   })
 
-  test('backtracking works across sibling subtrees at depth 3+', () => {
-    const routes: Manifest['routes'] = {
-      __root__: {
-        children: ['a', 'b'],
-        preloads: ['/root.js'],
-      } as any,
-      a: {
-        children: ['a-child'],
-        preloads: ['/a.js'],
-      } as any,
-      'a-child': {
-        preloads: ['/deep.js'],
-      },
-      b: {
-        children: ['b-child'],
-        preloads: ['/b.js'],
-      } as any,
-      'b-child': {
-        // deep.js should NOT be deduped: it's a cousin, not an ancestor
-        preloads: ['/deep.js', '/b-child.js'],
-      },
-    }
+  test('dedupes reused assets and preloads across a deeply nested ancestor chain', () => {
+    const entryChunk = makeChunk({
+      fileName: 'entry.js',
+      isEntry: true,
+      imports: ['shared-root.js'],
+      importedCss: ['root.css'],
+    })
+    const sharedRootChunk = makeChunk({
+      fileName: 'shared-root.js',
+      importedCss: ['shared-root.css'],
+    })
+    const levelOneChunk = makeChunk({
+      fileName: 'level-one.js',
+      imports: ['shared-root.js', 'level-one-only.js'],
+      moduleIds: ['/routes/level-one.tsx?tsr-split=component'],
+    })
+    const levelOneOnlyChunk = makeChunk({
+      fileName: 'level-one-only.js',
+      importedCss: ['level-one.css'],
+    })
+    const levelTwoChunk = makeChunk({
+      fileName: 'level-two.js',
+      imports: ['shared-root.js', 'level-one-only.js', 'level-two-only.js'],
+      moduleIds: ['/routes/level-two.tsx?tsr-split=component'],
+    })
+    const levelTwoOnlyChunk = makeChunk({
+      fileName: 'level-two-only.js',
+      importedCss: ['level-two.css'],
+    })
+    const levelThreeChunk = makeChunk({
+      fileName: 'level-three.js',
+      imports: [
+        'shared-root.js',
+        'level-one-only.js',
+        'level-two-only.js',
+        'level-three-only.js',
+      ],
+      moduleIds: ['/routes/level-three.tsx?tsr-split=component'],
+    })
+    const levelThreeOnlyChunk = makeChunk({
+      fileName: 'level-three-only.js',
+      importedCss: ['level-three.css'],
+    })
 
-    dedupeNestedRoutePreloads(routes.__root__!, routes)
+    const manifest = buildStartManifest({
+      clientBundle: {
+        'entry.js': entryChunk,
+        'shared-root.js': sharedRootChunk,
+        'level-one.js': levelOneChunk,
+        'level-one-only.js': levelOneOnlyChunk,
+        'level-two.js': levelTwoChunk,
+        'level-two-only.js': levelTwoOnlyChunk,
+        'level-three.js': levelThreeChunk,
+        'level-three-only.js': levelThreeOnlyChunk,
+      },
+      routeTreeRoutes: {
+        __root__: { children: ['/level-one'] } as any,
+        '/level-one': {
+          filePath: '/routes/level-one.tsx',
+          children: ['/level-two'],
+        },
+        '/level-two': {
+          filePath: '/routes/level-two.tsx',
+          children: ['/level-three'],
+        },
+        '/level-three': { filePath: '/routes/level-three.tsx' },
+      },
+      basePath: '/assets',
+    })
 
-    expect(routes['a-child']!.preloads).toEqual(['/deep.js'])
-    expect(routes['b-child']!.preloads).toEqual(['/deep.js', '/b-child.js'])
+    expect(manifest.routes.__root__!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/root.css',
+          type: 'text/css',
+        },
+      },
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/shared-root.css',
+          type: 'text/css',
+        },
+      },
+    ])
+    expect(manifest.routes.__root__!.preloads).toEqual([
+      '/assets/entry.js',
+      '/assets/shared-root.js',
+    ])
+    expect(manifest.routes['/level-one']!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/level-one.css',
+          type: 'text/css',
+        },
+      },
+    ])
+    expect(manifest.routes['/level-one']!.preloads).toEqual([
+      '/assets/level-one.js',
+      '/assets/level-one-only.js',
+    ])
+    expect(manifest.routes['/level-two']!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/level-two.css',
+          type: 'text/css',
+        },
+      },
+    ])
+    expect(manifest.routes['/level-two']!.preloads).toEqual([
+      '/assets/level-two.js',
+      '/assets/level-two-only.js',
+    ])
+    expect(manifest.routes['/level-three']!.assets).toEqual([
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: '/assets/level-three.css',
+          type: 'text/css',
+        },
+      },
+    ])
+    expect(manifest.routes['/level-three']!.preloads).toEqual([
+      '/assets/level-three.js',
+      '/assets/level-three-only.js',
+    ])
   })
 
   test('throws when non-root route has no filePath', () => {
@@ -640,6 +1024,26 @@ describe('dedupeNestedRoutePreloads', () => {
         basePath: '/assets',
       }),
     ).toThrow('expected filePath to be set for /about')
+  })
+
+  test('throws a descriptive error when a child route is missing from the tree', () => {
+    const entryChunk = makeChunk({
+      fileName: 'entry.js',
+      isEntry: true,
+      importedCss: ['entry.css'],
+    })
+
+    expect(() =>
+      buildStartManifest({
+        clientBundle: { 'entry.js': entryChunk },
+        routeTreeRoutes: {
+          __root__: { children: ['/about'] } as any,
+        },
+        basePath: '/assets',
+      }),
+    ).toThrow(
+      'Route tree references child route /about from __root__, but no route entry was found',
+    )
   })
 })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSS assets in the Start manifest are now properly deduplicated. Shared stylesheets no longer appear multiple times within individual route entries or across active parent-child route chains, reducing manifest size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->