### PR TITLE
fix(scroll-restoration): capture restoreKey at scroll-event time to prevent throttle race condition

### DIFF
--- a/.changeset/fix-scroll-restoration-race-7040.md
+++ b/.changeset/fix-scroll-restoration-race-7040.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/router-core": patch
+'@tanstack/router-core': patch
 ---
 
 fix(scroll-restoration): capture restoreKey at scroll-event time to prevent race condition
@@ -11,6 +11,7 @@ If the user scrolled and then immediately navigated, the throttle could fire aft
 page's scroll position under the new page's cache key.
 
 Two fixes:
+
 1. Capture `restoreKey` eagerly at scroll-event time by separating the event
    listener from the throttled save function. The throttle receives the key as
    an argument so it always writes to the key that was active when the scroll

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -283,10 +283,7 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
 
   // observeDom()
 
-  const saveScrollPosition = (
-    restoreKey: string,
-    elementSelector: string,
-  ) => {
+  const saveScrollPosition = (restoreKey: string, elementSelector: string) => {
     scrollRestorationCache.set((state) => {
       const keyEntry = (state[restoreKey] ||= {} as ScrollRestorationByElement)
 


### PR DESCRIPTION
## Summary

Fixes #7040

Fixes a race condition in  where the  throttle read `router.state.location` at **execution time** (up to 100ms after the scroll event fired), rather than at the time of the event.

### Root Cause

```ts
// Before fix: restoreKey captured when throttle fires, not when scroll occurs
const onScroll = (event: Event) => {
  // ...
  const restoreKey = getKey(router.stores.location.state) // ← read at EXECUTION time
  scrollRestorationCache.set(...)
}
document.addEventListener('scroll', throttle(onScroll, 100), true)
```

If a user scrolled and then immediately clicked a `<Link>` within the 100ms throttle window, `router.state.location` could have already changed to the new route when the throttle finally fired. The old page's scroll position would then be saved under the **new page's cache key**, causing the new page to scroll partway down on arrival.

### Fix 1: Capture `restoreKey` at event time

Split `onScroll` into an immediate event listener and a throttled save function. The event listener captures `restoreKey` eagerly, then passes it as an argument to the throttled save. Since the throttle preserves the arguments from the **first call** in each window, the key always reflects the route active at the time of the scroll.

### Fix 2: Clear stale cache before `restoreScroll()`

In the `onRendered` subscriber, delete any existing cache entry for the destination key before calling `restoreScroll()`. This guards against browser-generated scroll events that can fire during DOM transitions after `router.state.location` has already advanced to the new route.

## Testing

The reporter confirmed the fix with a Playwright test suite. Before the fix, dumped sessionStorage showed game page keys with home page scroll positions. After the fix, the destination key always has `scrollY: 0` for fresh forward navigations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll position restoration race condition that could occur during navigation, preventing scroll positions from being incorrectly saved or restored when page transitions happen rapidly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->