### PR TITLE
fix(start): skip plugin-injected entries in manifest chunk scanner

### DIFF
--- a/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
@@ -194,12 +194,19 @@ export function scanClientChunks(
     chunksByFileName.set(bundleEntry.fileName, bundleEntry)
 
     if (bundleEntry.isEntry) {
-      if (entryChunk) {
-        throw new Error(
-          `multiple entries detected: ${entryChunk.fileName} ${bundleEntry.fileName}`,
-        )
+      // Skip injected entries from bundler plugins (e.g. @module-federation/vite
+      // emits hostInit and remoteEntry entries). These are not the app entry.
+      const facadeId = bundleEntry.facadeModuleId ?? ''
+      const isPluginInjectedEntry =
+        facadeId.includes('__mf__virtual') || facadeId.startsWith('virtual:mf-')
+      if (!isPluginInjectedEntry) {
+        if (entryChunk) {
+          throw new Error(
+            `multiple entries detected: ${entryChunk.fileName} ${bundleEntry.fileName}`,
+          )
+        }
+        entryChunk = bundleEntry
       }
-      entryChunk = bundleEntry
     }
 
     const routeFilePaths = getRouteFilePathsFromModuleIds(bundleEntry.moduleIds)

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -19,6 +19,7 @@ function makeChunk(options: {
   importedCss?: Array<string>
   moduleIds?: Array<string>
   isEntry?: boolean
+  facadeModuleId?: string | null
 }): Rollup.OutputChunk {
   return {
     type: 'chunk',
@@ -29,7 +30,7 @@ function makeChunk(options: {
     moduleIds: options.moduleIds ?? [],
     isEntry: options.isEntry ?? false,
     isDynamicEntry: false,
-    facadeModuleId: null,
+    facadeModuleId: options.facadeModuleId ?? null,
     implicitlyLoadedBefore: [],
     importedBindings: {},
     modules: {},
@@ -191,6 +192,67 @@ describe('scanClientChunks', () => {
     expect(() => scanClientChunks({ 'posts.js': routeChunk })).toThrow(
       'No entry file found',
     )
+  })
+
+  test('skips __mf__virtual plugin-injected entry chunks', () => {
+    const appEntry = makeChunk({
+      fileName: 'main.js',
+      isEntry: true,
+      facadeModuleId: '/project/src/client.tsx',
+    })
+    const mfHostInit = makeChunk({
+      fileName: 'hostInit.js',
+      isEntry: true,
+      facadeModuleId:
+        '/project/node_modules/__mf__virtual/host__H_A_I__hostAutoInit__H_A_I__.js',
+    })
+
+    const scanned = scanClientChunks({
+      'main.js': appEntry,
+      'hostInit.js': mfHostInit,
+    })
+
+    expect(scanned.entryChunk).toBe(appEntry)
+  })
+
+  test('skips virtual:mf- plugin-injected entry chunks', () => {
+    const appEntry = makeChunk({
+      fileName: 'main.js',
+      isEntry: true,
+      facadeModuleId: '/project/src/client.tsx',
+    })
+    const mfRemoteEntry = makeChunk({
+      fileName: 'remoteEntry.js',
+      isEntry: true,
+      facadeModuleId: 'virtual:mf-REMOTE_ENTRY_ID:host__remoteEntry-hash',
+    })
+
+    const scanned = scanClientChunks({
+      'main.js': appEntry,
+      'remoteEntry.js': mfRemoteEntry,
+    })
+
+    expect(scanned.entryChunk).toBe(appEntry)
+  })
+
+  test('still throws on multiple non-plugin app entries', () => {
+    const entryA = makeChunk({
+      fileName: 'entryA.js',
+      isEntry: true,
+      facadeModuleId: '/project/src/clientA.tsx',
+    })
+    const entryB = makeChunk({
+      fileName: 'entryB.js',
+      isEntry: true,
+      facadeModuleId: '/project/src/clientB.tsx',
+    })
+
+    expect(() =>
+      scanClientChunks({
+        'entryA.js': entryA,
+        'entryB.js': entryB,
+      }),
+    ).toThrow('multiple entries detected')
   })
 })
 

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -235,6 +235,27 @@ describe('scanClientChunks', () => {
     expect(scanned.entryChunk).toBe(appEntry)
   })
 
+  test('skips plugin-injected entries even when scanned before the app entry', () => {
+    const mfHostInit = makeChunk({
+      fileName: 'hostInit.js',
+      isEntry: true,
+      facadeModuleId:
+        '/project/node_modules/__mf__virtual/host__H_A_I__hostAutoInit__H_A_I__.js',
+    })
+    const appEntry = makeChunk({
+      fileName: 'main.js',
+      isEntry: true,
+      facadeModuleId: '/project/src/client.tsx',
+    })
+
+    const scanned = scanClientChunks({
+      'hostInit.js': mfHostInit,
+      'main.js': appEntry,
+    })
+
+    expect(scanned.entryChunk).toBe(appEntry)
+  })
+
   test('still throws on multiple non-plugin app entries', () => {
     const entryA = makeChunk({
       fileName: 'entryA.js',


### PR DESCRIPTION
Hey everyone! I'm working on a POC for TanStack Start + Module Federation and hit this issue. This is my first PR here so apologies if I've missed anything from the contributing guide.

## The problem

When using `@module-federation/vite` as a host, `vite build` fails with:

```
Error: multiple entries detected: assets/hostInit-xxx.js assets/main-xxx.js
```

`@module-federation/vite` emits additional entry chunks into the client bundle — `hostInit` (via `__mf__virtual/...`) and `remoteEntry` (via `virtual:mf-...`). The `scanClientChunks` function in `manifestBuilder.ts` throws as soon as it sees more than one `isEntry` chunk, which makes it incompatible with any bundler plugin that emits its own entry points.

This is being tracked in #7032.

## What I changed

`scanClientChunks` now uses `facadeModuleId` to detect plugin-injected entries and skip them. `facadeModuleId` preserves the original entry module ID before Rolldown resolves it to a real file path, making it a reliable discriminator:

- Chunks with `__mf__virtual` in their `facadeModuleId` → MF `hostInit` entry, skip
- Chunks with a `virtual:mf-` prefix in their `facadeModuleId` → MF `remoteEntry`, skip
- Everything else → treated as the real app entry, original behaviour preserved (including throwing on genuine duplicates)

## How I tested it

- Added 3 unit tests to `manifestBuilder.test.ts` covering both skip patterns and the existing throw-on-duplicate behaviour
- Verified `tanstack-start-example-basic` still builds cleanly
- Validated end-to-end in the POC repo: https://github.com/rr-jimmy-multani/rr-tanstack-poc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented false "multiple entries" build errors by ignoring framework/plugin-injected entry chunks so only actual app entries are considered.

* **Tests**
  * Added regression tests to ensure injected entries are skipped and genuine multiple-entry errors still surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->