### PR TITLE
fix(react-start): align server-entry d.ts output with exports map

### DIFF
--- a/packages/react-start/tsconfig.build.server-entry.json
+++ b/packages/react-start/tsconfig.build.server-entry.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "./src/default-entry"
+  },
+  "include": ["src/default-entry"]
+}

--- a/packages/react-start/vite.config.server-entry.ts
+++ b/packages/react-start/vite.config.server-entry.ts
@@ -1,6 +1,7 @@
 import { tanstackViteConfig } from '@tanstack/vite-config'
 
 export default tanstackViteConfig({
+  tsconfigPath: './tsconfig.build.server-entry.json',
   srcDir: './src/default-entry',
   exclude: ['./src/default-entry/client.tsx'],
   entry: ['./src/default-entry/server.ts'],


### PR DESCRIPTION
## Related Issue
Closes #7038

## Summary
- Fixes the `@tanstack/react-start/server-entry` declaration output path regression introduced with TS6 build config changes
- Adds a dedicated server-entry tsconfig with `rootDir: ./src/default-entry`
- Wires `vite.config.server-entry.ts` to that tsconfig so emitted declarations match package exports

## Root Cause
The server-entry build did not use a tsconfig with the correct `rootDir`, so declarations were emitted at:
- `dist/default-entry/esm/src/default-entry/server.d.ts` (actual)
instead of:
- `dist/default-entry/esm/server.d.ts` (export-mapped expected path)

## Validation
- `pnpm --filter @tanstack/react-start run clean && pnpm --filter @tanstack/react-start run build`
- Confirmed `dist/default-entry/esm/server.d.ts` exists
- Confirmed nested `dist/default-entry/esm/src/default-entry/server.d.ts` is no longer emitted