### PR TITLE
chore(types): re-export SearchMiddleware type from react-router

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -71,6 +71,7 @@ export type {
   ResolveRouteContext,
   SearchSerializer,
   SearchParser,
+  SearchMiddleware,
   TrailingSlashOption,
   Manifest,
   RouterManagedTag,


### PR DESCRIPTION
Re-export `SearchMiddleware` from `@tanstack/router-core` in `@tanstack/react-router` to avoid needing to add a direct dependency on `@tanstack/router-core` when typing search middleware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `SearchMiddleware` type to public exports, allowing developers to import and use this type directly from the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->