### PR TITLE
fix(router-core): stop preload after beforeLoad errors

### DIFF
--- a/.changeset/green-turkeys-smile.md
+++ b/.changeset/green-turkeys-smile.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Fix preload from continuing into child `beforeLoad` and `head` handlers after a parent `beforeLoad` fails.

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -1002,7 +1002,7 @@ export async function loadMatches(arg: {
       break
     }
 
-    if (inner.serialError) {
+    if (inner.serialError || inner.firstBadMatchIndex != null) {
       break
     }
   }
@@ -1057,9 +1057,10 @@ export async function loadMatches(arg: {
     firstNotFound ??
     (beforeLoadNotFound && !inner.preload ? beforeLoadNotFound : undefined)
 
-  let headMaxIndex = inner.serialError
-    ? (inner.firstBadMatchIndex ?? 0)
-    : inner.matches.length - 1
+  let headMaxIndex =
+    inner.firstBadMatchIndex !== undefined
+      ? inner.firstBadMatchIndex
+      : inner.matches.length - 1
 
   if (!notFoundToThrow && beforeLoadNotFound && inner.preload) {
     return inner.matches

--- a/packages/router-core/tests/load.test.ts
+++ b/packages/router-core/tests/load.test.ts
@@ -260,6 +260,41 @@ describe('beforeLoad skip or exec', () => {
     expect(beforeLoad).toHaveBeenCalledTimes(2)
   })
 
+  test('skip child beforeLoad when parent beforeLoad throws during preload', async () => {
+    const parentBeforeLoad = vi.fn<BeforeLoad>(async ({ preload }) => {
+      if (preload) throw new Error('parent error')
+    })
+    const childBeforeLoad = vi.fn<BeforeLoad>()
+    const parentHead = vi.fn(() => ({ meta: [{ title: 'Parent' }] }))
+    const childHead = vi.fn(() => ({ meta: [{ title: 'Child' }] }))
+
+    const rootRoute = new BaseRootRoute({})
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      beforeLoad: parentBeforeLoad,
+      head: parentHead,
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      beforeLoad: childBeforeLoad,
+      head: childHead,
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([parentRoute.addChildren([childRoute])]),
+      history: createMemoryHistory(),
+    })
+
+    await router.preloadRoute({ to: '/parent/child' })
+
+    expect(parentBeforeLoad).toHaveBeenCalledTimes(1)
+    expect(childBeforeLoad).not.toHaveBeenCalled()
+    expect(parentHead).toHaveBeenCalledTimes(1)
+    expect(childHead).not.toHaveBeenCalled()
+  })
+
   test('exec if pending preload (error)', async () => {
     const beforeLoad = vi.fn<BeforeLoad>(async ({ preload }) => {
       await sleep(100)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a preload behavior issue in nested routes where child route handlers would continue executing even after a parent route's `beforeLoad` handler failed. Preload operations now correctly terminate early when a parent handler encounters an error, preventing unnecessary execution of subsequent route handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->