### PR TITLE
chore: upgrade h3 and cookie-es

### DIFF
--- a/packages/router-core/package.json
+++ b/packages/router-core/package.json
@@ -163,7 +163,7 @@
   },
   "dependencies": {
     "@tanstack/history": "workspace:*",
-    "cookie-es": "^2.0.0",
+    "cookie-es": "^3.0.0",
     "seroval": "^1.4.2",
     "seroval-plugins": "^1.4.2"
   },

--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -88,7 +88,7 @@
   "devDependencies": {
     "@standard-schema/spec": "^1.0.0",
     "@tanstack/intent": "^0.0.14",
-    "cookie-es": "^2.0.0",
+    "cookie-es": "^3.0.0",
     "fetchdts": "^0.1.6",
     "vite": "*",
     "@types/node": ">=20"

--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -82,7 +82,7 @@
     "@tanstack/router-core": "workspace:*",
     "@tanstack/start-client-core": "workspace:*",
     "@tanstack/start-storage-context": "workspace:*",
-    "h3-v2": "npm:h3@2.0.1-rc.16",
+    "h3": "2.0.1-rc.19",
     "seroval": "^1.4.2"
   },
   "devDependencies": {

--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -122,7 +122,15 @@ export function requestHandler<TRegister = unknown>(
   handler: RequestHandler<TRegister>,
 ) {
   return (request: Request, requestOpts: any): Promise<Response> | Response => {
-    const h3Event = new H3Event(request)
+    let h3Event: H3Event
+    try {
+      h3Event = new H3Event(request)
+    } catch (err) {
+      if (err instanceof URIError) {
+        return new Response(null, { status: 404 })
+      }
+      throw err
+    }
 
     const response = eventStorage.run({ h3Event }, () =>
       handler(request, requestOpts),

--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -284,7 +284,7 @@ export function setResponseStatus(code?: number, text?: string): void {
 export function getCookies(): Record<string, string> {
   const event = getH3Event()
   const cookies = h3_parseCookies(event)
-  const normalizedCookies: Record<string, string> = {}
+  const normalizedCookies: Record<string, string> = Object.create(null)
 
   for (const [name, value] of Object.entries(cookies)) {
     if (value !== undefined) {

--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -122,15 +122,7 @@ export function requestHandler<TRegister = unknown>(
   handler: RequestHandler<TRegister>,
 ) {
   return (request: Request, requestOpts: any): Promise<Response> | Response => {
-    let h3Event: H3Event
-    try {
-      h3Event = new H3Event(request)
-    } catch (err) {
-      if (err instanceof URIError) {
-        return new Response(null, { status: 404 })
-      }
-      throw err
-    }
+    const h3Event = new H3Event(request)
 
     const response = eventStorage.run({ h3Event }, () =>
       handler(request, requestOpts),

--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -147,7 +147,7 @@ export function getRequest(): Request {
 }
 
 export function getRequestHeaders(): TypedHeaders<RequestHeaderMap> {
-  return getH3Event().req.headers as any
+  return getH3Event().req.headers
 }
 
 export function getRequestHeader(name: RequestHeaderName): string | undefined {

--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -19,7 +19,7 @@ import {
   unsealSession as h3_unsealSession,
   updateSession as h3_updateSession,
   useSession as h3_useSession,
-} from 'h3-v2'
+} from 'h3'
 import type {
   RequestHeaderMap,
   RequestHeaderName,
@@ -147,7 +147,6 @@ export function getRequest(): Request {
 }
 
 export function getRequestHeaders(): TypedHeaders<RequestHeaderMap> {
-  // TODO `as any` not needed when fetchdts is updated
   return getH3Event().req.headers as any
 }
 
@@ -284,7 +283,16 @@ export function setResponseStatus(code?: number, text?: string): void {
  */
 export function getCookies(): Record<string, string> {
   const event = getH3Event()
-  return h3_parseCookies(event)
+  const cookies = h3_parseCookies(event)
+  const normalizedCookies: Record<string, string> = {}
+
+  for (const [name, value] of Object.entries(cookies)) {
+    if (value !== undefined) {
+      normalizedCookies[name] = value
+    }
+  }
+
+  return normalizedCookies
 }
 
 /**
@@ -296,7 +304,9 @@ export function getCookies(): Record<string, string> {
  * ```
  */
 export function getCookie(name: string): string | undefined {
-  return getCookies()[name] || undefined
+  const event = getH3Event()
+  const cookies = h3_parseCookies(event)
+  return cookies[name] || undefined
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11983,8 +11983,8 @@ importers:
         specifier: workspace:*
         version: link:../history
       cookie-es:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^3.0.0
+        version: 3.1.1
       seroval:
         specifier: ^1.4.2
         version: 1.4.2
@@ -12593,8 +12593,8 @@ importers:
         specifier: 25.0.9
         version: 25.0.9
       cookie-es:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^3.0.0
+        version: 3.1.1
       fetchdts:
         specifier: ^0.1.6
         version: 0.1.7
@@ -19792,6 +19792,9 @@ packages:
 
   cookie-es@2.0.0:
     resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
@@ -33128,6 +33131,8 @@ snapshots:
   cookie-es@1.2.2: {}
 
   cookie-es@2.0.0: {}
+
+  cookie-es@3.1.1: {}
 
   cookie-signature@1.0.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12576,9 +12576,9 @@ importers:
       '@tanstack/start-storage-context':
         specifier: workspace:*
         version: link:../start-storage-context
-      h3-v2:
-        specifier: npm:h3@2.0.1-rc.16
-        version: h3@2.0.1-rc.16(crossws@0.4.4(srvx@0.11.9))
+      h3:
+        specifier: 2.0.1-rc.19
+        version: 2.0.1-rc.19(crossws@0.4.4(srvx@0.11.13))
       seroval:
         specifier: ^1.4.2
         version: 1.4.2
@@ -21163,6 +21163,16 @@ packages:
       crossws:
         optional: true
 
+  h3@2.0.1-rc.19:
+    resolution: {integrity: sha512-47er/mh8eGA7+0nvNUloalj+yTJ1ku8M0BVzA2I1ZHSlpfbUNdBK4LpWztfH7TwW6kuhF8MfAvl0AwB+X9B+2w==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
@@ -23986,6 +23996,11 @@ packages:
 
   srvx@0.10.1:
     resolution: {integrity: sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  srvx@0.11.13:
+    resolution: {integrity: sha512-oknN6qduuMPafxKtHucUeG32Q963pjriA5g3/Bl05cwEsUe5VVbIU4qR9LrALHbipSCyBe+VmfDGGydqazDRkw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -33184,6 +33199,11 @@ snapshots:
     optionalDependencies:
       srvx: 0.10.1
 
+  crossws@0.4.4(srvx@0.11.13):
+    optionalDependencies:
+      srvx: 0.11.13
+    optional: true
+
   crossws@0.4.4(srvx@0.11.9):
     optionalDependencies:
       srvx: 0.11.9
@@ -34806,6 +34826,13 @@ snapshots:
       srvx: 0.11.9
     optionalDependencies:
       crossws: 0.4.4(srvx@0.11.9)
+
+  h3@2.0.1-rc.19(crossws@0.4.4(srvx@0.11.13)):
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.13
+    optionalDependencies:
+      crossws: 0.4.4(srvx@0.11.13)
 
   handle-thing@2.0.1: {}
 
@@ -37983,6 +38010,8 @@ snapshots:
   sqlstring@2.3.3: {}
 
   srvx@0.10.1: {}
+
+  srvx@0.11.13: {}
 
   srvx@0.11.9: {}
 


### PR DESCRIPTION
Closes #7043

The function `h3_parseCookies` now returns `Record<string, string | undefined>` instead of `Record<string, string>`. I handled that by filtering out the `undefined` values to keep the function signature unchanged to avoid breaking changes. Also inlined code from `getCookies` into `getCookie` to avoid the unnecessary execution of the `for` loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated HTTP library dependency to a newer pinned release and upgraded the cookie helper to v3.

* **Bug Fixes**
  * Improved request header access.
  * Normalized cookie parsing to exclude undefined entries.
  * Made single-cookie retrieval behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->