### PR TITLE
Fix(start-basic): Add deploy url to fix SSR fetch bug

### DIFF
--- a/examples/react/start-basic/src/routes/users.$userId.tsx
+++ b/examples/react/start-basic/src/routes/users.$userId.tsx
@@ -1,12 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { NotFound } from '../components/NotFound'
 import { UserErrorComponent } from '../components/UserError'
+import { DEPLOY_URL } from '../utils/users'
 import type { User } from '../utils/users'
 
 export const Route = createFileRoute('/users/$userId')({
   loader: async ({ params: { userId } }) => {
     try {
-      const res = await fetch('/api/users/' + userId)
+      const res = await fetch(DEPLOY_URL + '/api/users/' + userId)
       if (!res.ok) {
         throw new Error('Unexpected status code')
       }

--- a/examples/react/start-basic/src/routes/users.tsx
+++ b/examples/react/start-basic/src/routes/users.tsx
@@ -1,9 +1,10 @@
 import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
+import { DEPLOY_URL } from '../utils/users'
 import type { User } from '../utils/users'
 
 export const Route = createFileRoute('/users')({
   loader: async () => {
-    const res = await fetch('/api/users')
+    const res = await fetch(DEPLOY_URL + '/api/users')
 
     if (!res.ok) {
       throw new Error('Unexpected status code')

--- a/examples/react/start-basic/src/utils/users.tsx
+++ b/examples/react/start-basic/src/utils/users.tsx
@@ -3,3 +3,5 @@ export type User = {
   name: string
   email: string
 }
+
+export const DEPLOY_URL = 'http://localhost:3000'


### PR DESCRIPTION
The Problem

I ran the start-basic example but when i refresh the page under /users or /users/9 is not working, it is failing at the fetch

```
npx gitpick TanStack/router/tree/main/examples/react/start-basic start-basic
cd start-basic
npm install
npm run dev
```

<img width="1534" height="327" alt="Screenshot 2026-04-04 at 13 37 34" src="https://github.com/user-attachments/assets/fb8419f1-c6c4-476f-8f04-4ed009c8bc9d" />


It was there previously but it was removed I am not sure why.

https://github.com/TanStack/router/commit/8b5accb27c85634fbda985c2506844b1a388f61a?w=1#diff-78bdb6a3013dc993b00e687f00f3d23bb60c5fd036c6ccc3d2a9b4aee5143690

![issue](https://github.com/user-attachments/assets/5ebbbb0b-36d8-47f3-9e42-eb95a420a2d1)

