### PR TITLE
fix: preserve unmasked route on SSR hard reload

### DIFF
--- a/.changeset/calmly-fox-smiled.md
+++ b/.changeset/calmly-fox-smiled.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+Injected `unmaskOnReload` pre-hydration script during SSR so hard reloads preserved the unmasked route.

--- a/.changeset/swiftly-otter-jumped.md
+++ b/.changeset/swiftly-otter-jumped.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Added helpers for building `unmaskOnReload` reload scripts and route mask match patterns. This enabled SSR hard reload recovery for masked routes.

--- a/packages/react-router/src/headContentUtils.tsx
+++ b/packages/react-router/src/headContentUtils.tsx
@@ -431,7 +431,7 @@ function buildUnmaskOnReloadHeadScript(
 
   return {
     tag: 'script',
-    attrs: nonce ? { nonce } : undefined,
+    ...(nonce ? { attrs: { nonce } } : {}),
     children: script,
   } satisfies RouterManagedTag
 }

--- a/packages/react-router/src/headContentUtils.tsx
+++ b/packages/react-router/src/headContentUtils.tsx
@@ -169,6 +169,8 @@ function buildTagsFromMatches(
     children,
   }))
 
+  const unmaskOnReloadScript = buildUnmaskOnReloadHeadScript(router, nonce)
+
   return uniqBy(
     [
       ...resultMeta,
@@ -176,6 +178,7 @@ function buildTagsFromMatches(
       ...constructedLinks,
       ...assetLinks,
       ...styles,
+      ...(unmaskOnReloadScript ? [unmaskOnReloadScript] : []),
       ...headScripts,
     ] as Array<RouterManagedTag>,
     (d) => JSON.stringify(d),
@@ -397,18 +400,128 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
     deepEqual,
   )
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
+  const unmaskOnReloadScript = React.useMemo(
+    () => buildUnmaskOnReloadHeadScript(router, nonce),
+    [router, nonce],
+  )
+
   return uniqBy(
     [
       ...meta,
       ...preloadLinks,
       ...links,
       ...styles,
+      ...(unmaskOnReloadScript ? [unmaskOnReloadScript] : []),
       ...headScripts,
     ] as Array<RouterManagedTag>,
     (d) => {
       return JSON.stringify(d)
     },
   )
+}
+
+function buildUnmaskOnReloadHeadScript(
+  router: ReturnType<typeof useRouter>,
+  nonce: string | undefined,
+) {
+  const routeMaskSources = (router.options.routeMasks ?? [])
+    .filter((routeMask) => routeMask.unmaskOnReload && typeof routeMask.from === 'string')
+    .map((routeMask) => routePathToRegExpSource(routeMask.from))
+
+  if (!routeMaskSources.length) return undefined
+
+  return {
+    tag: 'script',
+    attrs: nonce ? { nonce } : undefined,
+    children: `
+(() => {
+  const maskedRoutePathPatterns = ${JSON.stringify(routeMaskSources)}
+    .map((source) => new RegExp(source))
+  const tempLocation = window.history.state?.__tempLocation
+  if (!tempLocation?.pathname) return
+  if (
+    tempLocation.pathname === window.location.pathname &&
+    (tempLocation.search ?? '') === window.location.search &&
+    (tempLocation.hash ?? '') === window.location.hash
+  ) return
+  if (!maskedRoutePathPatterns.some((pattern) => pattern.test(tempLocation.pathname)))
+    return
+  window.location.replace(
+    tempLocation.pathname + (tempLocation.search ?? '') + (tempLocation.hash ?? ''),
+  )
+})()
+`,
+  } satisfies RouterManagedTag
+}
+
+function routePathToRegExpSource(routePath: string) {
+  let regExpSource = '^'
+
+  for (const segment of routePath.split('/').filter(Boolean)) {
+    const routeSegment = parseRoutePathSegment(segment)
+
+    if (routeSegment.type === 'optional-param') {
+      regExpSource += `(?:/${routeSegment.source})?`
+      continue
+    }
+
+    if (routeSegment.type === 'wildcard') {
+      regExpSource += `(?:/${routeSegment.source})?`
+      continue
+    }
+
+    regExpSource += `/${routeSegment.source}`
+  }
+
+  return `${regExpSource}$`
+}
+
+function parseRoutePathSegment(segment: string) {
+  if (!segment.includes('$')) {
+    return { source: escapeRegExp(segment), type: 'pathname' as const }
+  }
+
+  if (segment === '$') {
+    return { source: '.*', type: 'wildcard' as const }
+  }
+
+  if (segment.startsWith('$')) {
+    return { source: '[^/]+', type: 'param' as const }
+  }
+
+  const openBraceIndex = segment.indexOf('{')
+  if (openBraceIndex === -1) {
+    return { source: escapeRegExp(segment), type: 'pathname' as const }
+  }
+
+  const closeBraceIndex = segment.indexOf('}', openBraceIndex)
+  if (closeBraceIndex === -1) {
+    return { source: escapeRegExp(segment), type: 'pathname' as const }
+  }
+
+  const prefix = segment.slice(0, openBraceIndex)
+  const suffix = segment.slice(closeBraceIndex + 1)
+  const token = segment.slice(openBraceIndex + 1, closeBraceIndex)
+  const source = `${escapeRegExp(prefix)}${token === '$' ? '.*' : '[^/]+'}${escapeRegExp(suffix)}`
+
+  if (token === '$') {
+    return { source, type: 'wildcard' as const }
+  }
+
+  if (token.startsWith('-$') && token.length > 2) {
+    return { source, type: 'optional-param' as const }
+  }
+
+  if (token.startsWith('$') && token.length > 1) {
+    return { source, type: 'param' as const }
+  }
+
+  return { source: escapeRegExp(segment), type: 'pathname' as const }
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 export function uniqBy<T>(arr: Array<T>, fn: (item: T) => string) {

--- a/packages/react-router/src/headContentUtils.tsx
+++ b/packages/react-router/src/headContentUtils.tsx
@@ -4,6 +4,7 @@ import {
   deepEqual,
   escapeHtml,
   getAssetCrossOrigin,
+  getUnmaskOnReloadScript,
   resolveManifestAssetLink,
   routePathToRegExpSource,
 } from '@tanstack/router-core'
@@ -432,27 +433,13 @@ function buildUnmaskOnReloadHeadScript(
 
   if (!routeMaskSources.length) return undefined
 
+  const script = getUnmaskOnReloadScript(routeMaskSources)
+  if (!script) return undefined
+
   return {
     tag: 'script',
     attrs: nonce ? { nonce } : undefined,
-    children: `
-(() => {
-  const maskedRoutePathPatterns = ${JSON.stringify(routeMaskSources)}
-    .map((source) => new RegExp(source))
-  const tempLocation = window.history.state?.__tempLocation
-  if (!tempLocation?.pathname) return
-  if (
-    tempLocation.pathname === window.location.pathname &&
-    (tempLocation.search ?? '') === window.location.search &&
-    (tempLocation.hash ?? '') === window.location.hash
-  ) return
-  if (!maskedRoutePathPatterns.some((pattern) => pattern.test(tempLocation.pathname)))
-    return
-  window.location.replace(
-    tempLocation.pathname + (tempLocation.search ?? '') + (tempLocation.hash ?? ''),
-  )
-})()
-`,
+    children: script,
   } satisfies RouterManagedTag
 }
 

--- a/packages/react-router/src/headContentUtils.tsx
+++ b/packages/react-router/src/headContentUtils.tsx
@@ -4,9 +4,8 @@ import {
   deepEqual,
   escapeHtml,
   getAssetCrossOrigin,
-  getUnmaskOnReloadScript,
+  getUnmaskOnReloadScriptFromRouteMasks,
   resolveManifestAssetLink,
-  routePathToRegExpSource,
 } from '@tanstack/router-core'
 import { isServer } from '@tanstack/router-core/isServer'
 import { useRouter } from './useRouter'
@@ -427,13 +426,7 @@ function buildUnmaskOnReloadHeadScript(
   router: ReturnType<typeof useRouter>,
   nonce: string | undefined,
 ) {
-  const routeMaskSources = (router.options.routeMasks ?? [])
-    .filter((routeMask) => routeMask.unmaskOnReload && typeof routeMask.from === 'string')
-    .map((routeMask) => routePathToRegExpSource(routeMask.from))
-
-  if (!routeMaskSources.length) return undefined
-
-  const script = getUnmaskOnReloadScript(routeMaskSources)
+  const script = getUnmaskOnReloadScriptFromRouteMasks(router.options.routeMasks)
   if (!script) return undefined
 
   return {

--- a/packages/react-router/src/headContentUtils.tsx
+++ b/packages/react-router/src/headContentUtils.tsx
@@ -5,6 +5,7 @@ import {
   escapeHtml,
   getAssetCrossOrigin,
   resolveManifestAssetLink,
+  routePathToRegExpSource,
 } from '@tanstack/router-core'
 import { isServer } from '@tanstack/router-core/isServer'
 import { useRouter } from './useRouter'
@@ -453,75 +454,6 @@ function buildUnmaskOnReloadHeadScript(
 })()
 `,
   } satisfies RouterManagedTag
-}
-
-function routePathToRegExpSource(routePath: string) {
-  let regExpSource = '^'
-
-  for (const segment of routePath.split('/').filter(Boolean)) {
-    const routeSegment = parseRoutePathSegment(segment)
-
-    if (routeSegment.type === 'optional-param') {
-      regExpSource += `(?:/${routeSegment.source})?`
-      continue
-    }
-
-    if (routeSegment.type === 'wildcard') {
-      regExpSource += `(?:/${routeSegment.source})?`
-      continue
-    }
-
-    regExpSource += `/${routeSegment.source}`
-  }
-
-  return `${regExpSource}$`
-}
-
-function parseRoutePathSegment(segment: string) {
-  if (!segment.includes('$')) {
-    return { source: escapeRegExp(segment), type: 'pathname' as const }
-  }
-
-  if (segment === '$') {
-    return { source: '.*', type: 'wildcard' as const }
-  }
-
-  if (segment.startsWith('$')) {
-    return { source: '[^/]+', type: 'param' as const }
-  }
-
-  const openBraceIndex = segment.indexOf('{')
-  if (openBraceIndex === -1) {
-    return { source: escapeRegExp(segment), type: 'pathname' as const }
-  }
-
-  const closeBraceIndex = segment.indexOf('}', openBraceIndex)
-  if (closeBraceIndex === -1) {
-    return { source: escapeRegExp(segment), type: 'pathname' as const }
-  }
-
-  const prefix = segment.slice(0, openBraceIndex)
-  const suffix = segment.slice(closeBraceIndex + 1)
-  const token = segment.slice(openBraceIndex + 1, closeBraceIndex)
-  const source = `${escapeRegExp(prefix)}${token === '$' ? '.*' : '[^/]+'}${escapeRegExp(suffix)}`
-
-  if (token === '$') {
-    return { source, type: 'wildcard' as const }
-  }
-
-  if (token.startsWith('-$') && token.length > 2) {
-    return { source, type: 'optional-param' as const }
-  }
-
-  if (token.startsWith('$') && token.length > 1) {
-    return { source, type: 'param' as const }
-  }
-
-  return { source: escapeRegExp(segment), type: 'pathname' as const }
-}
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 export function uniqBy<T>(arr: Array<T>, fn: (item: T) => string) {

--- a/packages/react-router/tests/Scripts.test.tsx
+++ b/packages/react-router/tests/Scripts.test.tsx
@@ -19,6 +19,7 @@ import {
   createMemoryHistory,
   createRootRoute,
   createRoute,
+  createRouteMask,
   createRouter,
 } from '../src'
 import { Scripts } from '../src/Scripts'
@@ -369,6 +370,95 @@ describe('ssr HeadContent', () => {
     expect(html).toEqual(
       `<title>Index</title><meta name="image" content="image.jpg"/><meta property="og:description" content="Root description"/><meta name="description" content="Index"/><meta name="last-modified" content="2021-10-10"/><meta property="og:image" content="index-image.jpg"/>`,
     )
+  })
+
+  test('injects a nonce-aware preload script for masks that unmask on reload', async () => {
+    const rootRoute = createRootRoute({
+      component: () => <HeadContent />,
+    })
+
+    const indexRoute = createRoute({
+      path: '/',
+      getParentRoute: () => rootRoute,
+    })
+
+    const modalRoute = createRoute({
+      path: '/modal',
+      getParentRoute: () => rootRoute,
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute, modalRoute])
+
+    const router = createRouter({
+      history: createMemoryHistory({
+        initialEntries: ['/'],
+      }),
+      isServer: true,
+      routeMasks: [
+        createRouteMask({
+          from: '/modal',
+          routeTree,
+          to: '/',
+          unmaskOnReload: true,
+        }),
+      ],
+      routeTree,
+      ssr: {
+        nonce: 'test-nonce',
+      },
+    })
+
+    await router.load()
+
+    const html = ReactDOMServer.renderToString(
+      <RouterProvider router={router} />,
+    )
+
+    expect(html).toContain('<script nonce="test-nonce">')
+    expect(html).toContain('window.history.state?.__tempLocation')
+    expect(html).toContain('window.location.replace(')
+    expect(html).toContain('^/modal$')
+  })
+
+  test('does not inject an unmask-on-reload script for ordinary route masks', async () => {
+    const rootRoute = createRootRoute({
+      component: () => <HeadContent />,
+    })
+
+    const indexRoute = createRoute({
+      path: '/',
+      getParentRoute: () => rootRoute,
+    })
+
+    const modalRoute = createRoute({
+      path: '/modal',
+      getParentRoute: () => rootRoute,
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute, modalRoute])
+
+    const router = createRouter({
+      history: createMemoryHistory({
+        initialEntries: ['/'],
+      }),
+      isServer: true,
+      routeMasks: [
+        createRouteMask({
+          from: '/modal',
+          routeTree,
+          to: '/',
+        }),
+      ],
+      routeTree,
+    })
+
+    await router.load()
+
+    const html = ReactDOMServer.renderToString(
+      <RouterProvider router={router} />,
+    )
+
+    expect(html).not.toContain('window.history.state?.__tempLocation')
   })
 
   test('keeps manifest stylesheet links mounted when history state changes', async () => {

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -111,6 +111,7 @@ export {
 export { encode, decode } from './qss'
 export { rootRouteId } from './root'
 export type { RootRouteId } from './root'
+export { getUnmaskOnReloadScript } from './unmask-on-reload-script'
 
 export { BaseRoute, BaseRouteApi, BaseRootRoute } from './route'
 export type {

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -111,7 +111,10 @@ export {
 export { encode, decode } from './qss'
 export { rootRouteId } from './root'
 export type { RootRouteId } from './root'
-export { getUnmaskOnReloadScript } from './unmask-on-reload-script'
+export {
+  getUnmaskOnReloadScript,
+  getUnmaskOnReloadScriptFromRouteMasks,
+} from './unmask-on-reload-script'
 
 export { BaseRoute, BaseRouteApi, BaseRootRoute } from './route'
 export type {

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -106,6 +106,7 @@ export {
   exactPathTest,
   resolvePath,
   interpolatePath,
+  routePathToRegExpSource,
 } from './path'
 export { encode, decode } from './qss'
 export { rootRouteId } from './root'

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -199,6 +199,58 @@ export function resolvePath({
 }
 
 /**
+ * Convert a route path template into a regular expression source that matches
+ * concrete pathnames for that route.
+ */
+export function routePathToRegExpSource(routePath: string) {
+  if (!routePath || routePath === '/') {
+    return '^/$'
+  }
+
+  let cursor = 0
+  let regExpSource = ''
+  let segment
+
+  while (cursor < routePath.length) {
+    const start = cursor
+    segment = parseSegment(routePath, start, segment)
+    const end = segment[5]
+    cursor = end + 1
+
+    if (start === end) continue
+
+    const kind = segment[0]
+
+    if (kind === SEGMENT_TYPE_PATHNAME) {
+      regExpSource += `/${escapeRegExp(routePath.substring(start, end))}`
+      continue
+    }
+
+    const prefix = routePath.substring(start, segment[1])
+    const suffix = routePath.substring(segment[4], end)
+
+    if (kind === SEGMENT_TYPE_OPTIONAL_PARAM) {
+      regExpSource += `(?:/${escapeRegExp(prefix)}[^/]+${escapeRegExp(suffix)})?`
+      continue
+    }
+
+    if (kind === SEGMENT_TYPE_WILDCARD) {
+      if (!prefix && !suffix) {
+        regExpSource += '(?:/.*)?'
+        continue
+      }
+
+      regExpSource += `/${escapeRegExp(prefix)}.*${escapeRegExp(suffix)}`
+      continue
+    }
+
+    regExpSource += `/${escapeRegExp(prefix)}[^/]+${escapeRegExp(suffix)}`
+  }
+
+  return `^${regExpSource}$`
+}
+
+/**
  * Create a pre-compiled decode config from allowed characters.
  * This should be called once at router initialization.
  */
@@ -210,7 +262,7 @@ export function compileDecodeCharMap(
   )
   // Escape special regex characters and join with |
   const pattern = Array.from(charMap.keys())
-    .map((key) => key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .map((key) => escapeRegExp(key))
     .join('|')
   const regex = new RegExp(pattern, 'g')
   return (encoded: string) =>
@@ -433,4 +485,8 @@ function encodePathParam(
 ) {
   const encoded = encodeURIComponent(value)
   return decoder?.(encoded) ?? encoded
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/packages/router-core/src/unmask-on-reload-inline.ts
+++ b/packages/router-core/src/unmask-on-reload-inline.ts
@@ -1,0 +1,22 @@
+export default function (options: { routeMaskSources: Array<string> }) {
+  const maskedRoutePathPatterns = options.routeMaskSources.map(
+    (source) => new RegExp(source),
+  )
+  const tempLocation = window.history.state?.__tempLocation
+
+  if (!tempLocation?.pathname) return
+
+  if (
+    tempLocation.pathname === window.location.pathname &&
+    (tempLocation.search ?? '') === window.location.search &&
+    (tempLocation.hash ?? '') === window.location.hash
+  )
+    return
+
+  if (!maskedRoutePathPatterns.some((pattern) => pattern.test(tempLocation.pathname)))
+    return
+
+  window.location.replace(
+    tempLocation.pathname + (tempLocation.search ?? '') + (tempLocation.hash ?? ''),
+  )
+}

--- a/packages/router-core/src/unmask-on-reload-script.ts
+++ b/packages/router-core/src/unmask-on-reload-script.ts
@@ -1,5 +1,27 @@
 import minifiedUnmaskOnReloadScript from './unmask-on-reload-inline?script-string'
+import { routePathToRegExpSource } from './path'
+import type { AnyRoute, RouteMask } from './route'
 import { escapeHtml } from './utils'
+
+export function getUnmaskOnReloadScriptFromRouteMasks(
+  routeMasks?: ReadonlyArray<
+    Pick<RouteMask<AnyRoute>, 'from' | 'unmaskOnReload'>
+  >,
+) {
+  return getUnmaskOnReloadScript(
+    (routeMasks ?? [])
+      .filter(
+        (
+          routeMask,
+        ): routeMask is {
+          from: RouteMask<AnyRoute>['from']
+          unmaskOnReload: true
+        } =>
+          routeMask.unmaskOnReload === true && typeof routeMask.from === 'string',
+      )
+      .map((routeMask) => routePathToRegExpSource(routeMask.from)),
+  )
+}
 
 export function getUnmaskOnReloadScript(routeMaskSources: Array<string>) {
   if (!routeMaskSources.length) return null

--- a/packages/router-core/src/unmask-on-reload-script.ts
+++ b/packages/router-core/src/unmask-on-reload-script.ts
@@ -1,7 +1,7 @@
 import minifiedUnmaskOnReloadScript from './unmask-on-reload-inline?script-string'
 import { routePathToRegExpSource } from './path'
-import type { AnyRoute, RouteMask } from './route'
 import { escapeHtml } from './utils'
+import type { AnyRoute, RouteMask } from './route'
 
 export function getUnmaskOnReloadScriptFromRouteMasks(
   routeMasks?: ReadonlyArray<

--- a/packages/router-core/src/unmask-on-reload-script.ts
+++ b/packages/router-core/src/unmask-on-reload-script.ts
@@ -1,16 +1,10 @@
 import minifiedUnmaskOnReloadScript from './unmask-on-reload-inline?script-string'
 import { escapeHtml } from './utils'
 
-type InlineUnmaskOnReloadScriptOptions = {
-  routeMaskSources: Array<string>
-}
-
 export function getUnmaskOnReloadScript(routeMaskSources: Array<string>) {
   if (!routeMaskSources.length) return null
 
   return `(${minifiedUnmaskOnReloadScript})(${escapeHtml(
-    JSON.stringify({
-      routeMaskSources,
-    } satisfies InlineUnmaskOnReloadScriptOptions),
+    JSON.stringify({ routeMaskSources }),
   )})`
 }

--- a/packages/router-core/src/unmask-on-reload-script.ts
+++ b/packages/router-core/src/unmask-on-reload-script.ts
@@ -1,0 +1,16 @@
+import minifiedUnmaskOnReloadScript from './unmask-on-reload-inline?script-string'
+import { escapeHtml } from './utils'
+
+type InlineUnmaskOnReloadScriptOptions = {
+  routeMaskSources: Array<string>
+}
+
+export function getUnmaskOnReloadScript(routeMaskSources: Array<string>) {
+  if (!routeMaskSources.length) return null
+
+  return `(${minifiedUnmaskOnReloadScript})(${escapeHtml(
+    JSON.stringify({
+      routeMaskSources,
+    } satisfies InlineUnmaskOnReloadScriptOptions),
+  )})`
+}

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -4,6 +4,7 @@ import {
   exactPathTest,
   interpolatePath,
   removeTrailingSlash,
+  routePathToRegExpSource,
   resolvePath,
   trimPathLeft,
 } from '../src/path'
@@ -240,6 +241,62 @@ describe('resolvePath', () => {
       })
     },
   )
+})
+
+describe('routePathToRegExpSource', () => {
+  it('matches static paths', () => {
+    const pattern = new RegExp(routePathToRegExpSource('/modal'))
+
+    expect(pattern.test('/modal')).toBe(true)
+    expect(pattern.test('/billing')).toBe(false)
+  })
+
+  it('matches params', () => {
+    const pattern = new RegExp(
+      routePathToRegExpSource('/photos/$photoId/modal'),
+    )
+
+    expect(pattern.test('/photos/123/modal')).toBe(true)
+    expect(pattern.test('/photos/123')).toBe(false)
+  })
+
+  it('matches optional params with and without the segment', () => {
+    const pattern = new RegExp(
+      routePathToRegExpSource('/docs/{-$lang}/install'),
+    )
+
+    expect(pattern.test('/docs/install')).toBe(true)
+    expect(pattern.test('/docs/en/install')).toBe(true)
+    expect(pattern.test('/docs/en')).toBe(false)
+  })
+
+  it('matches wildcard segments with and without a splat', () => {
+    const pattern = new RegExp(routePathToRegExpSource('/files/$'))
+
+    expect(pattern.test('/files')).toBe(true)
+    expect(pattern.test('/files/readme.md')).toBe(true)
+    expect(pattern.test('/files/nested/path')).toBe(true)
+    expect(pattern.test('/file')).toBe(false)
+  })
+
+  it('keeps wildcard prefix and suffix segments required', () => {
+    const pattern = new RegExp(
+      routePathToRegExpSource('/docs/prefix{$}suffix'),
+    )
+
+    expect(pattern.test('/docs/prefixsuffix')).toBe(true)
+    expect(pattern.test('/docs/prefixnested/pathsuffix')).toBe(true)
+    expect(pattern.test('/docs')).toBe(false)
+  })
+
+  it('matches param segments with prefixes and suffixes', () => {
+    const pattern = new RegExp(
+      routePathToRegExpSource('/blog/prefix{$slug}suffix'),
+    )
+
+    expect(pattern.test('/blog/prefixpostsuffix')).toBe(true)
+    expect(pattern.test('/blog/prefixsuffix')).toBe(false)
+  })
 })
 
 describe.each([{ server: true }, { server: false }])(

--- a/packages/router-core/tests/unmask-on-reload-script.test.ts
+++ b/packages/router-core/tests/unmask-on-reload-script.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'vitest'
-import { getUnmaskOnReloadScript } from '../src'
+import {
+  getUnmaskOnReloadScript,
+  getUnmaskOnReloadScriptFromRouteMasks,
+} from '../src'
 
 describe('getUnmaskOnReloadScript', () => {
   test('returns null when no route mask sources are provided', () => {
@@ -12,5 +15,27 @@ describe('getUnmaskOnReloadScript', () => {
     expect(script).toContain('window.history.state?.__tempLocation')
     expect(script).toContain('window.location.replace')
     expect(script).toContain('"routeMaskSources":["^/modal$"]')
+  })
+})
+
+describe('getUnmaskOnReloadScriptFromRouteMasks', () => {
+  test('serializes unmask-on-reload route masks into the inline script', () => {
+    const script = getUnmaskOnReloadScriptFromRouteMasks([
+      { from: '/modal', unmaskOnReload: true },
+      { from: '/ignored', unmaskOnReload: false },
+    ])
+
+    expect(script).toContain('window.history.state?.__tempLocation')
+    expect(script).toContain('window.location.replace')
+    expect(script).toContain('"routeMaskSources":["^/modal$"]')
+    expect(script).not.toContain('/ignored')
+  })
+
+  test('returns null when no route masks opt into unmask-on-reload', () => {
+    expect(
+      getUnmaskOnReloadScriptFromRouteMasks([
+        { from: '/modal', unmaskOnReload: false },
+      ]),
+    ).toBeNull()
   })
 })

--- a/packages/router-core/tests/unmask-on-reload-script.test.ts
+++ b/packages/router-core/tests/unmask-on-reload-script.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+import { getUnmaskOnReloadScript } from '../src'
+
+describe('getUnmaskOnReloadScript', () => {
+  test('returns null when no route mask sources are provided', () => {
+    expect(getUnmaskOnReloadScript([])).toBeNull()
+  })
+
+  test('serializes the inline unmask-on-reload script', () => {
+    const script = getUnmaskOnReloadScript(['^/modal$'])
+
+    expect(script).toContain('window.history.state?.__tempLocation')
+    expect(script).toContain('window.location.replace')
+    expect(script).toContain('"routeMaskSources":["^/modal$"]')
+  })
+})


### PR DESCRIPTION
SSR hard reloads on masked routes can lose the real route because the server only sees the masked URL, so hydration can drop modal or dialog UI that depends on the unmasked route.

This injects a small pre-hydration script for masks with `unmaskOnReload` that restores `history.state.__tempLocation` before hydration (while preserving the SSR nonce).

Closes #7115.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server-side rendering now preserves masked route navigation state during hard page reloads, maintaining user context and preventing loss of state across browser refreshes

* **Tests**
  * Added comprehensive test coverage for route state preservation behavior during page reload scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->