### PR TITLE
fix: don't leak internal props in Link

### DIFF
--- a/.changeset/calm-walls-begin.md
+++ b/.changeset/calm-walls-begin.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+---
+
+Fix `Link` to keep internal routing props like `preloadIntentProximity`, `from`, and `unsafeRelative` from leaking to rendered DOM elements across React, Solid, and Vue.

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -64,6 +64,7 @@ export function useLinkProps<
     to,
     preload: userPreload,
     preloadDelay: userPreloadDelay,
+    preloadIntentProximity: _preloadIntentProximity,
     hashScrollIntoView,
     replace,
     startTransition,

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -177,6 +177,96 @@ describe('Link', () => {
     ).rejects.toThrow()
   })
 
+  test('does not forward internal Link props to the DOM', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const internalPropNames = [
+      'activeProps',
+      'inactiveProps',
+      'activeOptions',
+      'to',
+      'from',
+      'preload',
+      'preloadDelay',
+      'preloadIntentProximity',
+      'hashScrollIntoView',
+      'replace',
+      'startTransition',
+      'resetScroll',
+      'viewTransition',
+      'ignoreBlocker',
+      'params',
+      'search',
+      'hash',
+      'state',
+      'mask',
+      'reloadDocument',
+      'unsafeRelative',
+    ].map((propName) => propName.toLowerCase())
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <Link
+          to="/posts"
+          from="/"
+          activeProps={{ className: 'active' }}
+          inactiveProps={{ className: 'inactive' }}
+          activeOptions={{
+            exact: true,
+            includeHash: true,
+            includeSearch: true,
+          }}
+          preload="intent"
+          preloadDelay={50}
+          preloadIntentProximity={123}
+          hashScrollIntoView={true}
+          replace={true}
+          startTransition={true}
+          resetScroll={true}
+          viewTransition={true}
+          ignoreBlocker={true}
+          params={{}}
+          search={{ foo: 'bar' }}
+          hash="details"
+          state={{}}
+          mask={{ to: '/posts', hash: 'masked' }}
+          reloadDocument={true}
+          unsafeRelative="path"
+        >
+          Posts
+        </Link>
+      ),
+    })
+
+    const postsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      component: () => <h1>Posts</h1>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+      history,
+    })
+
+    render(<RouterProvider router={router} />)
+
+    const postsLink = await screen.findByRole('link', { name: 'Posts' })
+    const renderedAttributeNames = postsLink
+      .getAttributeNames()
+      .map((attributeName) => attributeName.toLowerCase())
+
+    for (const propName of internalPropNames) {
+      expect(renderedAttributeNames).not.toContain(propName)
+    }
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
   test('when the current route is the root', async () => {
     const rootRoute = createRootRoute()
     const indexRoute = createRoute({

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -63,6 +63,7 @@ export function useLinkProps<
       'to',
       'preload',
       'preloadDelay',
+      'preloadIntentProximity',
       'hashScrollIntoView',
       'replace',
       'startTransition',
@@ -120,6 +121,7 @@ export function useLinkProps<
     'mask',
     'reloadDocument',
     'unsafeRelative',
+    'from',
   ])
 
   const currentLocation = Solid.createMemo(

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -174,6 +174,90 @@ describe('Link', () => {
     ).rejects.toThrow()
   })
 
+  test('does not forward internal Link props to the DOM', async () => {
+    const internalPropNames = [
+      'activeProps',
+      'inactiveProps',
+      'activeOptions',
+      'to',
+      'from',
+      'preload',
+      'preloadDelay',
+      'preloadIntentProximity',
+      'hashScrollIntoView',
+      'replace',
+      'startTransition',
+      'resetScroll',
+      'viewTransition',
+      'ignoreBlocker',
+      'params',
+      'search',
+      'hash',
+      'state',
+      'mask',
+      'reloadDocument',
+      'unsafeRelative',
+    ].map((propName) => propName.toLowerCase())
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <Link
+          to="/posts"
+          from="/"
+          activeProps={{ class: 'active' }}
+          inactiveProps={{ class: 'inactive' }}
+          activeOptions={{
+            exact: true,
+            includeHash: true,
+            includeSearch: true,
+          }}
+          preload="intent"
+          preloadDelay={50}
+          preloadIntentProximity={123}
+          hashScrollIntoView={true}
+          replace={true}
+          startTransition={true}
+          resetScroll={true}
+          viewTransition={true}
+          ignoreBlocker={true}
+          params={{}}
+          search={{ foo: 'bar' }}
+          hash="details"
+          state={{}}
+          mask={{ to: '/posts', hash: 'masked' }}
+          reloadDocument={true}
+          unsafeRelative="path"
+        >
+          Posts
+        </Link>
+      ),
+    })
+
+    const postsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      component: () => <h1>Posts</h1>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+    })
+
+    render(() => <RouterProvider router={router} />)
+
+    const postsLink = await screen.findByRole('link', { name: 'Posts' })
+    const renderedAttributeNames = postsLink
+      .getAttributeNames()
+      .map((attributeName) => attributeName.toLowerCase())
+
+    for (const propName of internalPropNames) {
+      expect(renderedAttributeNames).not.toContain(propName)
+    }
+  })
+
   test('when a Link has children', async () => {
     const ChildComponent = vi.fn().mockReturnValue(<button>Posts</button>)
     const rootRoute = createRootRoute()

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -597,58 +597,57 @@ function getLinkEventHandlers(
   }
 }
 
-const propsUnsafeToSpread = new Set([
-  'activeProps',
-  'inactiveProps',
-  'activeOptions',
-  'to',
-  'preload',
-  'preloadDelay',
-  'hashScrollIntoView',
-  'replace',
-  'startTransition',
-  'resetScroll',
-  'viewTransition',
-  'children',
-  'target',
-  'disabled',
-  'style',
-  'class',
-  'onClick',
-  'onBlur',
-  'onFocus',
-  'onMouseEnter',
-  'onMouseenter',
-  'onMouseLeave',
-  'onMouseleave',
-  'onMouseOver',
-  'onMouseover',
-  'onMouseOut',
-  'onMouseout',
-  'onTouchStart',
-  'onTouchstart',
-  'ignoreBlocker',
-  'params',
-  'search',
-  'hash',
-  'state',
-  'mask',
-  'reloadDocument',
-  '_asChild',
-  'from',
-  'additionalProps',
-])
-
-// Create safe props that can be spread
 const getPropsSafeToSpread = (options: AnyLinkPropsOptions) => {
-  const result: Record<string, unknown> = {}
-  for (const key in options) {
-    if (!propsUnsafeToSpread.has(key)) {
-      result[key] = (options as Record<string, unknown>)[key]
-    }
+  const {
+    activeProps: _activeProps,
+    inactiveProps: _inactiveProps,
+    activeOptions: _activeOptions,
+    to: _to,
+    preload: _preload,
+    preloadDelay: _preloadDelay,
+    preloadIntentProximity: _preloadIntentProximity,
+    hashScrollIntoView: _hashScrollIntoView,
+    replace: _replace,
+    startTransition: _startTransition,
+    resetScroll: _resetScroll,
+    viewTransition: _viewTransition,
+    children: _children,
+    target: _target,
+    disabled: _disabled,
+    style: _style,
+    class: _class,
+    onClick: _onClick,
+    onBlur: _onBlur,
+    onFocus: _onFocus,
+    onMouseEnter: _onMouseEnter,
+    onMouseenter: _onMouseenter,
+    onMouseLeave: _onMouseLeave,
+    onMouseleave: _onMouseleave,
+    onMouseOver: _onMouseOver,
+    onMouseover: _onMouseover,
+    onMouseOut: _onMouseOut,
+    onMouseout: _onMouseout,
+    onTouchStart: _onTouchStart,
+    onTouchstart: _onTouchstart,
+    ignoreBlocker: _ignoreBlocker,
+    params: _params,
+    search: _search,
+    hash: _hash,
+    state: _state,
+    mask: _mask,
+    reloadDocument: _reloadDocument,
+    unsafeRelative: _unsafeRelative,
+    _asChild: __asChild,
+    from: _from,
+    additionalProps: _additionalProps,
+    ...propsSafeToSpread
+  } = options as AnyLinkPropsOptions & {
+    additionalProps?: unknown
+    children?: unknown
+    _asChild?: unknown
   }
 
-  return result
+  return propsSafeToSpread
 }
 
 function getIsActive({
@@ -872,6 +871,7 @@ const LinkImpl = Vue.defineComponent({
     'to',
     'preload',
     'preloadDelay',
+    'preloadIntentProximity',
     'activeProps',
     'inactiveProps',
     'activeOptions',

--- a/packages/vue-router/tests/link.test.tsx
+++ b/packages/vue-router/tests/link.test.tsx
@@ -173,6 +173,90 @@ describe('Link', () => {
     ).rejects.toThrow()
   })
 
+  test('does not forward internal Link props to the DOM', async () => {
+    const internalPropNames = [
+      'activeProps',
+      'inactiveProps',
+      'activeOptions',
+      'to',
+      'from',
+      'preload',
+      'preloadDelay',
+      'preloadIntentProximity',
+      'hashScrollIntoView',
+      'replace',
+      'startTransition',
+      'resetScroll',
+      'viewTransition',
+      'ignoreBlocker',
+      'params',
+      'search',
+      'hash',
+      'state',
+      'mask',
+      'reloadDocument',
+      'unsafeRelative',
+    ].map((propName) => propName.toLowerCase())
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <Link
+          to="/posts"
+          from="/"
+          activeProps={{ class: 'active' }}
+          inactiveProps={{ class: 'inactive' }}
+          activeOptions={{
+            exact: true,
+            includeHash: true,
+            includeSearch: true,
+          }}
+          preload="intent"
+          preloadDelay={50}
+          preloadIntentProximity={123}
+          hashScrollIntoView={true}
+          replace={true}
+          startTransition={true}
+          resetScroll={true}
+          viewTransition={true}
+          ignoreBlocker={true}
+          params={{}}
+          search={{ foo: 'bar' }}
+          hash="details"
+          state={{}}
+          mask={{ to: '/posts', hash: 'masked' }}
+          reloadDocument={true}
+          unsafeRelative="path"
+        >
+          Posts
+        </Link>
+      ),
+    })
+
+    const postsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      component: () => <h1>Posts</h1>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+    })
+
+    render(<RouterProvider router={router} />)
+
+    const postsLink = await screen.findByRole('link', { name: 'Posts' })
+    const renderedAttributeNames = postsLink
+      .getAttributeNames()
+      .map((attributeName) => attributeName.toLowerCase())
+
+    for (const propName of internalPropNames) {
+      expect(renderedAttributeNames).not.toContain(propName)
+    }
+  })
+
   test('when a Link has children', async () => {
     const ChildComponent = vi.fn().mockReturnValue(<button>Posts</button>)
     const rootRoute = createRootRoute()

--- a/packages/vue-router/tests/setupTests.tsx
+++ b/packages/vue-router/tests/setupTests.tsx
@@ -1,4 +1,8 @@
 import '@testing-library/jest-dom/vitest'
+import { vi } from 'vitest'
 
 // For @testing-library to work properly with Vue tests
 // global.IS_REACT_ACT_ENVIRONMENT = true
+
+// Mock window.scrollTo to silence jsdom errors in tests
+window.scrollTo = vi.fn()


### PR DESCRIPTION
fixes #7127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed internal routing configuration properties from being unintentionally added to rendered link elements in React Router, Solid Router, and Vue Router. This prevents unexpected HTML attributes from appearing on links and improves DOM cleanliness.

* **Tests**
  * Added comprehensive tests to ensure internal routing properties are properly isolated and don't leak to the DOM across all router implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->