### PR TITLE
docs: add How To section to navigation sidebar

### DIFF
--- a/docs/router/config.json
+++ b/docs/router/config.json
@@ -327,6 +327,105 @@
       ]
     },
     {
+      "label": "How To",
+      "children": [
+        {
+          "label": "Overview",
+          "to": "how-to/README"
+        },
+        {
+          "label": "Install",
+          "to": "how-to/install"
+        },
+        {
+          "label": "Setup Authentication",
+          "to": "how-to/setup-authentication"
+        },
+        {
+          "label": "Setup Auth Providers",
+          "to": "how-to/setup-auth-providers"
+        },
+        {
+          "label": "Setup RBAC",
+          "to": "how-to/setup-rbac"
+        },
+        {
+          "label": "Setup SSR",
+          "to": "how-to/setup-ssr"
+        },
+        {
+          "label": "Setup Testing",
+          "to": "how-to/setup-testing"
+        },
+        {
+          "label": "Setup Basic Search Params",
+          "to": "how-to/setup-basic-search-params"
+        },
+        {
+          "label": "Validate Search Params",
+          "to": "how-to/validate-search-params"
+        },
+        {
+          "label": "Arrays, Objects, Dates in Search Params",
+          "to": "how-to/arrays-objects-dates-search-params"
+        },
+        {
+          "label": "Navigate with Search Params",
+          "to": "how-to/navigate-with-search-params"
+        },
+        {
+          "label": "Share Search Params Across Routes",
+          "to": "how-to/share-search-params-across-routes"
+        },
+        {
+          "label": "Test File-Based Routing",
+          "to": "how-to/test-file-based-routing"
+        },
+        {
+          "label": "Debug Router Issues",
+          "to": "how-to/debug-router-issues"
+        },
+        {
+          "label": "Deploy to Production",
+          "to": "how-to/deploy-to-production"
+        },
+        {
+          "label": "Use Environment Variables",
+          "to": "how-to/use-environment-variables"
+        },
+        {
+          "label": "Integrate Chakra UI",
+          "to": "how-to/integrate-chakra-ui"
+        },
+        {
+          "label": "Integrate Framer Motion",
+          "to": "how-to/integrate-framer-motion"
+        },
+        {
+          "label": "Integrate Material UI",
+          "to": "how-to/integrate-material-ui"
+        },
+        {
+          "label": "Integrate shadcn/ui",
+          "to": "how-to/integrate-shadcn-ui"
+        },
+        {
+          "label": "Migrate from React Router",
+          "to": "how-to/migrate-from-react-router"
+        }
+      ],
+      "frameworks": [
+        {
+          "label": "react",
+          "children": []
+        },
+        {
+          "label": "solid",
+          "children": []
+        }
+      ]
+    },
+    {
       "label": "Router Examples",
       "children": [],
       "frameworks": [


### PR DESCRIPTION
The how-to guides in `docs/router/how-to/` were not accessible from the navigation sidebar, as reported in #6801.

This PR adds a new 'How To' section after ESLint and before Router Examples, making all 20+ guides discoverable.

Fixes #6801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "How To" section with guides for installation, setup, authentication, testing, debugging, deployment, environment variables, and UI integrations with support for React and Solid frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->