### PR TITLE
fix: MatchRoute types

### DIFF
--- a/.changeset/fair-phones-grow.md
+++ b/.changeset/fair-phones-grow.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+---
+
+Fix `MatchRoute` child callback param inference to resolve params from the target `to` route instead of the route path key across React, Solid, and Vue adapters.

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -22,11 +22,8 @@ import type {
   MakeRouteMatchUnion,
   MaskOptions,
   MatchRouteOptions,
-  NoInfer,
   RegisteredRouter,
-  ResolveRelativePath,
   ResolveRoute,
-  RouteByPath,
   ToSubOptionsProps,
 } from '@tanstack/router-core'
 
@@ -180,10 +177,9 @@ export type MakeMatchRouteOptions<
   // If a function is passed as a child, it will be given the `isActive` boolean to aid in further styling on the element it returns
   children?:
     | ((
-        params?: RouteByPath<
-          TRouter['routeTree'],
-          ResolveRelativePath<TFrom, NoInfer<TTo>>
-        >['types']['allParams'],
+        params?: Expand<
+          ResolveRoute<TRouter, TFrom, TTo>['types']['allParams']
+        >,
       ) => React.ReactNode)
     | React.ReactNode
 }

--- a/packages/react-router/tests/Matches.test-d.tsx
+++ b/packages/react-router/tests/Matches.test-d.tsx
@@ -1,4 +1,6 @@
 import { expectTypeOf, test } from 'vitest'
+import type * as React from 'react'
+import type { MakeMatchRouteOptions } from '../src'
 import {
   MatchRoute,
   createRootRoute,
@@ -232,4 +234,20 @@ test('when filtering useMatches by loaderData with an array', () => {
   expectTypeOf(
     matches.filter((match) => isMatch(match, 'loaderData.0.comment')),
   ).toEqualTypeOf<Array<CommentsMatch>>()
+})
+
+test('MatchRoute children are typed from resolved params under pathless layouts', () => {
+  type CommentsMatchRouteChildren = MakeMatchRouteOptions<
+    DefaultRouter,
+    string,
+    '/comments/$id'
+  >['children']
+  type CommentsMatchRouteRenderFn = Extract<
+    CommentsMatchRouteChildren,
+    (...args: Array<any>) => any
+  >
+
+  expectTypeOf<CommentsMatchRouteRenderFn>().toEqualTypeOf<
+    (params?: { id: string } | undefined) => React.ReactNode
+  >()
 })

--- a/packages/react-router/tests/Matches.test-d.tsx
+++ b/packages/react-router/tests/Matches.test-d.tsx
@@ -1,6 +1,4 @@
 import { expectTypeOf, test } from 'vitest'
-import type * as React from 'react'
-import type { MakeMatchRouteOptions } from '../src'
 import {
   MatchRoute,
   createRootRoute,
@@ -10,7 +8,8 @@ import {
   useMatchRoute,
   useMatches,
 } from '../src'
-import type { AnyRouteMatch, RouteMatch } from '../src'
+import type * as React from 'react'
+import type { AnyRouteMatch, MakeMatchRouteOptions, RouteMatch } from '../src'
 
 const rootRoute = createRootRoute()
 

--- a/packages/solid-router/src/Matches.tsx
+++ b/packages/solid-router/src/Matches.tsx
@@ -17,11 +17,8 @@ import type {
   MakeRouteMatchUnion,
   MaskOptions,
   MatchRouteOptions,
-  NoInfer,
   RegisteredRouter,
-  ResolveRelativePath,
   ResolveRoute,
-  RouteByPath,
   ToSubOptionsProps,
 } from '@tanstack/router-core'
 
@@ -166,10 +163,9 @@ export type MakeMatchRouteOptions<
   // If a function is passed as a child, it will be given the `isActive` boolean to aid in further styling on the element it returns
   children?:
     | ((
-        params?: RouteByPath<
-          TRouter['routeTree'],
-          ResolveRelativePath<TFrom, NoInfer<TTo>>
-        >['types']['allParams'],
+        params?: Expand<
+          ResolveRoute<TRouter, TFrom, TTo>['types']['allParams']
+        >,
       ) => Solid.JSX.Element)
     | Solid.JSX.Element
 }

--- a/packages/solid-router/tests/Matches.test-d.tsx
+++ b/packages/solid-router/tests/Matches.test-d.tsx
@@ -1,4 +1,5 @@
 import { expectTypeOf, test } from 'vitest'
+import type { MakeMatchRouteOptions } from '../src'
 import {
   MatchRoute,
   createRootRoute,
@@ -233,4 +234,20 @@ test('when filtering useMatches by loaderData with an array', () => {
   expectTypeOf(
     matches.filter((match) => isMatch(match, 'loaderData.0.comment')),
   ).toEqualTypeOf<Array<CommentsMatch>>()
+})
+
+test('MatchRoute children are typed from resolved params under pathless layouts', () => {
+  type CommentsMatchRouteChildren = MakeMatchRouteOptions<
+    DefaultRouter,
+    string,
+    '/comments/$id'
+  >['children']
+  type CommentsMatchRouteRenderFn = Extract<
+    CommentsMatchRouteChildren,
+    (...args: Array<any>) => any
+  >
+
+  expectTypeOf<CommentsMatchRouteRenderFn>().toEqualTypeOf<
+    (params?: { id: string } | undefined) => Solid.JSX.Element
+  >()
 })

--- a/packages/solid-router/tests/Matches.test-d.tsx
+++ b/packages/solid-router/tests/Matches.test-d.tsx
@@ -1,5 +1,4 @@
 import { expectTypeOf, test } from 'vitest'
-import type { MakeMatchRouteOptions } from '../src'
 import {
   MatchRoute,
   createRootRoute,
@@ -11,6 +10,7 @@ import {
 } from '../src'
 import type { AnyRouteMatch, RouteMatch } from '@tanstack/router-core'
 import type * as Solid from 'solid-js'
+import type { MakeMatchRouteOptions } from '../src'
 
 const rootRoute = createRootRoute()
 

--- a/packages/vue-router/src/Matches.tsx
+++ b/packages/vue-router/src/Matches.tsx
@@ -15,11 +15,8 @@ import type {
   MakeRouteMatchUnion,
   MaskOptions,
   MatchRouteOptions,
-  NoInfer,
   RegisteredRouter,
-  ResolveRelativePath,
   ResolveRoute,
-  RouteByPath,
   ToSubOptionsProps,
 } from '@tanstack/router-core'
 
@@ -198,10 +195,7 @@ export type MakeMatchRouteOptions<
   // If a function is passed as a child, it will be given the `isActive` boolean to aid in further styling on the element it returns
   children?:
     | ((
-        params?: RouteByPath<
-          TRouter['routeTree'],
-          ResolveRelativePath<TFrom, NoInfer<TTo>>
-        >['types']['allParams'],
+        params?: ResolveRoute<TRouter, TFrom, TTo>['types']['allParams'],
       ) => Vue.VNode)
     | Vue.VNode
 }


### PR DESCRIPTION
fixes #7128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type inference for MatchRoute children callbacks so route parameters are resolved from the target route, improving accurate parameter types in child render functions across React, Solid, and Vue adapters.

* **Tests**
  * Added type-level tests to validate the corrected parameter inference for children render callbacks.

* **Documentation**
  * Added a changeset entry to mark the patch releases reflecting this fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->