### PR TITLE
perf(solid-router): drop deep equality in selector hooks

### DIFF
--- a/packages/solid-router/src/Matches.tsx
+++ b/packages/solid-router/src/Matches.tsx
@@ -1,5 +1,5 @@
 import * as Solid from 'solid-js'
-import { replaceEqualDeep, rootRouteId } from '@tanstack/router-core'
+import { rootRouteId } from '@tanstack/router-core'
 import { isServer } from '@tanstack/router-core/isServer'
 import { CatchBoundary, ErrorComponent } from './CatchBoundary'
 import { useRouter } from './useRouter'
@@ -214,13 +214,11 @@ export function useMatches<
   opts?: UseMatchesBaseOptions<TRouter, TSelected>,
 ): Solid.Accessor<UseMatchesResult<TRouter, TSelected>> {
   const router = useRouter<TRouter>()
-  return Solid.createMemo((prev: TSelected | undefined) => {
+  return Solid.createMemo(() => {
     const matches = router.stores.activeMatchesSnapshot.state as Array<
       MakeRouteMatchUnion<TRouter>
     >
-    const res = opts?.select ? opts.select(matches) : matches
-    if (prev === undefined) return res
-    return replaceEqualDeep(prev, res) as any
+    return (opts?.select ? opts.select(matches) : matches) as any
   }) as Solid.Accessor<UseMatchesResult<TRouter, TSelected>>
 }
 

--- a/packages/solid-router/src/useLocation.tsx
+++ b/packages/solid-router/src/useLocation.tsx
@@ -1,5 +1,4 @@
 import * as Solid from 'solid-js'
-import { replaceEqualDeep } from '@tanstack/router-core'
 import { useRouter } from './useRouter'
 import type {
   AnyRouter,
@@ -35,9 +34,7 @@ export function useLocation<
 
   const select = opts.select
 
-  return Solid.createMemo((prev: TSelected | undefined) => {
-    const res = select(router.stores.location.state)
-    if (prev === undefined) return res
-    return replaceEqualDeep(prev, res)
-  }) as Accessor<UseLocationResult<TRouter, TSelected>>
+  return Solid.createMemo(() =>
+    select(router.stores.location.state),
+  ) as Accessor<UseLocationResult<TRouter, TSelected>>
 }

--- a/packages/solid-router/src/useMatch.tsx
+++ b/packages/solid-router/src/useMatch.tsx
@@ -1,5 +1,5 @@
 import * as Solid from 'solid-js'
-import { invariant, replaceEqualDeep } from '@tanstack/router-core'
+import { invariant } from '@tanstack/router-core'
 import { nearestMatchContext } from './matchContext'
 import { useRouter } from './useRouter'
 import type {
@@ -106,12 +106,12 @@ export function useMatch<
     }
   })
 
-  return Solid.createMemo((prev: TSelected | undefined) => {
+  return Solid.createMemo(() => {
     const selectedMatch = match()
 
     if (selectedMatch === undefined) return undefined
-    const res = opts.select ? opts.select(selectedMatch as any) : selectedMatch
-    if (prev === undefined) return res as TSelected
-    return replaceEqualDeep(prev, res) as TSelected
+    return (opts.select ? opts.select(selectedMatch as any) : selectedMatch) as
+      | TSelected
+      | undefined
   }) as any
 }

--- a/packages/solid-router/src/useRouterState.tsx
+++ b/packages/solid-router/src/useRouterState.tsx
@@ -1,6 +1,5 @@
 import { isServer } from '@tanstack/router-core/isServer'
 import * as Solid from 'solid-js'
-import { replaceEqualDeep } from '@tanstack/router-core'
 import { useRouter } from './useRouter'
 import type {
   AnyRouter,
@@ -54,9 +53,7 @@ export function useRouterState<
 
   const select = opts.select
 
-  return Solid.createMemo((prev: TSelected | undefined) => {
-    const res = select(router.stores.__store.state)
-    if (prev === undefined) return res
-    return replaceEqualDeep(prev, res)
-  }) as Accessor<UseRouterStateResult<TRouter, TSelected>>
+  return Solid.createMemo(() =>
+    select(router.stores.__store.state),
+  ) as Accessor<UseRouterStateResult<TRouter, TSelected>>
 }


### PR DESCRIPTION
DO NOT MERGE, I JUST OPENED THE PR TO GET CODSPEED MEASUREMENTS

## Summary
- remove `replaceEqualDeep` from the hot-path Solid selector hooks in `useRouterState`, `useLocation`, `useMatch`, and `useMatches`
- keep the head tag dedupe path unchanged, since that one still stabilizes rendered head assets rather than only suppressing signal invalidation
- make it easier to validate in CI whether dropping these structural-sharing passes improves the stable `@benchmarks/client-nav` Solid benchmark

## Testing
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/solid-router:test:unit --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/solid-router:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @benchmarks/client-nav:test:perf:solid --outputStyle=stream --skipRemoteCache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified memoization logic in core router hooks (`useMatches`, `useLocation`, `useMatch`, `useRouterState`) by streamlining internal value stabilization. No changes to public APIs or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->