### PR TITLE
fix(start): strip trailing slash from prerenderable paths

### DIFF
--- a/packages/start-plugin-core/src/start-router-plugin/generator-plugins/prerender-routes-plugin.ts
+++ b/packages/start-plugin-core/src/start-router-plugin/generator-plugins/prerender-routes-plugin.ts
@@ -31,7 +31,8 @@ function getPrerenderablePaths(
     // filter routes that do not have a component, i.e api routes
     if (!route.createFileRouteProps?.has('component')) continue
 
-    paths.add(inferFullPath(route))
+    const fullPath = inferFullPath(route)
+    paths.add(fullPath === '/' ? fullPath : fullPath.replace(/\/$/, ''))
   }
 
   return Array.from(paths).map((path) => ({ path }))


### PR DESCRIPTION
Fixes #6978

When using nested index routes like `blog/index.tsx`, the prerender path discovery generates `/blog/` (with trailing slash) via `inferFullPath`, which intentionally preserves trailing slashes for index routes. But when the crawler picks up links from rendered HTML, it gets `/blog` (no trailing slash). The `seen` Set in `addCrawlPageTask` uses exact string matching, so both pass dedup and end up as separate entries in the sitemap.

The fix strips the trailing slash from `inferFullPath` output in `getPrerenderablePaths` before adding to the Set. This way discovered paths match crawled paths and the dedup works correctly. Root path `/` is kept as-is.

This is consistent with how `inferTo` (same package, unexported) already handles paths -- it calls `inferFullPath` then strips the trailing slash, since prerender paths are URLs rather than type identifiers.

Tested against the reproduction repo from the issue (https://github.com/dotnize/start-static-test). Before this change, `/blog` and `/blog/` are crawled separately. After, only `/blog` is crawled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed path normalization in the prerender process to ensure consistent route path handling. Non-root routes now have trailing slashes removed for consistency, while the root path remains unchanged, improving path storage reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->