### PR TITLE
fix(start-plugin-core): strip middleware chain on client builds

### DIFF
--- a/packages/start-plugin-core/src/start-compiler-plugin/handleCreateServerFn.ts
+++ b/packages/start-plugin-core/src/start-compiler-plugin/handleCreateServerFn.ts
@@ -227,7 +227,7 @@ export function handleCreateServerFn(
 
   for (const candidate of candidates) {
     const { path: candidatePath, methodChain } = candidate
-    const { inputValidator, handler } = methodChain
+    const { inputValidator, handler, middleware } = methodChain
 
     // Check if the call is assigned to a variable
     if (!candidatePath.parentPath.isVariableDeclarator()) {
@@ -282,6 +282,13 @@ export function handleCreateServerFn(
       if (context.env === 'client') {
         stripMethodCall(inputValidator.callPath)
       }
+    }
+
+    // Handle middleware - remove on client to prevent server-only
+    // dependencies (auth, DB, etc.) from leaking into the client bundle.
+    // Middleware only executes server-side; the client RPC stub skips it.
+    if (middleware && context.env === 'client') {
+      stripMethodCall(middleware.callPath)
     }
 
     const handlerFnPath = handler?.firstArgPath

--- a/packages/start-plugin-core/tests/compiler.test.ts
+++ b/packages/start-plugin-core/tests/compiler.test.ts
@@ -434,6 +434,57 @@ describe('edge cases for detectedKinds', () => {
   })
 })
 
+describe('middleware stripping on client', () => {
+  test('strips .middleware() from createServerFn on client builds', async () => {
+    const compiler = createFullCompiler('client')
+
+    const result = await compiler.compile({
+      code: `
+        import { createServerFn } from '@tanstack/react-start'
+        import { authMiddleware } from './server-only-auth'
+        export const fetchData = createServerFn()
+          .middleware([authMiddleware])
+          .handler(async () => {
+            return { data: 'hello' }
+          })
+      `,
+      id: 'with-middleware.ts',
+
+      detectedKinds: new Set(['ServerFn']),
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.code).toContain('createClientRpc')
+    // Middleware should be stripped on client — server-only imports
+    // like authMiddleware must not survive into the client bundle
+    expect(result!.code).not.toContain('.middleware(')
+    expect(result!.code).not.toContain('authMiddleware')
+  })
+
+  test('preserves .middleware() on server builds', async () => {
+    const compiler = createFullCompiler('server')
+
+    const result = await compiler.compile({
+      code: `
+        import { createServerFn } from '@tanstack/react-start'
+        import { authMiddleware } from './server-only-auth'
+        export const fetchData = createServerFn()
+          .middleware([authMiddleware])
+          .handler(async () => {
+            return { data: 'hello' }
+          })
+      `,
+      id: 'with-middleware-server.ts',
+
+      detectedKinds: new Set(['ServerFn']),
+    })
+
+    expect(result).not.toBeNull()
+    // Server should keep middleware intact
+    expect(result!.code).toContain('authMiddleware')
+  })
+})
+
 test('ingestModule handles empty code gracefully', () => {
   const compiler = new StartCompiler({
     env: 'client',


### PR DESCRIPTION
## Summary

The `createServerFn` compiler correctly replaces `.handler(fn)` with `.handler(createClientRpc('hash'))` for client builds, and strips `.inputValidator()` — but leaves the `.middleware([...])` chain intact. This keeps server-only imports (auth middleware, DB connections, etc.) alive in the client bundle.

With esbuild (Vite 7/rolldown-vite), these dead references were tree-shaken. With Rolldown (Vite 8), the middleware functions remain as live symbol references, pulling the entire server dependency tree into the client bundle. This causes runtime crashes like:

```
ReferenceError: Buffer is not defined
    at server-BPubewzM.js:2:19645
```

...when Node.js-only packages (e.g. `postgres`) end up in the browser, preventing `hydrateRoot` from completing.

## Fix

Strip `.middleware()` calls on client builds using `stripMethodCall`, matching the existing pattern for `.inputValidator()`. Since middleware only executes server-side and the client RPC stub skips it entirely, the middleware chain is dead code on the client.

**Before (client build output):**
```js
const fn = createServerFn({method: 'GET'})
  .middleware([requireAuth, requirePermission('academic', 'read')])
  .handler(createClientRpc('hash'))
```

**After (client build output):**
```js
const fn = createServerFn({method: 'GET'})
  .handler(createClientRpc('hash'))
```

This makes the middleware imports (`requireAuth`, `requirePermission`) unreferenced, allowing the bundler to tree-shake the entire server dependency chain.

## Tests

Added two tests to `compiler.test.ts`:
- **`strips .middleware() from createServerFn on client builds`** — verifies `.middleware()` and the middleware import are removed from client output
- **`preserves .middleware() on server builds`** — verifies server builds keep middleware intact

## Context

- Filed as cloudflare/workers-sdk#13356 (root cause diagnosed there)
- Affects any TanStack Start app using `createServerFn().middleware([...])` with Vite 8
- Workaround: stub server-only modules in the client build via a Vite plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure middleware method calls are removed from client-side compiled output so middleware isn't executed or referenced in browser bundles.

* **Tests**
  * Added tests verifying middleware is stripped for client builds and preserved for server builds to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->