### PR TITLE
fix(router): core trim whitespace from SSR dehydrated script output

### DIFF
--- a/packages/router-core/src/ssr/ssr-server.ts
+++ b/packages/router-core/src/ssr/ssr-server.ts
@@ -74,13 +74,13 @@ class ScriptBuffer {
 
   constructor(router: AnyRouter) {
     this.router = router
-    // Copy INITIAL_SCRIPTS to avoid mutating the shared array
-    this._queue = INITIAL_SCRIPTS.slice()
+    // Copy INITIAL_SCRIPTS and trim to avoid unnecessary whitespace in HTML output
+    this._queue = INITIAL_SCRIPTS.map((s) => s.trim())
   }
 
   enqueue(script: string) {
     if (this._cleanedUp) return
-    this._queue.push(script)
+    this._queue.push(script.trim())
     // If barrier is lifted, schedule injection (if not already scheduled)
     if (this._scriptBarrierLifted && !this._pendingMicrotask) {
       this._pendingMicrotask = true


### PR DESCRIPTION
Fix: https://github.com/TanStack/router/issues/6947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved script handling consistency in server-side rendering by standardizing whitespace formatting in script injection, ensuring cleaner and more consistent script output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->