### PR TITLE
fix(react-start): add tsconfigPath to server-entry vite build config

### DIFF
--- a/packages/react-start/tsconfig.build.server-entry.json
+++ b/packages/react-start/tsconfig.build.server-entry.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src/default-entry"
+  },
+  "include": ["src/default-entry"]
+}

--- a/packages/react-start/vite.config.server-entry.ts
+++ b/packages/react-start/vite.config.server-entry.ts
@@ -1,6 +1,7 @@
 import { tanstackViteConfig } from '@tanstack/vite-config'
 
 export default tanstackViteConfig({
+  tsconfigPath: './tsconfig.build.server-entry.json',
   srcDir: './src/default-entry',
   exclude: ['./src/default-entry/client.tsx'],
   entry: ['./src/default-entry/server.ts'],


### PR DESCRIPTION
Since [v1.167.6](https://github.com/TanStack/router/releases/tag/release-2026-03-24-2312) (after #7024), importing `@tanstack/react-start/server-entry` produces TypeScript errors:

```
TS7016: Could not find a declaration file for module '@tanstack/react-start/server-entry'.
```

All type-level imports from the `./server-entry` subpath are broken —`createServerEntry`, the default export, and the `ServerEntry` type all resolve as any.

### Root cause

PR #7024 upgraded the monorepo to TypeScript 6, which changed the default rootDir inference from "narrowest directory containing all source files" to . (the project root).

To compensate, #7024 added a [`tsconfig.build.json`](https://github.com/TanStack/router/blob/531bb1852012e63294f05544c24ac16ffaeb9934/packages/react-start/tsconfig.build.json) (with explicit rootDir: "./src") and wired it into the main [`vite.config.ts`](https://github.com/TanStack/router/blob/531bb1852012e63294f05544c24ac16ffaeb9934/packages/react-start/vite.config.ts) via `tsconfigPath`. However, this was not applied to `vite.config.server-entry.ts`, which runs as a separate `vite build` (`vite build -c vite.config.server-entry.ts`).

Without the tsconfigPath override, vite-plugin-dts uses TS 6's new default rootDir: ".", which shifts the .d.ts output path:

v1.167.5 and v1.167.6 expected the types exports at `dist/default-entry/esm/server.d.ts` but the actual location in v1.167.6 was `dist/default-entry/esm/src/default-entry/server.d.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and compilation configuration to enhance server entry point handling during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->