### PR TITLE
fix(react-router): clear stale route errors on navigation

### DIFF
--- a/.changeset/ten-cougars-jump.md
+++ b/.changeset/ten-cougars-jump.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+Fix a stale route error boundary state issue that could briefly render the next route's `errorComponent` after navigating away from a failed route.

--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -36,9 +36,12 @@ class CatchBoundaryImpl extends React.Component<{
   }) => React.ReactNode
   onCatch?: (error: Error, errorInfo: ErrorInfo) => void
 }> {
-  state = { error: null } as { error: Error | null; resetKey: string }
+  state = { error: null } as { error: Error | null; resetKey?: string | number }
 
-  static getDerivedStateFromProps(props: any, state: any) {
+  static getDerivedStateFromProps(
+    props: { getResetKey: () => string | number },
+    state: { resetKey?: string | number; error: Error | null },
+  ) {
     const resetKey = props.getResetKey()
 
     if (state.error && state.resetKey !== resetKey) {

--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -37,8 +37,15 @@ class CatchBoundaryImpl extends React.Component<{
   onCatch?: (error: Error, errorInfo: ErrorInfo) => void
 }> {
   state = { error: null } as { error: Error | null; resetKey: string }
-  static getDerivedStateFromProps(props: any) {
-    return { resetKey: props.getResetKey() }
+
+  static getDerivedStateFromProps(props: any, state: any) {
+    const resetKey = props.getResetKey()
+
+    if (state.error && state.resetKey !== resetKey) {
+      return { resetKey, error: null }
+    }
+
+    return { resetKey }
   }
   static getDerivedStateFromError(error: Error) {
     return { error }
@@ -46,30 +53,14 @@ class CatchBoundaryImpl extends React.Component<{
   reset() {
     this.setState({ error: null })
   }
-  componentDidUpdate(
-    prevProps: Readonly<{
-      getResetKey: () => string
-      children: (props: { error: any; reset: () => void }) => any
-      onCatch?: ((error: any, info: any) => void) | undefined
-    }>,
-    prevState: any,
-  ): void {
-    if (prevState.error && prevState.resetKey !== this.state.resetKey) {
-      this.reset()
-    }
-  }
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     if (this.props.onCatch) {
       this.props.onCatch(error, errorInfo)
     }
   }
   render() {
-    // If the resetKey has changed, don't render the error
     return this.props.children({
-      error:
-        this.state.resetKey !== this.props.getResetKey()
-          ? null
-          : this.state.error,
+      error: this.state.error,
       reset: () => {
         this.reset()
       },

--- a/packages/react-router/tests/errorComponent.test.tsx
+++ b/packages/react-router/tests/errorComponent.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 
 import {
   Link,
@@ -169,5 +169,92 @@ describe.each([true, false])(
         })
       },
     )
+
+    describe('stale route errors do not leak after navigation', () => {
+      test.each([
+        {
+          caller: 'loader' as const,
+          routeOptions: {
+            loader: throwFn,
+          },
+        },
+        {
+          caller: 'render' as const,
+          routeOptions: {
+            component: function RenderErrorComponent() {
+              throwFn()
+            },
+          },
+        },
+      ])(
+        'navigating away from a $caller error does not call the next route errorComponent',
+        async ({ routeOptions }) => {
+          const rootRoute = createRootRoute()
+          const indexErrorComponent = vi.fn(() => <div>Index error</div>)
+
+          const indexRoute = createRoute({
+            getParentRoute: () => rootRoute,
+            path: '/',
+            component: function Home() {
+              return (
+                <div>
+                  <div>Index route content</div>
+                  <Link to="/about">link to about</Link>
+                </div>
+              )
+            },
+            errorComponent: indexErrorComponent,
+          })
+
+          const aboutRoute = createRoute({
+            getParentRoute: () => rootRoute,
+            path: '/about',
+            component: function About() {
+              return <div>About route content</div>
+            },
+            errorComponent: isUsingLazyError ? undefined : MyErrorComponent,
+            ...routeOptions,
+          })
+
+          if (isUsingLazyError) {
+            aboutRoute.lazy(() =>
+              Promise.resolve(
+                createLazyRoute('/about')({
+                  errorComponent: MyErrorComponent,
+                }),
+              ),
+            )
+          }
+
+          const routeTree = rootRoute.addChildren([indexRoute, aboutRoute])
+
+          const router = createRouter({
+            routeTree,
+            history,
+          })
+
+          render(<RouterProvider router={router} />)
+
+          const linkToAbout = await screen.findByRole('link', {
+            name: 'link to about',
+          })
+
+          await act(() => fireEvent.click(linkToAbout))
+
+          expect(
+            await screen.findByText('Error: error thrown', undefined, {
+              timeout: 1500,
+            }),
+          ).toBeInTheDocument()
+
+          await act(() => router.navigate({ to: '/' }))
+
+          expect(
+            await screen.findByText('Index route content'),
+          ).toBeInTheDocument()
+          expect(indexErrorComponent).not.toHaveBeenCalled()
+        },
+      )
+    })
   },
 )


### PR DESCRIPTION
fixes #7121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an error boundary state issue where the error component from a failed route could briefly appear when navigating to a subsequent route.

* **Tests**
  * Added comprehensive test coverage to verify error states no longer leak across route navigations, including errors thrown from loaders and component rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->