### PR TITLE
docs: fix file extension syntax for prefix/suffix routing examples

### DIFF
--- a/docs/router/guide/path-params.md
+++ b/docs/router/guide/path-params.md
@@ -317,7 +317,7 @@ You can combine both prefixes and suffixes to create very specific routing patte
 
 # React
 
-```tsx title="src/routes/users/user-{$userId}.json"
+```tsx title="src/routes/users/user-{$userId}[.]json.tsx"
 export const Route = createFileRoute('/users/user-{$userId}.json')({
   component: UserComponent,
 })
@@ -331,7 +331,7 @@ function UserComponent() {
 
 # Solid
 
-```tsx title="src/routes/users/user-{$userId}.json"
+```tsx title="src/routes/users/user-{$userId}[.]json.tsx"
 export const Route = createFileRoute('/users/user-{$userId}.json')({
   component: UserComponent,
 })
@@ -455,7 +455,7 @@ Optional parameters support prefix and suffix patterns:
 
 # React
 
-```tsx title="src/routes/files/prefix{-$name}.txt"
+```tsx title="src/routes/files/prefix{-$name}[.]txt.tsx"
 // Route: /files/prefix{-$name}.txt
 // Matches: /files/prefix.txt and /files/prefixdocument.txt
 export const Route = createFileRoute('/files/prefix{-$name}.txt')({
@@ -470,7 +470,7 @@ function FileComponent() {
 
 # Solid
 
-```tsx title="src/routes/files/prefix{-$name}.txt"
+```tsx title="src/routes/files/prefix{-$name}[.]txt.tsx"
 // Route: /files/prefix{-$name}.txt
 // Matches: /files/prefix.txt and /files/prefixdocument.txt
 export const Route = createFileRoute('/files/prefix{-$name}.txt')({


### PR DESCRIPTION
### Description

This PR fixes a syntax error in the file names provided in the documentation for prefix and suffix routing patterns (applicable to both React and Solid docs).

Currently, the documentation examples show file names ending directly with `.json` and `.txt` (e.g., `user-{$userId}.json`). According to TanStack Router's file-based routing conventions, literal dots in the URL path must be escaped using brackets `[.]`, and the file itself must have a valid component extension (like `.tsx`) to properly export the route component.

### Changes Made
Updated the file path examples in the "Combining Prefixes and Suffixes" and "Advanced Optional Parameter Patterns" sections:
- `src/routes/users/user-{$userId}.json` ➡️ `src/routes/users/user-{$userId}[.]json.tsx`
- `src/routes/files/prefix{-$name}.txt` ➡️ `src/routes/files/prefix{-$name}[.]txt.tsx`

### Motivation
To prevent confusion for new developers copying the file names directly from the documentation, ensuring the examples strictly follow the `[.]` escaping convention for literal dots in paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in routing guide to reflect current syntax conventions for optional suffixes and patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->