### PR TITLE
test: cover lazy errorComponent behavior across frameworks

### DIFF
--- a/packages/solid-router/tests/errorComponent.test.tsx
+++ b/packages/solid-router/tests/errorComponent.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 import {
   Link,
   RouterProvider,
+  createLazyRoute,
   createRootRoute,
   createRoute,
   createRouter,
@@ -29,108 +30,133 @@ afterEach(() => {
   cleanup()
 })
 
-describe.each([{ preload: false }, { preload: 'intent' }] as const)(
-  'errorComponent is rendered when the preload=$preload',
-  (options) => {
-    describe.each([true, false])('with async=%s', (isAsync) => {
-      const throwableFn = isAsync ? asyncToThrowFn : throwFn
+describe.each([true, false])(
+  'with lazy errorComponent=%s',
+  (isUsingLazyError) => {
+    describe.each([{ preload: false }, { preload: 'intent' }] as const)(
+      'errorComponent is rendered when the preload=$preload',
+      (options) => {
+        describe.each([true, false])('with async=%s', (isAsync) => {
+          const throwableFn = isAsync ? asyncToThrowFn : throwFn
 
-      const callers = [
-        { caller: 'beforeLoad', testFn: throwableFn },
-        { caller: 'loader', testFn: throwableFn },
-      ]
+          const callers = [
+            { caller: 'beforeLoad', testFn: throwableFn },
+            { caller: 'loader', testFn: throwableFn },
+          ]
 
-      test.each(callers)(
-        'an Error is thrown on navigate in the route $caller function',
-        async ({ caller, testFn }) => {
-          const rootRoute = createRootRoute()
-          const indexRoute = createRoute({
-            getParentRoute: () => rootRoute,
-            path: '/',
-            component: function Home() {
-              return (
-                <div>
-                  <Link to="/about">link to about</Link>
-                </div>
+          test.each(callers)(
+            'an Error is thrown on navigate in the route $caller function',
+            async ({ caller, testFn }) => {
+              const rootRoute = createRootRoute()
+              const indexRoute = createRoute({
+                getParentRoute: () => rootRoute,
+                path: '/',
+                component: function Home() {
+                  return (
+                    <div>
+                      <Link to="/about">link to about</Link>
+                    </div>
+                  )
+                },
+              })
+              const aboutRoute = createRoute({
+                getParentRoute: () => rootRoute,
+                path: '/about',
+                beforeLoad: caller === 'beforeLoad' ? testFn : undefined,
+                loader: caller === 'loader' ? testFn : undefined,
+                component: function Home() {
+                  return <div>About route content</div>
+                },
+                errorComponent: isUsingLazyError ? undefined : MyErrorComponent,
+              })
+
+              if (isUsingLazyError) {
+                aboutRoute.lazy(() =>
+                  Promise.resolve(
+                    createLazyRoute('/about')({
+                      errorComponent: MyErrorComponent,
+                    }),
+                  ),
+                )
+              }
+
+              const routeTree = rootRoute.addChildren([indexRoute, aboutRoute])
+
+              const router = createRouter({
+                routeTree,
+                defaultPreload: options.preload,
+              })
+
+              render(() => <RouterProvider router={router} />)
+
+              const linkToAbout = await screen.findByRole('link', {
+                name: 'link to about',
+              })
+
+              expect(linkToAbout).toBeInTheDocument()
+              fireEvent.mouseOver(linkToAbout)
+              fireEvent.focus(linkToAbout)
+              fireEvent.click(linkToAbout)
+
+              const errorComponent = await screen.findByText(
+                `Error: error thrown`,
+                undefined,
+                { timeout: 1500 },
               )
+              await expect(
+                screen.findByText('About route content'),
+              ).rejects.toThrow()
+              expect(errorComponent).toBeInTheDocument()
             },
-          })
-          const aboutRoute = createRoute({
-            getParentRoute: () => rootRoute,
-            path: '/about',
-            beforeLoad: caller === 'beforeLoad' ? testFn : undefined,
-            loader: caller === 'loader' ? testFn : undefined,
-            component: function Home() {
-              return <div>About route content</div>
-            },
-            errorComponent: MyErrorComponent,
-          })
-
-          const routeTree = rootRoute.addChildren([indexRoute, aboutRoute])
-
-          const router = createRouter({
-            routeTree,
-            defaultPreload: options.preload,
-          })
-
-          render(() => <RouterProvider router={router} />)
-
-          const linkToAbout = await screen.findByRole('link', {
-            name: 'link to about',
-          })
-
-          expect(linkToAbout).toBeInTheDocument()
-          fireEvent.mouseOver(linkToAbout)
-          fireEvent.focus(linkToAbout)
-          fireEvent.click(linkToAbout)
-
-          const errorComponent = await screen.findByText(
-            `Error: error thrown`,
-            undefined,
-            { timeout: 1500 },
           )
-          await expect(
-            screen.findByText('About route content'),
-          ).rejects.toThrow()
-          expect(errorComponent).toBeInTheDocument()
-        },
-      )
 
-      test.each(callers)(
-        'an Error is thrown on first load in the route $caller function',
-        async ({ caller, testFn }) => {
-          const rootRoute = createRootRoute()
-          const indexRoute = createRoute({
-            getParentRoute: () => rootRoute,
-            path: '/',
-            beforeLoad: caller === 'beforeLoad' ? testFn : undefined,
-            loader: caller === 'loader' ? testFn : undefined,
-            component: function Home() {
-              return <div>Index route content</div>
+          test.each(callers)(
+            'an Error is thrown on first load in the route $caller function',
+            async ({ caller, testFn }) => {
+              const rootRoute = createRootRoute()
+              const indexRoute = createRoute({
+                getParentRoute: () => rootRoute,
+                path: '/',
+                beforeLoad: caller === 'beforeLoad' ? testFn : undefined,
+                loader: caller === 'loader' ? testFn : undefined,
+                component: function Home() {
+                  return <div>Index route content</div>
+                },
+                errorComponent: isUsingLazyError ? undefined : MyErrorComponent,
+              })
+
+              if (isUsingLazyError) {
+                indexRoute.lazy(() =>
+                  Promise.resolve(
+                    createLazyRoute('/')({
+                      errorComponent: MyErrorComponent,
+                    }),
+                  ),
+                )
+              }
+
+              const routeTree = rootRoute.addChildren([indexRoute])
+
+              const router = createRouter({
+                routeTree,
+                defaultPreload: options.preload,
+              })
+
+              render(() => <RouterProvider router={router} />)
+
+              const errorComponent = await screen.findByText(
+                `Error: error thrown`,
+                undefined,
+                { timeout: 750 },
+              )
+              await expect(
+                screen.findByText('Index route content'),
+              ).rejects.toThrow()
+              expect(errorComponent).toBeInTheDocument()
             },
-            errorComponent: MyErrorComponent,
-          })
-
-          const routeTree = rootRoute.addChildren([indexRoute])
-
-          const router = createRouter({
-            routeTree,
-            defaultPreload: options.preload,
-          })
-
-          render(() => <RouterProvider router={router} />)
-
-          const errorComponent = await screen.findByText(
-            `Error: error thrown`,
-            undefined,
-            { timeout: 750 },
           )
-          await expect(
-            screen.findByText('Index route content'),
-          ).rejects.toThrow()
-          expect(errorComponent).toBeInTheDocument()
-        },
-      )
-    })
+        })
+      },
+    )
   },
 )

--- a/packages/vue-router/tests/errorComponent.test.tsx
+++ b/packages/vue-router/tests/errorComponent.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/vue'
 import {
   Link,
   RouterProvider,
+  createLazyRoute,
   createRootRoute,
   createRoute,
   createRouter,
@@ -29,108 +30,133 @@ afterEach(() => {
   cleanup()
 })
 
-describe.each([{ preload: false }, { preload: 'intent' }] as const)(
-  'errorComponent is rendered when the preload=$preload',
-  (options) => {
-    describe.each([true, false])('with async=%s', (isAsync) => {
-      const throwableFn = isAsync ? asyncToThrowFn : throwFn
+describe.each([true, false])(
+  'with lazy errorComponent=%s',
+  (isUsingLazyError) => {
+    describe.each([{ preload: false }, { preload: 'intent' }] as const)(
+      'errorComponent is rendered when the preload=$preload',
+      (options) => {
+        describe.each([true, false])('with async=%s', (isAsync) => {
+          const throwableFn = isAsync ? asyncToThrowFn : throwFn
 
-      const callers = [
-        { caller: 'beforeLoad', testFn: throwableFn },
-        { caller: 'loader', testFn: throwableFn },
-      ]
+          const callers = [
+            { caller: 'beforeLoad', testFn: throwableFn },
+            { caller: 'loader', testFn: throwableFn },
+          ]
 
-      test.each(callers)(
-        'an Error is thrown on navigate in the route $caller function',
-        async ({ caller, testFn }) => {
-          const rootRoute = createRootRoute()
-          const indexRoute = createRoute({
-            getParentRoute: () => rootRoute,
-            path: '/',
-            component: function Home() {
-              return (
-                <div>
-                  <Link to="/about">link to about</Link>
-                </div>
+          test.each(callers)(
+            'an Error is thrown on navigate in the route $caller function',
+            async ({ caller, testFn }) => {
+              const rootRoute = createRootRoute()
+              const indexRoute = createRoute({
+                getParentRoute: () => rootRoute,
+                path: '/',
+                component: function Home() {
+                  return (
+                    <div>
+                      <Link to="/about">link to about</Link>
+                    </div>
+                  )
+                },
+              })
+              const aboutRoute = createRoute({
+                getParentRoute: () => rootRoute,
+                path: '/about',
+                beforeLoad: caller === 'beforeLoad' ? testFn : undefined,
+                loader: caller === 'loader' ? testFn : undefined,
+                component: function Home() {
+                  return <div>About route content</div>
+                },
+                errorComponent: isUsingLazyError ? undefined : MyErrorComponent,
+              })
+
+              if (isUsingLazyError) {
+                aboutRoute.lazy(() =>
+                  Promise.resolve(
+                    createLazyRoute('/about')({
+                      errorComponent: MyErrorComponent,
+                    }),
+                  ),
+                )
+              }
+
+              const routeTree = rootRoute.addChildren([indexRoute, aboutRoute])
+
+              const router = createRouter({
+                routeTree,
+                defaultPreload: options.preload,
+              })
+
+              render(<RouterProvider router={router} />)
+
+              const linkToAbout = await screen.findByRole('link', {
+                name: 'link to about',
+              })
+
+              expect(linkToAbout).toBeInTheDocument()
+              fireEvent.mouseOver(linkToAbout)
+              fireEvent.focus(linkToAbout)
+              fireEvent.click(linkToAbout)
+
+              const errorComponent = await screen.findByText(
+                `Error: error thrown`,
+                undefined,
+                { timeout: 1500 },
               )
+              await expect(
+                screen.findByText('About route content'),
+              ).rejects.toThrow()
+              expect(errorComponent).toBeInTheDocument()
             },
-          })
-          const aboutRoute = createRoute({
-            getParentRoute: () => rootRoute,
-            path: '/about',
-            beforeLoad: caller === 'beforeLoad' ? testFn : undefined,
-            loader: caller === 'loader' ? testFn : undefined,
-            component: function Home() {
-              return <div>About route content</div>
-            },
-            errorComponent: MyErrorComponent,
-          })
-
-          const routeTree = rootRoute.addChildren([indexRoute, aboutRoute])
-
-          const router = createRouter({
-            routeTree,
-            defaultPreload: options.preload,
-          })
-
-          render(<RouterProvider router={router} />)
-
-          const linkToAbout = await screen.findByRole('link', {
-            name: 'link to about',
-          })
-
-          expect(linkToAbout).toBeInTheDocument()
-          fireEvent.mouseOver(linkToAbout)
-          fireEvent.focus(linkToAbout)
-          fireEvent.click(linkToAbout)
-
-          const errorComponent = await screen.findByText(
-            `Error: error thrown`,
-            undefined,
-            { timeout: 1500 },
           )
-          await expect(
-            screen.findByText('About route content'),
-          ).rejects.toThrow()
-          expect(errorComponent).toBeInTheDocument()
-        },
-      )
 
-      test.each(callers)(
-        'an Error is thrown on first load in the route $caller function',
-        async ({ caller, testFn }) => {
-          const rootRoute = createRootRoute()
-          const indexRoute = createRoute({
-            getParentRoute: () => rootRoute,
-            path: '/',
-            beforeLoad: caller === 'beforeLoad' ? testFn : undefined,
-            loader: caller === 'loader' ? testFn : undefined,
-            component: function Home() {
-              return <div>Index route content</div>
+          test.each(callers)(
+            'an Error is thrown on first load in the route $caller function',
+            async ({ caller, testFn }) => {
+              const rootRoute = createRootRoute()
+              const indexRoute = createRoute({
+                getParentRoute: () => rootRoute,
+                path: '/',
+                beforeLoad: caller === 'beforeLoad' ? testFn : undefined,
+                loader: caller === 'loader' ? testFn : undefined,
+                component: function Home() {
+                  return <div>Index route content</div>
+                },
+                errorComponent: isUsingLazyError ? undefined : MyErrorComponent,
+              })
+
+              if (isUsingLazyError) {
+                indexRoute.lazy(() =>
+                  Promise.resolve(
+                    createLazyRoute('/')({
+                      errorComponent: MyErrorComponent,
+                    }),
+                  ),
+                )
+              }
+
+              const routeTree = rootRoute.addChildren([indexRoute])
+
+              const router = createRouter({
+                routeTree,
+                defaultPreload: options.preload,
+              })
+
+              render(<RouterProvider router={router} />)
+
+              const errorComponent = await screen.findByText(
+                `Error: error thrown`,
+                undefined,
+                { timeout: 750 },
+              )
+              await expect(
+                screen.findByText('Index route content'),
+              ).rejects.toThrow()
+              expect(errorComponent).toBeInTheDocument()
             },
-            errorComponent: MyErrorComponent,
-          })
-
-          const routeTree = rootRoute.addChildren([indexRoute])
-
-          const router = createRouter({
-            routeTree,
-            defaultPreload: options.preload,
-          })
-
-          render(<RouterProvider router={router} />)
-
-          const errorComponent = await screen.findByText(
-            `Error: error thrown`,
-            undefined,
-            { timeout: 750 },
           )
-          await expect(
-            screen.findByText('Index route content'),
-          ).rejects.toThrow()
-          expect(errorComponent).toBeInTheDocument()
-        },
-      )
-    })
+        })
+      },
+    )
   },
 )


### PR DESCRIPTION
## Summary
- add lazy `errorComponent` coverage for beforeLoad/loader failures in React and Solid error-component tests
- include the same lazy error-component matrix in Vue tests to match framework parity added after PR #5568
- keep scope test-only: the bug was fixed since then 

## Impact
- improves regression coverage for lazy error-boundary behavior without changing runtime behavior, that is critical for monorepo setup 
- increases confidence that framework adapters (React/Solid/Vue) handle lazy `errorComponent` consistently
- low risk: changes are isolated to test files and assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded error component test coverage across React Router, Solid Router, and Vue Router packages to validate error component rendering with both eager and lazy-loading patterns, ensuring consistent behavior regardless of initialization method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->