### PR TITLE
feat: throwOnError for preloadRoute

### DIFF
--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -35,6 +35,7 @@ type InnerLoadContext = {
   forceStaleReload?: boolean
   onReady?: () => Promise<void>
   sync?: boolean
+  throwOnError?: boolean
 }
 
 const triggerOnReady = (inner: InnerLoadContext): void | Promise<void> => {
@@ -245,7 +246,11 @@ const handleSerialError = (
     }
   })
 
-  if (!inner.preload && !isRedirect(err) && !isNotFound(err)) {
+  if (
+    (!inner.preload || inner.throwOnError) &&
+    !isRedirect(err) &&
+    !isNotFound(err)
+  ) {
     inner.serialError ??= err
   }
 }
@@ -970,6 +975,7 @@ export async function loadMatches(arg: {
   onReady?: () => Promise<void>
   updateMatch: UpdateMatchFn
   sync?: boolean
+  throwOnError?: boolean
 }): Promise<Array<MakeRouteMatch>> {
   const inner: InnerLoadContext = arg
   const matchPromises: Array<Promise<AnyRouteMatch>> = []
@@ -997,7 +1003,7 @@ export async function loadMatches(arg: {
       if (isNotFound(err)) {
         beforeLoadNotFound = err
       } else {
-        if (!inner.preload) throw err
+        if (!inner.preload || inner.throwOnError) throw err
       }
       break
     }
@@ -1055,7 +1061,9 @@ export async function loadMatches(arg: {
 
   const notFoundToThrow =
     firstNotFound ??
-    (beforeLoadNotFound && !inner.preload ? beforeLoadNotFound : undefined)
+    (beforeLoadNotFound && (!inner.preload || inner.throwOnError)
+      ? beforeLoadNotFound
+      : undefined)
 
   let headMaxIndex = inner.serialError
     ? (inner.firstBadMatchIndex ?? 0)
@@ -1179,8 +1187,22 @@ export async function loadMatches(arg: {
     throw notFoundToThrow
   }
 
-  if (inner.serialError && !inner.preload && !inner.onReady) {
+  if (
+    inner.serialError &&
+    (!inner.preload || inner.throwOnError) &&
+    !inner.onReady
+  ) {
     throw inner.serialError
+  }
+
+  if (inner.preload && inner.throwOnError) {
+    const preloadErrorMatch = inner.matches.find((match) => {
+      return inner.router.getMatch(match.id)?.status === 'error'
+    })
+
+    if (preloadErrorMatch) {
+      throw inner.router.getMatch(preloadErrorMatch.id)?.error
+    }
   }
 
   return inner.matches

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -671,6 +671,10 @@ export type PreloadRouteFn<
     TMaskTo
   > & {
     /**
+     * If `true`, preload errors are rethrown instead of being swallowed.
+     */
+    throwOnError?: boolean
+    /**
      * @internal
      * A **trusted** built location that can be used to redirect to.
      */
@@ -2840,6 +2844,7 @@ export class RouterCore<
         matches,
         location: next,
         preload: true,
+        throwOnError: opts.throwOnError,
         updateMatch: (id, updater) => {
           // Don't update the match if it's currently loaded
           if (activeMatchIds.has(id)) {
@@ -2862,6 +2867,10 @@ export class RouterCore<
           _fromLocation: next,
         })
       }
+      if (opts.throwOnError) {
+        throw err
+      }
+
       if (!isNotFound(err)) {
         // Preload errors are not fatal, but we should still log them
         console.error(err)

--- a/packages/router-core/tests/load.test.ts
+++ b/packages/router-core/tests/load.test.ts
@@ -274,6 +274,61 @@ describe('beforeLoad skip or exec', () => {
 
     expect(beforeLoad).toHaveBeenCalledTimes(2)
   })
+
+  test('throws if rejected preload beforeLoad (error) when throwOnError is true', async () => {
+    const beforeLoadError = new Error('error')
+    const beforeLoad = vi.fn<BeforeLoad>(async ({ preload }) => {
+      if (preload) throw beforeLoadError
+      await Promise.resolve()
+    })
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const router = setup({
+      beforeLoad,
+    })
+
+    await expect(
+      router.preloadRoute({ to: '/foo', throwOnError: true }),
+    ).rejects.toBe(beforeLoadError)
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(beforeLoad).toHaveBeenCalledTimes(1)
+    consoleSpy.mockRestore()
+  })
+
+  test('throws if rejected preload beforeLoad (notFound) when throwOnError is true', async () => {
+    const notFoundError = notFound()
+    const beforeLoad = vi.fn<BeforeLoad>(async ({ preload }) => {
+      if (preload) throw notFoundError
+      await Promise.resolve()
+    })
+    const router = setup({
+      beforeLoad,
+    })
+
+    await expect(
+      router.preloadRoute({ to: '/foo', throwOnError: true }),
+    ).rejects.toBe(notFoundError)
+
+    expect(beforeLoad).toHaveBeenCalledTimes(1)
+  })
+
+  test('follows redirect if rejected preload beforeLoad (redirect) when throwOnError is true', async () => {
+    const beforeLoad = vi.fn<BeforeLoad>(async ({ preload }) => {
+      if (preload) throw redirect({ to: '/bar' })
+      await Promise.resolve()
+    })
+    const router = setup({
+      beforeLoad,
+    })
+
+    await expect(
+      router.preloadRoute({ to: '/foo', throwOnError: true }),
+    ).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ routeId: '/bar' })]),
+    )
+
+    expect(beforeLoad).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('loader skip or exec', () => {
@@ -502,6 +557,61 @@ describe('loader skip or exec', () => {
     await router.navigate({ to: '/foo' })
 
     expect(loader).toHaveBeenCalledTimes(2)
+  })
+
+  test('throws if rejected preload (error) when throwOnError is true', async () => {
+    const loaderError = new Error('error')
+    const loader: Loader = vi.fn(async ({ preload }) => {
+      if (preload) throw loaderError
+      await Promise.resolve()
+    })
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const router = setup({
+      loader,
+    })
+
+    await expect(
+      router.preloadRoute({ to: '/foo', throwOnError: true }),
+    ).rejects.toBe(loaderError)
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(loader).toHaveBeenCalledTimes(1)
+    consoleSpy.mockRestore()
+  })
+
+  test('throws if rejected preload (notFound) when throwOnError is true', async () => {
+    const notFoundError = notFound()
+    const loader: Loader = vi.fn(async ({ preload }) => {
+      if (preload) throw notFoundError
+      await Promise.resolve()
+    })
+    const router = setup({
+      loader,
+    })
+
+    await expect(
+      router.preloadRoute({ to: '/foo', throwOnError: true }),
+    ).rejects.toBe(notFoundError)
+
+    expect(loader).toHaveBeenCalledTimes(1)
+  })
+
+  test('follows redirect if rejected preload (redirect) when throwOnError is true', async () => {
+    const loader: Loader = vi.fn(async ({ preload }) => {
+      if (preload) throw redirect({ to: '/bar' })
+      await Promise.resolve()
+    })
+    const router = setup({
+      loader,
+    })
+
+    await expect(
+      router.preloadRoute({ to: '/foo', throwOnError: true }),
+    ).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ routeId: '/bar' })]),
+    )
+
+    expect(loader).toHaveBeenCalledTimes(1)
   })
 
   test('skip if pending preload (error)', async () => {


### PR DESCRIPTION
prompted by https://github.com/TanStack/router/discussions/7002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `throwOnError` flag to control preload route error handling. When enabled, errors encountered during preload are thrown immediately. When disabled, errors continue to be logged and handled gracefully as before.

* **Tests**
  * Added comprehensive test coverage validating preload error behavior with standard errors, notFound results, and redirect outcomes using the new flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->