### PR TITLE
fix(react-router): clear stale error in CatchBoundary on route change

### DIFF
--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -37,8 +37,12 @@ class CatchBoundaryImpl extends React.Component<{
   onCatch?: (error: Error, errorInfo: ErrorInfo) => void
 }> {
   state = { error: null } as { error: Error | null; resetKey: string }
-  static getDerivedStateFromProps(props: any) {
-    return { resetKey: props.getResetKey() }
+  static getDerivedStateFromProps(props: any, state: any) {
+    const resetKey = props.getResetKey()
+    if (state.error && state.resetKey !== resetKey) {
+      return { resetKey: resetKey, error: null }
+    }
+    return { resetKey: resetKey }
   }
   static getDerivedStateFromError(error: Error) {
     return { error }
@@ -46,30 +50,14 @@ class CatchBoundaryImpl extends React.Component<{
   reset() {
     this.setState({ error: null })
   }
-  componentDidUpdate(
-    prevProps: Readonly<{
-      getResetKey: () => string
-      children: (props: { error: any; reset: () => void }) => any
-      onCatch?: ((error: any, info: any) => void) | undefined
-    }>,
-    prevState: any,
-  ): void {
-    if (prevState.error && prevState.resetKey !== this.state.resetKey) {
-      this.reset()
-    }
-  }
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     if (this.props.onCatch) {
       this.props.onCatch(error, errorInfo)
     }
   }
   render() {
-    // If the resetKey has changed, don't render the error
     return this.props.children({
-      error:
-        this.state.resetKey !== this.props.getResetKey()
-          ? null
-          : this.state.error,
+      error: this.state.error,
       reset: () => {
         this.reset()
       },

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -1529,6 +1529,8 @@ describe('Link', () => {
   test('when navigating away from a route with a loader that errors', async () => {
     const postsOnError = vi.fn()
     const indexOnError = vi.fn()
+    const indexErrorComponent = vi.fn(() => (<span>IndexError</span>))
+
     const rootRoute = createRootRoute({
       component: () => (
         <>
@@ -1551,7 +1553,7 @@ describe('Link', () => {
         )
       },
       onError: indexOnError,
-      errorComponent: () => <span>IndexError</span>,
+      errorComponent: indexErrorComponent,
     })
 
     const error = new Error('Something went wrong!')
@@ -1596,6 +1598,7 @@ describe('Link', () => {
 
     await expect(screen.findByText('IndexError')).rejects.toThrow()
     expect(indexOnError).not.toHaveBeenCalledOnce()
+    expect(indexErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when navigating to /posts with a beforeLoad that redirects', async () => {

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -1529,7 +1529,7 @@ describe('Link', () => {
   test('when navigating away from a route with a loader that errors', async () => {
     const postsOnError = vi.fn()
     const indexOnError = vi.fn()
-    const indexErrorComponent = vi.fn(() => (<span>IndexError</span>))
+    const indexErrorComponent = vi.fn(() => <span>IndexError</span>)
 
     const rootRoute = createRootRoute({
       component: () => (


### PR DESCRIPTION
fixes https://github.com/TanStack/router/issues/7121

I have modified the `CatchBoundary` to reset the `error` together with the `resetKey` in `getDerivedStateFromProps`. This removes the need for `componentDidUpdate` to call `reset()`, and makes the render `resetKey` mismatch check redundant.

An existing test that was testing the exact case in https://github.com/TanStack/router/issues/7121 but for `onError` is slightly modified to also test no calls are made to `errorComponent`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error state management in error boundaries to better handle error clearing and reset when navigating between routes.

* **Tests**
  * Improved error component callback testing to verify proper behavior during route navigation with errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->