### PR TITLE
fix(start): add missing changeset for start-server-core

### DIFF
--- a/.changeset/fix-start-server-core-release.md
+++ b/.changeset/fix-start-server-core-release.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-server-core': patch
+---
+
+Publish `start-server-core` with the `pluginAdapters` virtual module added in #7144, fixing a crash in `start-plugin-core@1.167.19` where `VIRTUAL_MODULES.pluginAdapters` is undefined.


### PR DESCRIPTION
PR #7144 added `pluginAdapters` to `VIRTUAL_MODULES` in `start-server-core` but the follow-up changeset only bumped `start-plugin-core`. The release bot published `start-plugin-core@1.167.19` with code that calls `VIRTUAL_MODULES.pluginAdapters.replace(...)`, while `start-server-core` stayed at `1.167.10` where `pluginAdapters` is `undefined`.

Anyone on `^1.166.x` or `^1.167.x` of `@tanstack/react-start` hits this on `vite dev`:

```
TypeError: Cannot read properties of undefined (reading 'replace')
    at serialization-adapters-plugin.js:6:69
```

This changeset adds the missing `@tanstack/start-server-core: patch` bump so the next release publishes `start-server-core` with the `pluginAdapters` export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Released a patch that restores a missing runtime component, preventing crashes during server startup and ensuring plugins initialize properly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->