### PR TITLE
refactor: switch router stores to atom get/set API

### DIFF
--- a/.changeset/yummy-eagles-work.md
+++ b/.changeset/yummy-eagles-work.md
@@ -1,0 +1,16 @@
+---
+'@tanstack/router-ssr-query-core': patch
+'@tanstack/router-devtools-core': patch
+'@tanstack/start-client-core': patch
+'@tanstack/start-server-core': patch
+'@tanstack/router-plugin': patch
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/react-start': patch
+'@tanstack/router-core': patch
+'@tanstack/solid-start': patch
+'@tanstack/vue-router': patch
+'@tanstack/vue-start': patch
+---
+
+migrate createStore > createAtom for simpler API

--- a/e2e/react-start/hmr/tests/app.spec.ts
+++ b/e2e/react-start/hmr/tests/app.spec.ts
@@ -142,9 +142,9 @@ async function waitForRouteLoaderCrumb(
 async function waitForRouteRemovalReload(page: Page) {
   await page.waitForFunction(() => {
     const router = (window as any).__TSR_ROUTER__
-    const match = router?.stores?.activeMatchesSnapshot?.state?.find(
-      (entry: any) => entry.routeId === '/child',
-    )
+    const match = router?.stores?.activeMatchesSnapshot
+      ?.get()
+      ?.find((entry: any) => entry.routeId === '/child')
 
     return !match?.invalid && match?.isFetching === false
   })

--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -30,7 +30,7 @@ export const Match = React.memo(function MatchImpl({
   const router = useRouter()
 
   if (isServer ?? router.isServer) {
-    const match = router.stores.activeMatchStoresById.get(matchId)?.state
+    const match = router.stores.activeMatchStoresById.get(matchId)?.get()
     if (!match) {
       if (process.env.NODE_ENV !== 'production') {
         throw new Error(
@@ -49,7 +49,7 @@ export const Match = React.memo(function MatchImpl({
       <MatchView
         router={router}
         matchId={matchId}
-        resetKey={router.stores.loadedAt.state}
+        resetKey={router.stores.loadedAt.get()}
         matchState={{
           routeId,
           ssr: match.ssr,
@@ -243,8 +243,8 @@ function OnRendered({ resetKey }: { resetKey: number }) {
       router.emit({
         type: 'onRendered',
         ...getLocationChangeInfo(
-          router.stores.location.state,
-          router.stores.resolvedLocation.state,
+          router.stores.location.get(),
+          router.stores.resolvedLocation.get(),
         ),
       })
       prevHrefRef.current = currentHref
@@ -278,7 +278,7 @@ export const MatchInner = React.memo(function MatchInnerImpl({
   }
 
   if (isServer ?? router.isServer) {
-    const match = router.stores.activeMatchStoresById.get(matchId)?.state
+    const match = router.stores.activeMatchStoresById.get(matchId)?.get()
     if (!match) {
       if (process.env.NODE_ENV !== 'production') {
         throw new Error(
@@ -504,7 +504,7 @@ export const Outlet = React.memo(function OutletImpl() {
   let childMatchId: string | undefined
 
   if (isServer ?? router.isServer) {
-    const matches = router.stores.activeMatchesSnapshot.state
+    const matches = router.stores.activeMatchesSnapshot.get()
     const parentIndex = matchId
       ? matches.findIndex((match) => match.id === matchId)
       : -1

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -77,11 +77,11 @@ function MatchesInner() {
   const router = useRouter()
   const _isServer = isServer ?? router.isServer
   const matchId = _isServer
-    ? router.stores.firstMatchId.state
+    ? router.stores.firstMatchId.get()
     : // eslint-disable-next-line react-hooks/rules-of-hooks
       useStore(router.stores.firstMatchId, (id) => id)
   const resetKey = _isServer
-    ? router.stores.loadedAt.state
+    ? router.stores.loadedAt.get()
     : // eslint-disable-next-line react-hooks/rules-of-hooks
       useStore(router.stores.loadedAt, (loadedAt) => loadedAt)
 
@@ -240,7 +240,7 @@ export function useMatches<
     )
 
   if (isServer ?? router.isServer) {
-    const matches = router.stores.activeMatchesSnapshot.state as Array<
+    const matches = router.stores.activeMatchesSnapshot.get() as Array<
       MakeRouteMatchUnion<TRouter>
     >
     return (opts?.select ? opts.select(matches) : matches) as UseMatchesResult<

--- a/packages/react-router/src/Scripts.tsx
+++ b/packages/react-router/src/Scripts.tsx
@@ -59,9 +59,9 @@ export const Scripts = () => {
 
   if (isServer ?? router.isServer) {
     const assetScripts = getAssetScripts(
-      router.stores.activeMatchesSnapshot.state,
+      router.stores.activeMatchesSnapshot.get(),
     )
-    const scripts = getScripts(router.stores.activeMatchesSnapshot.state)
+    const scripts = getScripts(router.stores.activeMatchesSnapshot.get())
     return renderScripts(router, scripts, assetScripts)
   }
 

--- a/packages/react-router/src/Scripts.tsx
+++ b/packages/react-router/src/Scripts.tsx
@@ -58,10 +58,9 @@ export const Scripts = () => {
     )
 
   if (isServer ?? router.isServer) {
-    const assetScripts = getAssetScripts(
-      router.stores.activeMatchesSnapshot.get(),
-    )
-    const scripts = getScripts(router.stores.activeMatchesSnapshot.get())
+    const activeMatches = router.stores.activeMatchesSnapshot.get()
+    const assetScripts = getAssetScripts(activeMatches)
+    const scripts = getScripts(activeMatches)
     return renderScripts(router, scripts, assetScripts)
   }
 

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -96,8 +96,8 @@ export function Transitioner() {
       router.emit({
         type: 'onLoad', // When the new URL has committed, when the new matches have been loaded into state.matches
         ...getLocationChangeInfo(
-          router.stores.location.state,
-          router.stores.resolvedLocation.state,
+          router.stores.location.get(),
+          router.stores.resolvedLocation.get(),
         ),
       })
     }
@@ -109,8 +109,8 @@ export function Transitioner() {
       router.emit({
         type: 'onBeforeRouteMount',
         ...getLocationChangeInfo(
-          router.stores.location.state,
-          router.stores.resolvedLocation.state,
+          router.stores.location.get(),
+          router.stores.resolvedLocation.get(),
         ),
       })
     }
@@ -119,8 +119,8 @@ export function Transitioner() {
   useLayoutEffect(() => {
     if (previousIsAnyPending && !isAnyPending) {
       const changeInfo = getLocationChangeInfo(
-        router.stores.location.state,
-        router.stores.resolvedLocation.state,
+        router.stores.location.get(),
+        router.stores.resolvedLocation.get(),
       )
       router.emit({
         type: 'onResolved',
@@ -128,9 +128,9 @@ export function Transitioner() {
       })
 
       batch(() => {
-        router.stores.status.setState(() => 'idle')
-        router.stores.resolvedLocation.setState(
-          () => router.stores.location.state,
+        router.stores.status.set(() => 'idle')
+        router.stores.resolvedLocation.set(
+          () => router.stores.location.get(),
         )
       })
 

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -129,9 +129,7 @@ export function Transitioner() {
 
       batch(() => {
         router.stores.status.set(() => 'idle')
-        router.stores.resolvedLocation.set(
-          () => router.stores.location.get(),
-        )
+        router.stores.resolvedLocation.set(() => router.stores.location.get())
       })
 
       if (changeInfo.hrefChanged) {

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -128,8 +128,8 @@ export function Transitioner() {
       })
 
       batch(() => {
-        router.stores.status.set(() => 'idle')
-        router.stores.resolvedLocation.set(() => router.stores.location.get())
+        router.stores.status.set('idle')
+        router.stores.resolvedLocation.set(router.stores.location.get())
       })
 
       if (changeInfo.hrefChanged) {

--- a/packages/react-router/src/headContentUtils.tsx
+++ b/packages/react-router/src/headContentUtils.tsx
@@ -194,7 +194,7 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
     return buildTagsFromMatches(
       router,
       nonce,
-      router.stores.activeMatchesSnapshot.state,
+      router.stores.activeMatchesSnapshot.get(),
       assetCrossOrigin,
     )
   }

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -207,7 +207,7 @@ export function useLinkProps<
     const isActive = (() => {
       if (externalLink) return false
 
-      const currentLocation = router.stores.location.state
+      const currentLocation = router.stores.location.get()
 
       const exact = activeOptions?.exact ?? false
 

--- a/packages/react-router/src/not-found.tsx
+++ b/packages/react-router/src/not-found.tsx
@@ -15,8 +15,8 @@ export function CatchNotFound(props: {
   const router = useRouter()
 
   if (isServer ?? router.isServer) {
-    const pathname = router.stores.location.state.pathname
-    const status = router.stores.status.state
+    const pathname = router.stores.location.get().pathname
+    const status = router.stores.status.get()
     const resetKey = `not-found-${pathname}-${status}`
 
     return (

--- a/packages/react-router/src/routerStores.ts
+++ b/packages/react-router/src/routerStores.ts
@@ -1,4 +1,4 @@
-import { batch, createStore } from '@tanstack/react-store'
+import { batch, createAtom } from '@tanstack/react-store'
 import {
   createNonReactiveMutableStore,
   createNonReactiveReadonlyStore,
@@ -19,8 +19,8 @@ export const getStoreFactory: GetStoreConfig = (opts) => {
     }
   }
   return {
-    createMutableStore: createStore,
-    createReadonlyStore: createStore,
+    createMutableStore: createAtom,
+    createReadonlyStore: createAtom,
     batch: batch,
   }
 }

--- a/packages/react-router/src/ssr/RouterClient.tsx
+++ b/packages/react-router/src/ssr/RouterClient.tsx
@@ -7,7 +7,7 @@ let hydrationPromise: Promise<void | Array<Array<void>>> | undefined
 
 export function RouterClient(props: { router: AnyRouter }) {
   if (!hydrationPromise) {
-    if (!props.router.stores.matchesId.state.length) {
+    if (!props.router.stores.matchesId.get().length) {
       hydrationPromise = hydrate(props.router)
     } else {
       hydrationPromise = Promise.resolve()

--- a/packages/react-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/react-router/src/ssr/renderRouterToStream.tsx
@@ -36,7 +36,7 @@ export const renderRouterToStream = async ({
       stream as unknown as ReadableStream,
     )
     return new Response(responseStream as any, {
-      status: router.stores.statusCode.state,
+      status: router.stores.statusCode.get(),
       headers: responseHeaders,
     })
   }
@@ -79,7 +79,7 @@ export const renderRouterToStream = async ({
       reactAppPassthrough,
     )
     return new Response(responseStream as any, {
-      status: router.stores.statusCode.state,
+      status: router.stores.statusCode.get(),
       headers: responseHeaders,
     })
   }

--- a/packages/react-router/src/ssr/renderRouterToString.tsx
+++ b/packages/react-router/src/ssr/renderRouterToString.tsx
@@ -21,7 +21,7 @@ export const renderRouterToString = async ({
     }
 
     return new Response(`<!DOCTYPE html>${html}`, {
-      status: router.stores.statusCode.state,
+      status: router.stores.statusCode.get(),
       headers: responseHeaders,
     })
   } catch (error) {

--- a/packages/react-router/src/useCanGoBack.ts
+++ b/packages/react-router/src/useCanGoBack.ts
@@ -6,7 +6,7 @@ export function useCanGoBack() {
   const router = useRouter()
 
   if (isServer ?? router.isServer) {
-    return router.stores.location.state.state.__TSR_index !== 0
+    return router.stores.location.get().state.__TSR_index !== 0
   }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static

--- a/packages/react-router/src/useLocation.tsx
+++ b/packages/react-router/src/useLocation.tsx
@@ -52,7 +52,7 @@ export function useLocation<
   const router = useRouter<TRouter>()
 
   if (isServer ?? router.isServer) {
-    const location = router.stores.location.state
+    const location = router.stores.location.get()
     return (
       opts?.select ? opts.select(location as any) : location
     ) as UseLocationResult<TRouter, TSelected>

--- a/packages/react-router/src/useMatch.tsx
+++ b/packages/react-router/src/useMatch.tsx
@@ -21,9 +21,8 @@ import type {
 } from '@tanstack/router-core'
 
 const dummyStore = {
-  state: undefined,
   get: () => undefined,
-  subscribe: () => () => {},
+  subscribe: () => ({ unsubscribe: () => {} }),
 } as any
 
 export interface UseMatchBaseOptions<
@@ -119,7 +118,7 @@ export function useMatch<
     : undefined
 
   if (isServer ?? router.isServer) {
-    const match = matchStore?.state
+    const match = matchStore?.get()
     if ((opts.shouldThrow ?? true) && !match) {
       if (process.env.NODE_ENV !== 'production') {
         throw new Error(

--- a/packages/react-router/src/useRouterState.tsx
+++ b/packages/react-router/src/useRouterState.tsx
@@ -59,7 +59,7 @@ export function useRouterState<
   // Avoid subscribing to the store (and any structural sharing work) on the server.
   const _isServer = isServer ?? router.isServer
   if (_isServer) {
-    const state = router.stores.__store.state as RouterState<
+    const state = router.stores.__store.get() as RouterState<
       TRouter['routeTree']
     >
     return (opts?.select ? opts.select(state) : state) as UseRouterStateResult<

--- a/packages/react-start/src/useServerFn.ts
+++ b/packages/react-start/src/useServerFn.ts
@@ -18,7 +18,7 @@ export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
         return res
       } catch (err) {
         if (isRedirect(err)) {
-          err.options._fromLocation = router.stores.location.state
+          err.options._fromLocation = router.stores.location.get()
           return router.navigate(router.resolveRedirect(err).options)
         }
 

--- a/packages/router-core/src/hash-scroll.ts
+++ b/packages/router-core/src/hash-scroll.ts
@@ -7,7 +7,7 @@ import type { AnyRouter } from './router'
  */
 export function handleHashScroll(router: AnyRouter) {
   if (typeof document !== 'undefined' && (document as any).querySelector) {
-    const location = router.stores.location.state
+    const location = router.stores.location.get()
     const hashScrollIntoViewOptions =
       location.state.__hashScrollIntoViewOptions ?? true
 

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -45,8 +45,8 @@ const triggerOnReady = (inner: InnerLoadContext): void | Promise<void> => {
 }
 
 const hasForcePendingActiveMatch = (router: AnyRouter): boolean => {
-  return router.stores.matchesId.state.some((matchId) => {
-    return router.stores.activeMatchStoresById.get(matchId)?.state._forcePending
+  return router.stores.matchesId.get().some((matchId) => {
+    return router.stores.activeMatchStoresById.get(matchId)?.get()._forcePending
   })
 }
 
@@ -879,7 +879,7 @@ const loadRouteMatch = async (
     }
   } else {
     const prevMatch = inner.router.getMatch(matchId)! // This is where all of the stale-while-revalidate magic happens
-    const activeIdAtIndex = inner.router.stores.matchesId.state[index]
+    const activeIdAtIndex = inner.router.stores.matchesId.get()[index]
     const activeAtIndex =
       (activeIdAtIndex &&
         inner.router.stores.activeMatchStoresById.get(activeIdAtIndex)) ||
@@ -887,9 +887,9 @@ const loadRouteMatch = async (
     const previousRouteMatchId =
       activeAtIndex?.routeId === routeId
         ? activeIdAtIndex
-        : inner.router.stores.activeMatchesSnapshot.state.find(
-            (d) => d.routeId === routeId,
-          )?.id
+        : inner.router.stores.activeMatchesSnapshot
+            .get()
+            .find((d) => d.routeId === routeId)?.id
     const preload = resolvePreload(inner, matchId)
 
     // there is a loaderPromise, so we are in the middle of a load

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1169,7 +1169,7 @@ export class RouterCore<
     }
 
     if (needsLocationUpdate && this.stores) {
-      this.stores.location.set(() => this.latestLocation)
+      this.stores.location.set(this.latestLocation)
     }
 
     if (
@@ -2362,10 +2362,10 @@ export class RouterCore<
 
     // Ingest the new matches
     this.batch(() => {
-      this.stores.status.set(() => 'pending')
-      this.stores.statusCode.set(() => 200)
-      this.stores.isLoading.set(() => true)
-      this.stores.location.set(() => this.latestLocation)
+      this.stores.status.set('pending')
+      this.stores.statusCode.set(200)
+      this.stores.isLoading.set(true)
+      this.stores.location.set(this.latestLocation)
       this.stores.setPendingMatches(pendingMatches)
       // If a cached match moved to pending matches, remove it from cached matches
       this.stores.setCachedMatches(nextCachedMatches)
@@ -2468,8 +2468,8 @@ export class RouterCore<
                         )
                       : currentMatches
 
-                    this.stores.isLoading.set(() => false)
-                    this.stores.loadedAt.set(() => Date.now())
+                    this.stores.isLoading.set(false)
+                    this.stores.loadedAt.set(Date.now())
                     /**
                      * When committing new matches, cache any exiting matches that are still usable.
                      * Routes that resolved with `status: 'error'` or `status: 'notFound'` are
@@ -2534,8 +2534,8 @@ export class RouterCore<
                 : 200
 
           this.batch(() => {
-            this.stores.statusCode.set(() => nextStatusCode)
-            this.stores.redirect.set(() => redirect)
+            this.stores.statusCode.set(nextStatusCode)
+            this.stores.redirect.set(redirect)
           })
         }
 
@@ -2569,7 +2569,7 @@ export class RouterCore<
       newStatusCode = 500
     }
     if (newStatusCode !== undefined) {
-      this.stores.statusCode.set(() => newStatusCode)
+      this.stores.statusCode.set(newStatusCode)
     }
   }
 
@@ -2651,7 +2651,7 @@ export class RouterCore<
             )
           }
         } else {
-          cachedMatch.set(() => next)
+          cachedMatch.set(next)
         }
       }
     })

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1169,7 +1169,7 @@ export class RouterCore<
     }
 
     if (needsLocationUpdate && this.stores) {
-      this.stores.location.setState(() => this.latestLocation)
+      this.stores.location.set(() => this.latestLocation)
     }
 
     if (
@@ -1184,7 +1184,7 @@ export class RouterCore<
   }
 
   get state(): RouterState<TRouteTree> {
-    return this.stores.__store.state
+    return this.stores.__store.get()
   }
 
   updateLatestLocation = () => {
@@ -1422,7 +1422,7 @@ export class RouterCore<
     const previousActiveMatchesByRouteId = new Map<string, AnyRouteMatch>()
     for (const store of this.stores.activeMatchStoresById.values()) {
       if (store.routeId) {
-        previousActiveMatchesByRouteId.set(store.routeId, store.state)
+        previousActiveMatchesByRouteId.set(store.routeId, store.get())
       }
     }
 
@@ -1715,10 +1715,10 @@ export class RouterCore<
     }
 
     // Determine params: reuse from state if possible, otherwise parse
-    const lastStateMatchId = last(this.stores.matchesId.state)
+    const lastStateMatchId = last(this.stores.matchesId.get())
     const lastStateMatch =
       lastStateMatchId &&
-      this.stores.activeMatchStoresById.get(lastStateMatchId)?.state
+      this.stores.activeMatchStoresById.get(lastStateMatchId)?.get()
     const canReuseParams =
       lastStateMatch &&
       lastStateMatch.routeId === lastRoute.id &&
@@ -1767,16 +1767,16 @@ export class RouterCore<
   }
 
   cancelMatches = () => {
-    this.stores.pendingMatchesId.state.forEach((matchId) => {
+    this.stores.pendingMatchesId.get().forEach((matchId) => {
       this.cancelMatch(matchId)
     })
 
-    this.stores.matchesId.state.forEach((matchId) => {
+    this.stores.matchesId.get().forEach((matchId) => {
       if (this.stores.pendingMatchStoresById.has(matchId)) {
         return
       }
 
-      const match = this.stores.activeMatchStoresById.get(matchId)?.state
+      const match = this.stores.activeMatchStoresById.get(matchId)?.get()
       if (!match) {
         return
       }
@@ -2356,16 +2356,16 @@ export class RouterCore<
     // Match the routes
     const pendingMatches = this.matchRoutes(this.latestLocation)
 
-    const nextCachedMatches = this.stores.cachedMatchesSnapshot.state.filter(
-      (d) => !pendingMatches.some((e) => e.id === d.id),
-    )
+    const nextCachedMatches = this.stores.cachedMatchesSnapshot
+      .get()
+      .filter((d) => !pendingMatches.some((e) => e.id === d.id))
 
     // Ingest the new matches
     this.batch(() => {
-      this.stores.status.setState(() => 'pending')
-      this.stores.statusCode.setState(() => 200)
-      this.stores.isLoading.setState(() => true)
-      this.stores.location.setState(() => this.latestLocation)
+      this.stores.status.set(() => 'pending')
+      this.stores.statusCode.set(() => 200)
+      this.stores.isLoading.set(() => true)
+      this.stores.location.set(() => this.latestLocation)
       this.stores.setPendingMatches(pendingMatches)
       // If a cached match moved to pending matches, remove it from cached matches
       this.stores.setCachedMatches(nextCachedMatches)
@@ -2377,7 +2377,7 @@ export class RouterCore<
     let notFound: NotFoundError | undefined
     let loadPromise: Promise<void>
     const previousLocation =
-      this.stores.resolvedLocation.state ?? this.stores.location.state
+      this.stores.resolvedLocation.get() ?? this.stores.location.get()
 
     // eslint-disable-next-line prefer-const
     loadPromise = new Promise<void>((resolve) => {
@@ -2385,10 +2385,10 @@ export class RouterCore<
         try {
           this.beforeLoad()
           const next = this.latestLocation
-          const prevLocation = this.stores.resolvedLocation.state
+          const prevLocation = this.stores.resolvedLocation.get()
           const locationChangeInfo = getLocationChangeInfo(next, prevLocation)
 
-          if (!this.stores.redirect.state) {
+          if (!this.stores.redirect.get()) {
             this.emit({
               type: 'onBeforeNavigate',
               ...locationChangeInfo,
@@ -2404,7 +2404,7 @@ export class RouterCore<
             router: this,
             sync: opts?.sync,
             forceStaleReload: previousLocation.href === next.href,
-            matches: this.stores.pendingMatchesSnapshot.state,
+            matches: this.stores.pendingMatchesSnapshot.get(),
             location: next,
             updateMatch: this.updateMatch,
             // eslint-disable-next-line @typescript-eslint/require-await
@@ -2429,10 +2429,10 @@ export class RouterCore<
 
                   this.batch(() => {
                     const pendingMatches =
-                      this.stores.pendingMatchesSnapshot.state
+                      this.stores.pendingMatchesSnapshot.get()
                     const mountPending = pendingMatches.length
                     const currentMatches =
-                      this.stores.activeMatchesSnapshot.state
+                      this.stores.activeMatchesSnapshot.get()
 
                     exitingMatches = mountPending
                       ? currentMatches.filter(
@@ -2468,8 +2468,8 @@ export class RouterCore<
                         )
                       : currentMatches
 
-                    this.stores.isLoading.setState(() => false)
-                    this.stores.loadedAt.setState(() => Date.now())
+                    this.stores.isLoading.set(() => false)
+                    this.stores.loadedAt.set(() => Date.now())
                     /**
                      * When committing new matches, cache any exiting matches that are still usable.
                      * Routes that resolved with `status: 'error'` or `status: 'notFound'` are
@@ -2480,7 +2480,7 @@ export class RouterCore<
                       this.stores.setActiveMatches(pendingMatches)
                       this.stores.setPendingMatches([])
                       this.stores.setCachedMatches([
-                        ...this.stores.cachedMatchesSnapshot.state,
+                        ...this.stores.cachedMatchesSnapshot.get(),
                         ...exitingMatches!.filter(
                           (d) =>
                             d.status !== 'error' &&
@@ -2527,15 +2527,15 @@ export class RouterCore<
             ? redirect.status
             : notFound
               ? 404
-              : this.stores.activeMatchesSnapshot.state.some(
-                    (d) => d.status === 'error',
-                  )
+              : this.stores.activeMatchesSnapshot
+                    .get()
+                    .some((d) => d.status === 'error')
                 ? 500
                 : 200
 
           this.batch(() => {
-            this.stores.statusCode.setState(() => nextStatusCode)
-            this.stores.redirect.setState(() => redirect)
+            this.stores.statusCode.set(() => nextStatusCode)
+            this.stores.redirect.set(() => redirect)
           })
         }
 
@@ -2564,12 +2564,12 @@ export class RouterCore<
     if (this.hasNotFoundMatch()) {
       newStatusCode = 404
     } else if (
-      this.stores.activeMatchesSnapshot.state.some((d) => d.status === 'error')
+      this.stores.activeMatchesSnapshot.get().some((d) => d.status === 'error')
     ) {
       newStatusCode = 500
     }
     if (newStatusCode !== undefined) {
-      this.stores.statusCode.setState(() => newStatusCode)
+      this.stores.statusCode.set(() => newStatusCode)
     }
   }
 
@@ -2598,7 +2598,7 @@ export class RouterCore<
         this.isViewTransitionTypesSupported
       ) {
         const next = this.latestLocation
-        const prevLocation = this.stores.resolvedLocation.state
+        const prevLocation = this.stores.resolvedLocation.get()
 
         const resolvedViewTransitionTypes =
           typeof shouldViewTransition.types === 'function'
@@ -2630,28 +2630,28 @@ export class RouterCore<
     this.startTransition(() => {
       const pendingMatch = this.stores.pendingMatchStoresById.get(id)
       if (pendingMatch) {
-        pendingMatch.setState(updater)
+        pendingMatch.set(updater)
         return
       }
 
       const activeMatch = this.stores.activeMatchStoresById.get(id)
       if (activeMatch) {
-        activeMatch.setState(updater)
+        activeMatch.set(updater)
         return
       }
 
       const cachedMatch = this.stores.cachedMatchStoresById.get(id)
       if (cachedMatch) {
-        const next = updater(cachedMatch.state)
+        const next = updater(cachedMatch.get())
         if (next.status === 'redirected') {
           const deleted = this.stores.cachedMatchStoresById.delete(id)
           if (deleted) {
-            this.stores.cachedMatchesId.setState((prev) =>
+            this.stores.cachedMatchesId.set((prev) =>
               prev.filter((matchId) => matchId !== id),
             )
           }
         } else {
-          cachedMatch.setState(() => next)
+          cachedMatch.set(() => next)
         }
       }
     })
@@ -2659,9 +2659,9 @@ export class RouterCore<
 
   getMatch: GetMatchFn = (matchId: string): AnyRouteMatch | undefined => {
     return (
-      this.stores.cachedMatchStoresById.get(matchId)?.state ??
-      this.stores.pendingMatchStoresById.get(matchId)?.state ??
-      this.stores.activeMatchStoresById.get(matchId)?.state
+      this.stores.cachedMatchStoresById.get(matchId)?.get() ??
+      this.stores.pendingMatchStoresById.get(matchId)?.get() ??
+      this.stores.activeMatchStoresById.get(matchId)?.get()
     )
   }
 
@@ -2699,13 +2699,13 @@ export class RouterCore<
 
     this.batch(() => {
       this.stores.setActiveMatches(
-        this.stores.activeMatchesSnapshot.state.map(invalidate),
+        this.stores.activeMatchesSnapshot.get().map(invalidate),
       )
       this.stores.setCachedMatches(
-        this.stores.cachedMatchesSnapshot.state.map(invalidate),
+        this.stores.cachedMatchesSnapshot.get().map(invalidate),
       )
       this.stores.setPendingMatches(
-        this.stores.pendingMatchesSnapshot.state.map(invalidate),
+        this.stores.pendingMatchesSnapshot.get().map(invalidate),
       )
     })
 
@@ -2765,9 +2765,9 @@ export class RouterCore<
     const filter = opts?.filter
     if (filter !== undefined) {
       this.stores.setCachedMatches(
-        this.stores.cachedMatchesSnapshot.state.filter(
-          (m) => !filter(m as MakeRouteMatchUnion<this>),
-        ),
+        this.stores.cachedMatchesSnapshot
+          .get()
+          .filter((m) => !filter(m as MakeRouteMatchUnion<this>)),
       )
     } else {
       this.stores.setCachedMatches([])
@@ -2818,13 +2818,13 @@ export class RouterCore<
     })
 
     const activeMatchIds = new Set([
-      ...this.stores.matchesId.state,
-      ...this.stores.pendingMatchesId.state,
+      ...this.stores.matchesId.get(),
+      ...this.stores.pendingMatchesId.get(),
     ])
 
     const loadedMatchIds = new Set([
       ...activeMatchIds,
-      ...this.stores.cachedMatchesId.state,
+      ...this.stores.cachedMatchesId.get(),
     ])
 
     // If the matches are already loaded, we need to add them to the cached matches.
@@ -2832,7 +2832,7 @@ export class RouterCore<
       (match) => !loadedMatchIds.has(match.id),
     )
     if (matchesToCache.length) {
-      const cachedMatches = this.stores.cachedMatchesSnapshot.state
+      const cachedMatches = this.stores.cachedMatchesSnapshot.get()
       this.stores.setCachedMatches([...cachedMatches, ...matchesToCache])
     }
 
@@ -2888,16 +2888,16 @@ export class RouterCore<
     }
     const next = this.buildLocation(matchLocation as any)
 
-    if (opts?.pending && this.stores.status.state !== 'pending') {
+    if (opts?.pending && this.stores.status.get() !== 'pending') {
       return false
     }
 
     const pending =
-      opts?.pending === undefined ? !this.stores.isLoading.state : opts.pending
+      opts?.pending === undefined ? !this.stores.isLoading.get() : opts.pending
 
     const baseLocation = pending
       ? this.latestLocation
-      : this.stores.resolvedLocation.state || this.stores.location.state
+      : this.stores.resolvedLocation.get() || this.stores.location.get()
 
     const match = findSingleMatch(
       next.pathname,
@@ -2933,9 +2933,9 @@ export class RouterCore<
   serverSsr?: ServerSsr
 
   hasNotFoundMatch = () => {
-    return this.stores.activeMatchesSnapshot.state.some(
-      (d) => d.status === 'notFound' || d.globalNotFound,
-    )
+    return this.stores.activeMatchesSnapshot
+      .get()
+      .some((d) => d.status === 'notFound' || d.globalNotFound)
   }
 }
 

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -233,7 +233,7 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
   window.addEventListener('pagehide', () => {
     snapshotCurrentScrollTargets(
       getKey(
-        router.stores.resolvedLocation.state ?? router.stores.location.state,
+        router.stores.resolvedLocation.get() ?? router.stores.location.get(),
       ),
     )
     cache.persist()

--- a/packages/router-core/src/ssr/createRequestHandler.ts
+++ b/packages/router-core/src/ssr/createRequestHandler.ts
@@ -79,12 +79,12 @@ export function createRequestHandler<TRouter extends AnyRouter>({
 
 function getRequestHeaders(opts: { router: AnyRouter }): Headers {
   const matchHeaders =
-    opts.router.stores.activeMatchesSnapshot.state.map<AnyHeaders>(
+    opts.router.stores.activeMatchesSnapshot.get().map<AnyHeaders>(
       (match) => match.headers,
     )
 
   // Handle Redirects
-  const redirect = opts.router.stores.redirect.state
+  const redirect = opts.router.stores.redirect.get()
   if (redirect) {
     matchHeaders.push(redirect.headers)
   }

--- a/packages/router-core/src/ssr/createRequestHandler.ts
+++ b/packages/router-core/src/ssr/createRequestHandler.ts
@@ -78,10 +78,9 @@ export function createRequestHandler<TRouter extends AnyRouter>({
 }
 
 function getRequestHeaders(opts: { router: AnyRouter }): Headers {
-  const matchHeaders =
-    opts.router.stores.activeMatchesSnapshot.get().map<AnyHeaders>(
-      (match) => match.headers,
-    )
+  const matchHeaders = opts.router.stores.activeMatchesSnapshot
+    .get()
+    .map<AnyHeaders>((match) => match.headers)
 
   // Handle Redirects
   const redirect = opts.router.stores.redirect.get()

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -295,8 +295,8 @@ export async function hydrate(router: AnyRouter): Promise<any> {
         if (router.stores.status.get() === 'pending') {
           router.batch(() => {
             router.stores.status.set(() => 'idle')
-            router.stores.resolvedLocation.set(
-              () => router.stores.location.get(),
+            router.stores.resolvedLocation.set(() =>
+              router.stores.location.get(),
             )
           })
         }

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -293,10 +293,8 @@ export async function hydrate(router: AnyRouter): Promise<any> {
         // this usually happens in Transitioner but if loading synchronously resolves,
         // Transitioner won't be rendered while loading so it cannot track the change from loading:true to loading:false
         if (router.stores.status.get() === 'pending') {
-          router.batch(() => {
-            router.stores.status.set('idle')
-            router.stores.resolvedLocation.set(router.stores.location.get())
-          })
+          router.stores.status.set('idle')
+          router.stores.resolvedLocation.set(router.stores.location.get())
         }
         // hide the pending component once the load is finished
         router.updateMatch(match.id, (prev) => ({

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -258,7 +258,7 @@ export async function hydrate(router: AnyRouter): Promise<any> {
     // (e.g. preloads, invalidations) don't mistakenly detect a href change
     // (resolvedLocation defaults to undefined and router.load() is skipped
     // in the normal SSR hydration path).
-    router.stores.resolvedLocation.set(() => router.stores.location.get())
+    router.stores.resolvedLocation.set(router.stores.location.get())
     return routeChunkPromise
   }
 
@@ -294,10 +294,8 @@ export async function hydrate(router: AnyRouter): Promise<any> {
         // Transitioner won't be rendered while loading so it cannot track the change from loading:true to loading:false
         if (router.stores.status.get() === 'pending') {
           router.batch(() => {
-            router.stores.status.set(() => 'idle')
-            router.stores.resolvedLocation.set(() =>
-              router.stores.location.get(),
-            )
+            router.stores.status.set('idle')
+            router.stores.resolvedLocation.set(router.stores.location.get())
           })
         }
         // hide the pending component once the load is finished

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -95,7 +95,7 @@ export async function hydrate(router: AnyRouter): Promise<any> {
   }
 
   // Hydrate the router state
-  const matches = router.matchRoutes(router.stores.location.state)
+  const matches = router.matchRoutes(router.stores.location.get())
 
   // kick off loading the route chunks
   const routeChunkPromise = Promise.all(
@@ -170,8 +170,8 @@ export async function hydrate(router: AnyRouter): Promise<any> {
   // now that all necessary data is hydrated:
   // 1) fully reconstruct the route context
   // 2) execute `head()` and `scripts()` for each match
-  const activeMatches = router.stores.activeMatchesSnapshot.state
-  const location = router.stores.location.state
+  const activeMatches = router.stores.activeMatchesSnapshot.get()
+  const location = router.stores.location.get()
   await Promise.all(
     activeMatches.map(async (match) => {
       try {
@@ -258,7 +258,7 @@ export async function hydrate(router: AnyRouter): Promise<any> {
     // (e.g. preloads, invalidations) don't mistakenly detect a href change
     // (resolvedLocation defaults to undefined and router.load() is skipped
     // in the normal SSR hydration path).
-    router.stores.resolvedLocation.setState(() => router.stores.location.state)
+    router.stores.resolvedLocation.set(() => router.stores.location.get())
     return routeChunkPromise
   }
 
@@ -292,11 +292,11 @@ export async function hydrate(router: AnyRouter): Promise<any> {
         // ensure router is not in status 'pending' anymore
         // this usually happens in Transitioner but if loading synchronously resolves,
         // Transitioner won't be rendered while loading so it cannot track the change from loading:true to loading:false
-        if (router.stores.status.state === 'pending') {
+        if (router.stores.status.get() === 'pending') {
           router.batch(() => {
-            router.stores.status.setState(() => 'idle')
-            router.stores.resolvedLocation.setState(
-              () => router.stores.location.state,
+            router.stores.status.set(() => 'idle')
+            router.stores.resolvedLocation.set(
+              () => router.stores.location.get(),
             )
           })
         }

--- a/packages/router-core/src/ssr/ssr-server.ts
+++ b/packages/router-core/src/ssr/ssr-server.ts
@@ -228,7 +228,7 @@ export function attachRouterServerSsrUtils({
 
         invariant()
       }
-      let matchesToDehydrate = router.stores.activeMatchesSnapshot.state
+      let matchesToDehydrate = router.stores.activeMatchesSnapshot.get()
       if (router.isShell()) {
         // In SPA mode we only want to dehydrate the root match
         matchesToDehydrate = matchesToDehydrate.slice(0, 1)

--- a/packages/router-core/src/stores.ts
+++ b/packages/router-core/src/stores.ts
@@ -9,13 +9,13 @@ import type { AnyRedirect } from './redirect'
 import type { AnyRouteMatch } from './Matches'
 
 export interface RouterReadableStore<TValue> {
-  readonly state: TValue
+  get: () => TValue
 }
 
 export interface RouterWritableStore<
   TValue,
 > extends RouterReadableStore<TValue> {
-  setState: (updater: (prev: TValue) => TValue) => void
+  set: (updater: (prev: TValue) => TValue) => void
 }
 
 export type RouterBatchFn = (fn: () => void) => void
@@ -49,10 +49,10 @@ export function createNonReactiveMutableStore<TValue>(
   let value = initialValue
 
   return {
-    get state() {
+    get() {
       return value
     },
-    setState(updater: (prev: TValue) => TValue) {
+    set(updater: (prev: TValue) => TValue) {
       value = updater(value)
     },
   }
@@ -63,7 +63,7 @@ export function createNonReactiveReadonlyStore<TValue>(
   read: () => TValue,
 ): RouterReadableStore<TValue> {
   return {
-    get state() {
+    get() {
       return read()
     },
   }
@@ -141,38 +141,38 @@ export function createRouterStores<TRouteTree extends AnyRoute>(
 
   // 1st order derived stores
   const activeMatchesSnapshot = createReadonlyStore(() =>
-    readPoolMatches(activeMatchStoresById, matchesId.state),
+    readPoolMatches(activeMatchStoresById, matchesId.get()),
   )
   const pendingMatchesSnapshot = createReadonlyStore(() =>
-    readPoolMatches(pendingMatchStoresById, pendingMatchesId.state),
+    readPoolMatches(pendingMatchStoresById, pendingMatchesId.get()),
   )
   const cachedMatchesSnapshot = createReadonlyStore(() =>
-    readPoolMatches(cachedMatchStoresById, cachedMatchesId.state),
+    readPoolMatches(cachedMatchStoresById, cachedMatchesId.get()),
   )
-  const firstMatchId = createReadonlyStore(() => matchesId.state[0])
+  const firstMatchId = createReadonlyStore(() => matchesId.get()[0])
   const hasPendingMatches = createReadonlyStore(() =>
-    matchesId.state.some((matchId) => {
+    matchesId.get().some((matchId) => {
       const store = activeMatchStoresById.get(matchId)
-      return store?.state.status === 'pending'
+      return store?.get().status === 'pending'
     }),
   )
   const matchRouteReactivity = createReadonlyStore(() => ({
-    locationHref: location.state.href,
-    resolvedLocationHref: resolvedLocation.state?.href,
-    status: status.state,
+    locationHref: location.get().href,
+    resolvedLocationHref: resolvedLocation.get()?.href,
+    status: status.get(),
   }))
 
   // compatibility "big" state store
   const __store = createReadonlyStore(() => ({
-    status: status.state,
-    loadedAt: loadedAt.state,
-    isLoading: isLoading.state,
-    isTransitioning: isTransitioning.state,
-    matches: activeMatchesSnapshot.state,
-    location: location.state,
-    resolvedLocation: resolvedLocation.state,
-    statusCode: statusCode.state,
-    redirect: redirect.state,
+    status: status.get(),
+    loadedAt: loadedAt.get(),
+    isLoading: isLoading.get(),
+    isTransitioning: isTransitioning.get(),
+    matches: activeMatchesSnapshot.get(),
+    location: location.get(),
+    resolvedLocation: resolvedLocation.get(),
+    statusCode: statusCode.get(),
+    redirect: redirect.get(),
   }))
 
   // Per-routeId computed store cache.
@@ -194,15 +194,15 @@ export function createRouterStores<TRouteTree extends AnyRoute>(
     let cached = matchStoreByRouteIdCache.get(routeId)
     if (!cached) {
       cached = createReadonlyStore(() => {
-        // Reading matchesId.state tracks it as a dependency.
+        // Reading matchesId.get() tracks it as a dependency.
         // When matchesId changes (navigation), this computed re-evaluates.
-        const ids = matchesId.state
+        const ids = matchesId.get()
         for (const id of ids) {
           const matchStore = activeMatchStoresById.get(id)
           if (matchStore && matchStore.routeId === routeId) {
-            // Reading matchStore.state tracks it as a dependency.
+            // Reading matchStore.get() tracks it as a dependency.
             // When the match store's state changes, this re-evaluates.
-            return matchStore.state
+            return matchStore.get()
           }
         }
         return undefined
@@ -297,7 +297,7 @@ function readPoolMatches(
   for (const id of ids) {
     const matchStore = pool.get(id)
     if (matchStore) {
-      matches.push(matchStore.state)
+      matches.push(matchStore.get())
     }
   }
   return matches
@@ -330,13 +330,13 @@ function reconcileMatchPool(
       }
 
       existing.routeId = nextMatch.routeId
-      if (existing.state !== nextMatch) {
-        existing.setState(() => nextMatch)
+      if (existing.get() !== nextMatch) {
+        existing.set(() => nextMatch)
       }
     }
 
-    if (!arraysEqual(idStore.state, nextIds)) {
-      idStore.setState(() => nextIds)
+    if (!arraysEqual(idStore.get(), nextIds)) {
+      idStore.set(() => nextIds)
     }
   })
 }

--- a/packages/router-core/src/stores.ts
+++ b/packages/router-core/src/stores.ts
@@ -1,5 +1,5 @@
 import { createLRUCache } from './lru-cache'
-import { arraysEqual } from './utils'
+import { arraysEqual, functionalUpdate } from './utils'
 
 import type { AnyRoute } from './route'
 import type { RouterState } from './router'
@@ -15,7 +15,7 @@ export interface RouterReadableStore<TValue> {
 export interface RouterWritableStore<
   TValue,
 > extends RouterReadableStore<TValue> {
-  set: (updater: (prev: TValue) => TValue) => void
+  set: ((updater: (prev: TValue) => TValue) => void) & ((value: TValue) => void)
 }
 
 export type RouterBatchFn = (fn: () => void) => void
@@ -52,8 +52,8 @@ export function createNonReactiveMutableStore<TValue>(
     get() {
       return value
     },
-    set(updater: (prev: TValue) => TValue) {
-      value = updater(value)
+    set(nextOrUpdater: TValue | ((prev: TValue) => TValue)) {
+      value = functionalUpdate(nextOrUpdater, value)
     },
   }
 }
@@ -331,12 +331,12 @@ function reconcileMatchPool(
 
       existing.routeId = nextMatch.routeId
       if (existing.get() !== nextMatch) {
-        existing.set(() => nextMatch)
+        existing.set(nextMatch)
       }
     }
 
     if (!arraysEqual(idStore.get(), nextIds)) {
-      idStore.set(() => nextIds)
+      idStore.set(nextIds)
     }
   })
 }

--- a/packages/router-core/tests/callbacks.test.ts
+++ b/packages/router-core/tests/callbacks.test.ts
@@ -201,7 +201,7 @@ describe('callbacks', () => {
       expect(page2MatchId).toBeDefined()
       expect(page2MatchId).not.toBe(page1MatchId)
       expect(
-        router.stores.cachedMatchesId.state.some((id) => id === page1MatchId),
+        router.stores.cachedMatchesId.get().some((id) => id === page1MatchId),
       ).toBe(true)
 
       await router.navigate({ to: '/foo', search: { page: '1' } })
@@ -226,7 +226,7 @@ describe('callbacks', () => {
       expect(post2MatchId).toBeDefined()
       expect(post2MatchId).not.toBe(post1MatchId)
       expect(
-        router.stores.cachedMatchesId.state.some((id) => id === post1MatchId),
+        router.stores.cachedMatchesId.get().some((id) => id === post1MatchId),
       ).toBe(true)
 
       await router.navigate({ to: '/posts/$postId', params: { postId: '1' } })

--- a/packages/router-core/tests/granular-stores.test.ts
+++ b/packages/router-core/tests/granular-stores.test.ts
@@ -91,7 +91,7 @@ describe('granular stores', () => {
     const activeMatches = router.state.matches
 
     // Active pool contains all active matches with correct routeIds
-    expect(router.stores.matchesId.state).toEqual(
+    expect(router.stores.matchesId.get()).toEqual(
       activeMatches.map((match) => match.id),
     )
     activeMatches.forEach((match) => {
@@ -99,8 +99,8 @@ describe('granular stores', () => {
       expect(store).toBeDefined()
       expect(store!.routeId).toBe(match.routeId)
       // getMatchStoreByRouteId resolves to the same state
-      expect(router.stores.getMatchStoreByRouteId(match.routeId).state).toBe(
-        store!.state,
+      expect(router.stores.getMatchStoreByRouteId(match.routeId).get()).toBe(
+        store!.get(),
       )
     })
 
@@ -116,13 +116,13 @@ describe('granular stores', () => {
     router.stores.setPendingMatches(pendingMatches)
     router.stores.setCachedMatches(cachedMatches)
 
-    expect(router.stores.matchesId.state).toEqual(
+    expect(router.stores.matchesId.get()).toEqual(
       activeMatches.map((match) => match.id),
     )
-    expect(router.stores.pendingMatchesId.state).toEqual(
+    expect(router.stores.pendingMatchesId.get()).toEqual(
       pendingMatches.map((match) => match.id),
     )
-    expect(router.stores.cachedMatchesId.state).toEqual(
+    expect(router.stores.cachedMatchesId.get()).toEqual(
       cachedMatches.map((match) => match.id),
     )
 
@@ -135,7 +135,7 @@ describe('granular stores', () => {
       expect(router.stores.activeMatchStoresById.get(match.id)).toBeUndefined()
       // Active pool still has a match for this routeId
       expect(
-        router.stores.getMatchStoreByRouteId(match.routeId).state,
+        router.stores.getMatchStoreByRouteId(match.routeId).get(),
       ).toBeDefined()
     })
 
@@ -145,15 +145,15 @@ describe('granular stores', () => {
     }))
     router.stores.setActiveMatches(nextActiveMatches)
 
-    expect(router.stores.matchesId.state).toEqual(
+    expect(router.stores.matchesId.get()).toEqual(
       nextActiveMatches.map((match) => match.id),
     )
     nextActiveMatches.forEach((match) => {
       const store = router.stores.activeMatchStoresById.get(match.id)
       expect(store).toBeDefined()
       expect(store!.routeId).toBe(match.routeId)
-      expect(router.stores.getMatchStoreByRouteId(match.routeId).state).toBe(
-        store!.state,
+      expect(router.stores.getMatchStoreByRouteId(match.routeId).get()).toBe(
+        store!.get(),
       )
     })
   })
@@ -182,17 +182,17 @@ describe('granular stores', () => {
       throw new Error('Expected root and leaf match stores to exist')
     }
 
-    const rootBefore = rootStore.state
-    const leafBefore = leafStore.state
+    const rootBefore = rootStore.get()
+    const leafBefore = leafStore.get()
 
     router.updateMatch(leafMatch.id, (prev) => ({
       ...prev,
       status: 'pending',
     }))
 
-    expect(rootStore.state).toBe(rootBefore)
-    expect(leafStore.state).not.toBe(leafBefore)
-    expect(leafStore.state.status).toBe('pending')
+    expect(rootStore.get()).toBe(rootBefore)
+    expect(leafStore.get()).not.toBe(leafBefore)
+    expect(leafStore.get().status).toBe('pending')
   })
 
   test('getMatchStoreByRouteId caches store instances and clears when route is inactive', async () => {
@@ -204,14 +204,14 @@ describe('granular stores', () => {
     expect(router.stores.getMatchStoreByRouteId('/posts/$postId')).toBe(
       postsStore,
     )
-    expect(postsStore.state?.routeId).toBe('/posts/$postId')
+    expect(postsStore.get()?.routeId).toBe('/posts/$postId')
 
     await router.navigate({ to: '/about' })
 
     expect(router.stores.getMatchStoreByRouteId('/posts/$postId')).toBe(
       postsStore,
     )
-    expect(postsStore.state).toBeUndefined()
+    expect(postsStore.get()).toBeUndefined()
   })
 
   test('no-op match pool reconciliation preserves ids and match state references', async () => {
@@ -219,21 +219,21 @@ describe('granular stores', () => {
     await router.navigate({ to: '/posts/123' })
 
     const activeMatches = router.state.matches
-    const activeIdsBefore = router.stores.matchesId.state
+    const activeIdsBefore = router.stores.matchesId.get()
     const activeStoresBefore = activeMatches.map((match) =>
       router.stores.activeMatchStoresById.get(match.id),
     )
-    const activeStatesBefore = activeStoresBefore.map((store) => store?.state)
+    const activeStatesBefore = activeStoresBefore.map((store) => store?.get())
 
     router.stores.setActiveMatches(activeMatches)
 
-    expect(router.stores.matchesId.state).toBe(activeIdsBefore)
-    expect(router.stores.activeMatchesSnapshot.state).toBe(activeMatches)
+    expect(router.stores.matchesId.get()).toBe(activeIdsBefore)
+    expect(router.stores.activeMatchesSnapshot.get()).toBe(activeMatches)
     for (let i = 0; i < activeMatches.length; i++) {
       const match = activeMatches[i]!
       const store = router.stores.activeMatchStoresById.get(match.id)
       expect(store).toBe(activeStoresBefore[i])
-      expect(store?.state).toBe(activeStatesBefore[i])
+      expect(store?.get()).toBe(activeStatesBefore[i])
     }
 
     const pendingMatches = activeMatches.map((match) => ({
@@ -244,20 +244,20 @@ describe('granular stores', () => {
 
     router.stores.setPendingMatches(pendingMatches)
 
-    const pendingIdsBefore = router.stores.pendingMatchesId.state
+    const pendingIdsBefore = router.stores.pendingMatchesId.get()
     const pendingStoresBefore = pendingMatches.map((match) =>
       router.stores.pendingMatchStoresById.get(match.id),
     )
-    const pendingStatesBefore = pendingStoresBefore.map((store) => store?.state)
+    const pendingStatesBefore = pendingStoresBefore.map((store) => store?.get())
 
     router.stores.setPendingMatches(pendingMatches)
 
-    expect(router.stores.pendingMatchesId.state).toBe(pendingIdsBefore)
+    expect(router.stores.pendingMatchesId.get()).toBe(pendingIdsBefore)
     for (let i = 0; i < pendingMatches.length; i++) {
       const match = pendingMatches[i]!
       const store = router.stores.pendingMatchStoresById.get(match.id)
       expect(store).toBe(pendingStoresBefore[i])
-      expect(store?.state).toBe(pendingStatesBefore[i])
+      expect(store?.get()).toBe(pendingStatesBefore[i])
     }
   })
 
@@ -282,7 +282,7 @@ describe('granular stores', () => {
       throw new Error('Expected active leaf store to exist')
     }
 
-    const activeBefore = activeStore.state
+    const activeBefore = activeStore.get()
 
     const reloadPromise = router.load()
     await Promise.resolve()
@@ -304,10 +304,10 @@ describe('granular stores', () => {
       error: new Error('pending-only-update'),
     }))
 
-    expect(activeStore.state).toBe(activeBefore)
-    expect(activeStore.state.status).toBe('success')
-    expect(pendingStore.state.status).toBe('error')
-    expect(pendingStore.state.error).toEqual(new Error('pending-only-update'))
+    expect(activeStore.get()).toBe(activeBefore)
+    expect(activeStore.get().status).toBe('success')
+    expect(pendingStore.get().status).toBe('error')
+    expect(pendingStore.get().error).toEqual(new Error('pending-only-update'))
 
     resolveLoader()
     await reloadPromise
@@ -344,19 +344,19 @@ describe('granular stores', () => {
     )
 
     expect(
-      router.stores.activeMatchStoresById.get(duplicatedId)?.state.status,
+      router.stores.activeMatchStoresById.get(duplicatedId)?.get().status,
     ).toBe('error')
     expect(
-      router.stores.getMatchStoreByRouteId(activeLeaf.routeId).state?.status,
+      router.stores.getMatchStoreByRouteId(activeLeaf.routeId).get()?.status,
     ).toBe('error')
     // Pending pool has its own store for this id
     expect(
-      router.stores.pendingMatchStoresById.get(duplicatedId)?.state.status,
+      router.stores.pendingMatchStoresById.get(duplicatedId)?.get().status,
     ).toBe('pending')
-    expect(router.stores.pendingMatchesSnapshot.state[0]?.status).toBe(
+    expect(router.stores.pendingMatchesSnapshot.get()[0]?.status).toBe(
       'pending',
     )
-    expect(router.stores.cachedMatchesSnapshot.state[0]?.status).toBe('success')
+    expect(router.stores.cachedMatchesSnapshot.get()[0]?.status).toBe('success')
     expect(router.getMatch(duplicatedId)?.status).toBe('success')
   })
 })

--- a/packages/router-core/tests/load.test.ts
+++ b/packages/router-core/tests/load.test.ts
@@ -119,7 +119,7 @@ describe('beforeLoad skip or exec', () => {
     const router = setup({ beforeLoad })
     const navigation = router.navigate({ to: '/foo' })
     expect(beforeLoad).toHaveBeenCalledTimes(1)
-    expect(router.stores.pendingMatchesSnapshot.state).toEqual(
+    expect(router.stores.pendingMatchesSnapshot.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await navigation
@@ -141,7 +141,7 @@ describe('beforeLoad skip or exec', () => {
     const beforeLoad = vi.fn()
     const router = setup({ beforeLoad })
     await router.preloadRoute({ to: '/foo' })
-    expect(router.stores.cachedMatchesSnapshot.state).toEqual(
+    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await sleep(10)
@@ -155,7 +155,7 @@ describe('beforeLoad skip or exec', () => {
     const router = setup({ beforeLoad })
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
-    expect(router.stores.cachedMatchesSnapshot.state).toEqual(
+    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await router.navigate({ to: '/foo' })
@@ -203,7 +203,7 @@ describe('beforeLoad skip or exec', () => {
     })
     await router.preloadRoute({ to: '/foo' })
     expect(
-      router.stores.cachedMatchesSnapshot.state.some(
+      router.stores.cachedMatchesSnapshot.get().some(
         (d) => d.status === 'redirected',
       ),
     ).toBe(false)
@@ -212,7 +212,7 @@ describe('beforeLoad skip or exec', () => {
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatchesSnapshot.state.some(
+      router.stores.cachedMatchesSnapshot.get().some(
         (d) => d.status === 'redirected',
       ),
     ).toBe(false)
@@ -230,7 +230,7 @@ describe('beforeLoad skip or exec', () => {
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
     expect(
-      router.stores.cachedMatchesSnapshot.state.some(
+      router.stores.cachedMatchesSnapshot.get().some(
         (d) => d.status === 'redirected',
       ),
     ).toBe(false)
@@ -238,7 +238,7 @@ describe('beforeLoad skip or exec', () => {
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatchesSnapshot.state.some(
+      router.stores.cachedMatchesSnapshot.get().some(
         (d) => d.status === 'redirected',
       ),
     ).toBe(false)
@@ -359,7 +359,7 @@ describe('loader skip or exec', () => {
     const router = setup({ loader })
     const navigation = router.navigate({ to: '/foo' })
     expect(loader).toHaveBeenCalledTimes(1)
-    expect(router.stores.pendingMatchesSnapshot.state).toEqual(
+    expect(router.stores.pendingMatchesSnapshot.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await navigation
@@ -381,7 +381,7 @@ describe('loader skip or exec', () => {
     const loader = vi.fn()
     const router = setup({ loader })
     await router.preloadRoute({ to: '/foo' })
-    expect(router.stores.cachedMatchesSnapshot.state).toEqual(
+    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await sleep(10)
@@ -394,7 +394,7 @@ describe('loader skip or exec', () => {
     const loader = vi.fn()
     const router = setup({ loader, staleTime: 1000 })
     await router.preloadRoute({ to: '/foo' })
-    expect(router.stores.cachedMatchesSnapshot.state).toEqual(
+    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await sleep(10)
@@ -408,7 +408,7 @@ describe('loader skip or exec', () => {
     const router = setup({ loader })
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
-    expect(router.stores.cachedMatchesSnapshot.state).toEqual(
+    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await router.navigate({ to: '/foo' })
@@ -456,7 +456,7 @@ describe('loader skip or exec', () => {
     })
     await router.preloadRoute({ to: '/foo' })
     expect(
-      router.stores.cachedMatchesSnapshot.state.some(
+      router.stores.cachedMatchesSnapshot.get().some(
         (d) => d.status === 'redirected',
       ),
     ).toBe(false)
@@ -465,7 +465,7 @@ describe('loader skip or exec', () => {
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatchesSnapshot.state.some(
+      router.stores.cachedMatchesSnapshot.get().some(
         (d) => d.status === 'redirected',
       ),
     ).toBe(false)
@@ -483,7 +483,7 @@ describe('loader skip or exec', () => {
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
     expect(
-      router.stores.cachedMatchesSnapshot.state.some(
+      router.stores.cachedMatchesSnapshot.get().some(
         (d) => d.status === 'redirected',
       ),
     ).toBe(false)
@@ -491,7 +491,7 @@ describe('loader skip or exec', () => {
 
     expect(router.state.location.pathname).toBe('/bar')
     expect(
-      router.stores.cachedMatchesSnapshot.state.some(
+      router.stores.cachedMatchesSnapshot.get().some(
         (d) => d.status === 'redirected',
       ),
     ).toBe(false)
@@ -503,7 +503,7 @@ describe('loader skip or exec', () => {
     const router = setup({ loader })
 
     await router.preloadRoute({ to: '/foo' })
-    expect(router.stores.cachedMatchesSnapshot.state).toEqual(
+    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
 
@@ -513,12 +513,12 @@ describe('loader skip or exec', () => {
     }))
 
     expect(
-      router.stores.cachedMatchesSnapshot.state.some(
+      router.stores.cachedMatchesSnapshot.get().some(
         (d) => d.id === '/foo/foo',
       ),
     ).toBe(false)
     expect(
-      router.stores.cachedMatchesSnapshot.state.some(
+      router.stores.cachedMatchesSnapshot.get().some(
         (d) => d.status === 'redirected',
       ),
     ).toBe(false)
@@ -648,10 +648,10 @@ describe('stale loader reload triggers', () => {
     id: string,
   ) =>
     router.state.matches.find((match) => match.id === id) ??
-    router.stores.pendingMatchesSnapshot.state.find(
+    router.stores.pendingMatchesSnapshot.get().find(
       (match) => match.id === id,
     ) ??
-    router.stores.cachedMatchesSnapshot.state.find((match) => match.id === id)
+    router.stores.cachedMatchesSnapshot.get().find((match) => match.id === id)
 
   const hasActiveMatch = (
     router: RouterCore<any, any, any, any, any>,
@@ -662,7 +662,7 @@ describe('stale loader reload triggers', () => {
     router: RouterCore<any, any, any, any, any>,
     id: string,
   ) =>
-    router.stores.pendingMatchesSnapshot.state.some(
+    router.stores.pendingMatchesSnapshot.get().some(
       (match) => match.id === id,
     ) ?? false
 
@@ -1766,7 +1766,7 @@ describe('head execution', () => {
         }),
       )
 
-      const rootMatch = router.stores.pendingMatchesSnapshot.state.find(
+      const rootMatch = router.stores.pendingMatchesSnapshot.get().find(
         (m) => m.routeId === routes[0].id,
       )
 
@@ -1795,7 +1795,7 @@ describe('head execution', () => {
       const second = await runLoadMatchesAndCapture(router)
       expect(second.error).toBeUndefined()
 
-      const rootMatch = router.stores.pendingMatchesSnapshot.state.find(
+      const rootMatch = router.stores.pendingMatchesSnapshot.get().find(
         (m) => m.routeId === routes[0].id,
       )
 
@@ -1832,7 +1832,7 @@ describe('head execution', () => {
 
       const staleRootNotFound = notFound({ data: { source: 'stale-root' } })
       const currentRootMatchId =
-        router.stores.pendingMatchesSnapshot.state.find(
+        router.stores.pendingMatchesSnapshot.get().find(
           (m) => m.routeId === rootRoute.id,
         )!.id
 
@@ -1862,7 +1862,7 @@ describe('head execution', () => {
 
       expect(rootLoader).toHaveBeenCalledTimes(1)
 
-      const rootMatch = router.stores.pendingMatchesSnapshot.state.find(
+      const rootMatch = router.stores.pendingMatchesSnapshot.get().find(
         (m) => m.routeId === rootRoute.id,
       )
 
@@ -1896,7 +1896,7 @@ describe('params.parse notFound', () => {
 
     await router.load()
 
-    const match = router.stores.activeMatchesSnapshot.state.find(
+    const match = router.stores.activeMatchesSnapshot.get().find(
       (m) => m.routeId === testRoute.id,
     )
 

--- a/packages/router-core/tests/load.test.ts
+++ b/packages/router-core/tests/load.test.ts
@@ -203,18 +203,18 @@ describe('beforeLoad skip or exec', () => {
     })
     await router.preloadRoute({ to: '/foo' })
     expect(
-      router.stores.cachedMatchesSnapshot.get().some(
-        (d) => d.status === 'redirected',
-      ),
+      router.stores.cachedMatchesSnapshot
+        .get()
+        .some((d) => d.status === 'redirected'),
     ).toBe(false)
     await sleep(10)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatchesSnapshot.get().some(
-        (d) => d.status === 'redirected',
-      ),
+      router.stores.cachedMatchesSnapshot
+        .get()
+        .some((d) => d.status === 'redirected'),
     ).toBe(false)
     expect(beforeLoad).toHaveBeenCalledTimes(2)
   })
@@ -230,17 +230,17 @@ describe('beforeLoad skip or exec', () => {
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
     expect(
-      router.stores.cachedMatchesSnapshot.get().some(
-        (d) => d.status === 'redirected',
-      ),
+      router.stores.cachedMatchesSnapshot
+        .get()
+        .some((d) => d.status === 'redirected'),
     ).toBe(false)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatchesSnapshot.get().some(
-        (d) => d.status === 'redirected',
-      ),
+      router.stores.cachedMatchesSnapshot
+        .get()
+        .some((d) => d.status === 'redirected'),
     ).toBe(false)
     expect(beforeLoad).toHaveBeenCalledTimes(2)
   })
@@ -456,18 +456,18 @@ describe('loader skip or exec', () => {
     })
     await router.preloadRoute({ to: '/foo' })
     expect(
-      router.stores.cachedMatchesSnapshot.get().some(
-        (d) => d.status === 'redirected',
-      ),
+      router.stores.cachedMatchesSnapshot
+        .get()
+        .some((d) => d.status === 'redirected'),
     ).toBe(false)
     await sleep(10)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatchesSnapshot.get().some(
-        (d) => d.status === 'redirected',
-      ),
+      router.stores.cachedMatchesSnapshot
+        .get()
+        .some((d) => d.status === 'redirected'),
     ).toBe(false)
     expect(loader).toHaveBeenCalledTimes(2)
   })
@@ -483,17 +483,17 @@ describe('loader skip or exec', () => {
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
     expect(
-      router.stores.cachedMatchesSnapshot.get().some(
-        (d) => d.status === 'redirected',
-      ),
+      router.stores.cachedMatchesSnapshot
+        .get()
+        .some((d) => d.status === 'redirected'),
     ).toBe(false)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/bar')
     expect(
-      router.stores.cachedMatchesSnapshot.get().some(
-        (d) => d.status === 'redirected',
-      ),
+      router.stores.cachedMatchesSnapshot
+        .get()
+        .some((d) => d.status === 'redirected'),
     ).toBe(false)
     expect(loader).toHaveBeenCalledTimes(1)
   })
@@ -513,14 +513,14 @@ describe('loader skip or exec', () => {
     }))
 
     expect(
-      router.stores.cachedMatchesSnapshot.get().some(
-        (d) => d.id === '/foo/foo',
-      ),
+      router.stores.cachedMatchesSnapshot
+        .get()
+        .some((d) => d.id === '/foo/foo'),
     ).toBe(false)
     expect(
-      router.stores.cachedMatchesSnapshot.get().some(
-        (d) => d.status === 'redirected',
-      ),
+      router.stores.cachedMatchesSnapshot
+        .get()
+        .some((d) => d.status === 'redirected'),
     ).toBe(false)
   })
 
@@ -648,9 +648,9 @@ describe('stale loader reload triggers', () => {
     id: string,
   ) =>
     router.state.matches.find((match) => match.id === id) ??
-    router.stores.pendingMatchesSnapshot.get().find(
-      (match) => match.id === id,
-    ) ??
+    router.stores.pendingMatchesSnapshot
+      .get()
+      .find((match) => match.id === id) ??
     router.stores.cachedMatchesSnapshot.get().find((match) => match.id === id)
 
   const hasActiveMatch = (
@@ -662,9 +662,9 @@ describe('stale loader reload triggers', () => {
     router: RouterCore<any, any, any, any, any>,
     id: string,
   ) =>
-    router.stores.pendingMatchesSnapshot.get().some(
-      (match) => match.id === id,
-    ) ?? false
+    router.stores.pendingMatchesSnapshot
+      .get()
+      .some((match) => match.id === id) ?? false
 
   const setup = ({
     loader,
@@ -1766,9 +1766,9 @@ describe('head execution', () => {
         }),
       )
 
-      const rootMatch = router.stores.pendingMatchesSnapshot.get().find(
-        (m) => m.routeId === routes[0].id,
-      )
+      const rootMatch = router.stores.pendingMatchesSnapshot
+        .get()
+        .find((m) => m.routeId === routes[0].id)
 
       expect(rootMatch?.globalNotFound).toBe(true)
       expect(rootMatch?.status).toBe('success')
@@ -1795,9 +1795,9 @@ describe('head execution', () => {
       const second = await runLoadMatchesAndCapture(router)
       expect(second.error).toBeUndefined()
 
-      const rootMatch = router.stores.pendingMatchesSnapshot.get().find(
-        (m) => m.routeId === routes[0].id,
-      )
+      const rootMatch = router.stores.pendingMatchesSnapshot
+        .get()
+        .find((m) => m.routeId === routes[0].id)
 
       expect(rootMatch?.globalNotFound).toBe(false)
     })
@@ -1831,10 +1831,9 @@ describe('head execution', () => {
       expect(rootLoader).toHaveBeenCalledTimes(1)
 
       const staleRootNotFound = notFound({ data: { source: 'stale-root' } })
-      const currentRootMatchId =
-        router.stores.pendingMatchesSnapshot.get().find(
-          (m) => m.routeId === rootRoute.id,
-        )!.id
+      const currentRootMatchId = router.stores.pendingMatchesSnapshot
+        .get()
+        .find((m) => m.routeId === rootRoute.id)!.id
 
       router.updateMatch(currentRootMatchId, (prev) => ({
         ...prev,
@@ -1862,9 +1861,9 @@ describe('head execution', () => {
 
       expect(rootLoader).toHaveBeenCalledTimes(1)
 
-      const rootMatch = router.stores.pendingMatchesSnapshot.get().find(
-        (m) => m.routeId === rootRoute.id,
-      )
+      const rootMatch = router.stores.pendingMatchesSnapshot
+        .get()
+        .find((m) => m.routeId === rootRoute.id)
 
       expect(rootMatch?.globalNotFound).toBe(false)
       expect(rootMatch?.error).toBeUndefined()
@@ -1896,9 +1895,9 @@ describe('params.parse notFound', () => {
 
     await router.load()
 
-    const match = router.stores.activeMatchesSnapshot.get().find(
-      (m) => m.routeId === testRoute.id,
-    )
+    const match = router.stores.activeMatchesSnapshot
+      .get()
+      .find((m) => m.routeId === testRoute.id)
 
     expect(match?.status).toBe('notFound')
   })

--- a/packages/router-core/tests/routerTestUtils.ts
+++ b/packages/router-core/tests/routerTestUtils.ts
@@ -1,4 +1,4 @@
-import { batch, createStore } from '@tanstack/store'
+import { batch, createAtom } from '@tanstack/store'
 import { isServer } from '@tanstack/router-core/isServer'
 import {
   RouterCore,
@@ -23,8 +23,8 @@ const getStoreConfig: GetStoreConfig = (opts) => {
   }
 
   return {
-    createMutableStore: createStore,
-    createReadonlyStore: createStore,
+    createMutableStore: createAtom,
+    createReadonlyStore: createAtom,
     batch,
   }
 }

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -294,30 +294,30 @@ export const BaseTanStackRouterDevtoolsPanel =
       type Subscribe = (fn: () => void) => { unsubscribe: () => void }
       createEffect(() => {
         const pendingMatchesStore = router().stores.pendingMatchesSnapshot
-        setPendingMatches(pendingMatchesStore.state)
+        setPendingMatches(pendingMatchesStore.get())
         const subscription = (
           (pendingMatchesStore as any).subscribe as Subscribe
         )(() => {
-          setPendingMatches(pendingMatchesStore.state)
+          setPendingMatches(pendingMatchesStore.get())
         })
         onCleanup(() => subscription.unsubscribe())
       })
 
       createEffect(() => {
         const cachedMatchesStore = router().stores.cachedMatchesSnapshot
-        setCachedMatches(cachedMatchesStore.state)
+        setCachedMatches(cachedMatchesStore.get())
         const subscription = (
           (cachedMatchesStore as any).subscribe as Subscribe
         )(() => {
-          setCachedMatches(cachedMatchesStore.state)
+          setCachedMatches(cachedMatchesStore.get())
         })
         onCleanup(() => subscription.unsubscribe())
       })
     }
     // signal implementation
     else {
-      pendingMatches = () => router().stores.pendingMatchesSnapshot.state
-      cachedMatches = () => router().stores.cachedMatchesSnapshot.state
+      pendingMatches = () => router().stores.pendingMatchesSnapshot.get()
+      cachedMatches = () => router().stores.cachedMatchesSnapshot.get()
     }
 
     createEffect(() => {

--- a/packages/router-plugin/src/core/route-hmr-statement.ts
+++ b/packages/router-plugin/src/core/route-hmr-statement.ts
@@ -1,6 +1,11 @@
 import * as template from '@babel/template'
 import { createHmrHotExpressionAst } from './hmr-hot-expression'
-import type { AnyRoute, AnyRouteMatch, AnyRouter } from '@tanstack/router-core'
+import type {
+  AnyRoute,
+  AnyRouteMatch,
+  AnyRouter,
+  RouterWritableStore,
+} from '@tanstack/router-core'
 
 type AnyRouteWithPrivateProps = AnyRoute & {
   options: Record<string, unknown>
@@ -19,21 +24,15 @@ type AnyRouterWithPrivateMaps = AnyRouter & {
   stores: AnyRouter['stores'] & {
     cachedMatchStoresById: Map<
       string,
-      {
-        setState: (updater: (prev: AnyRouteMatch) => AnyRouteMatch) => void
-      }
+      Pick<RouterWritableStore<AnyRouteMatch>, 'set'>
     >
     pendingMatchStoresById: Map<
       string,
-      {
-        setState: (updater: (prev: AnyRouteMatch) => AnyRouteMatch) => void
-      }
+      Pick<RouterWritableStore<AnyRouteMatch>, 'set'>
     >
     activeMatchStoresById: Map<
       string,
-      {
-        setState: (updater: (prev: AnyRouteMatch) => AnyRouteMatch) => void
-      }
+      Pick<RouterWritableStore<AnyRouteMatch>, 'set'>
     >
   }
 }

--- a/packages/router-plugin/src/core/route-hmr-statement.ts
+++ b/packages/router-plugin/src/core/route-hmr-statement.ts
@@ -96,9 +96,9 @@ function handleRouteUpdate(
   walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree)
 
   const filter = (m: AnyRouteMatch) => m.routeId === oldRoute.id
-  const activeMatch = router.stores.activeMatchesSnapshot.state.find(filter)
-  const pendingMatch = router.stores.pendingMatchesSnapshot.state.find(filter)
-  const cachedMatches = router.stores.cachedMatchesSnapshot.state.filter(filter)
+  const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter)
+  const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter)
+  const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter)
 
   if (activeMatch || pendingMatch || cachedMatches.length > 0) {
     // Clear stale match data for removed route options BEFORE invalidating.
@@ -122,7 +122,7 @@ function handleRouteUpdate(
             router.stores.activeMatchStoresById.get(matchId) ||
             router.stores.cachedMatchStoresById.get(matchId)
           if (store) {
-            store.setState((prev) => {
+            store.set((prev) => {
               const next: AnyRouteMatchWithPrivateProps = { ...prev }
 
               if (removedKeys.has('loader')) {

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@true.tsx
@@ -77,9 +77,9 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.state.find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.state.find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.state.filter(filter);
+        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
+        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
+        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
@@ -87,7 +87,7 @@ if (import.meta.hot) {
               for (const matchId of matchIds) {
                 const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
                 if (store) {
-                  store.setState(prev => {
+                  store.set(prev => {
                     const next = {
                       ...prev
                     };

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@webpack-hot.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@webpack-hot.tsx
@@ -77,9 +77,9 @@ if (import.meta.webpackHot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.state.find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.state.find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.state.filter(filter);
+        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
+        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
+        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
@@ -87,7 +87,7 @@ if (import.meta.webpackHot) {
               for (const matchId of matchIds) {
                 const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
                 if (store) {
-                  store.setState(prev => {
+                  store.set(prev => {
                     const next = {
                       ...prev
                     };

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRoute-inline-component@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRoute-inline-component@true.tsx
@@ -66,9 +66,9 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.state.find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.state.find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.state.filter(filter);
+        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
+        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
+        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
@@ -76,7 +76,7 @@ if (import.meta.hot) {
               for (const matchId of matchIds) {
                 const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
                 if (store) {
-                  store.setState(prev => {
+                  store.set(prev => {
                     const next = {
                       ...prev
                     };

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/explicit-undefined-component@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/explicit-undefined-component@true.tsx
@@ -65,9 +65,9 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.state.find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.state.find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.state.filter(filter);
+        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
+        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
+        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
@@ -75,7 +75,7 @@ if (import.meta.hot) {
               for (const matchId of matchIds) {
                 const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
                 if (store) {
-                  store.setState(prev => {
+                  store.set(prev => {
                     const next = {
                       ...prev
                     };

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/function-declaration@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/function-declaration@true.tsx
@@ -77,9 +77,9 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.state.find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.state.find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.state.filter(filter);
+        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
+        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
+        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
@@ -87,7 +87,7 @@ if (import.meta.hot) {
               for (const matchId of matchIds) {
                 const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
                 if (store) {
-                  store.setState(prev => {
+                  store.set(prev => {
                     const next = {
                       ...prev
                     };

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/multi-component@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/multi-component@true.tsx
@@ -87,9 +87,9 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.state.find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.state.find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.state.filter(filter);
+        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
+        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
+        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
@@ -97,7 +97,7 @@ if (import.meta.hot) {
               for (const matchId of matchIds) {
                 const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
                 if (store) {
-                  store.setState(prev => {
+                  store.set(prev => {
                     const next = {
                       ...prev
                     };

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/string-literal-keys@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/string-literal-keys@true.tsx
@@ -87,9 +87,9 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.state.find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.state.find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.state.filter(filter);
+        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
+        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
+        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
@@ -97,7 +97,7 @@ if (import.meta.hot) {
               for (const matchId of matchIds) {
                 const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
                 if (store) {
-                  store.setState(prev => {
+                  store.set(prev => {
                     const next = {
                       ...prev
                     };

--- a/packages/router-plugin/tests/add-hmr/snapshots/solid/arrow-function@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/solid/arrow-function@true.tsx
@@ -47,9 +47,9 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.state.find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.state.find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.state.filter(filter);
+        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
+        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
+        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
@@ -57,7 +57,7 @@ if (import.meta.hot) {
               for (const matchId of matchIds) {
                 const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
                 if (store) {
-                  store.setState(prev => {
+                  store.set(prev => {
                     const next = {
                       ...prev
                     };

--- a/packages/router-ssr-query-core/src/index.ts
+++ b/packages/router-ssr-query-core/src/index.ts
@@ -140,7 +140,7 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
         ...ogMutationCacheConfig,
         onError: (error, ...rest) => {
           if (isRedirect(error)) {
-            error.options._fromLocation = router.stores.location.state
+            error.options._fromLocation = router.stores.location.get()
             return router.navigate(router.resolveRedirect(error).options)
           }
 
@@ -153,7 +153,7 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
         ...ogQueryCacheConfig,
         onError: (error, ...rest) => {
           if (isRedirect(error)) {
-            error.options._fromLocation = router.stores.location.state
+            error.options._fromLocation = router.stores.location.get()
             return router.navigate(router.resolveRedirect(error).options)
           }
 

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -24,7 +24,7 @@ export const Match = (props: { matchId: string }) => {
   const match = Solid.createMemo(() => {
     const id = props.matchId
     if (!id) return undefined
-    return router.stores.activeMatchStoresById.get(id)?.state
+    return router.stores.activeMatchStoresById.get(id)?.get()
   })
 
   const rawMatchState = Solid.createMemo(() => {
@@ -49,7 +49,7 @@ export const Match = (props: { matchId: string }) => {
   const hasPendingMatch = Solid.createMemo(() => {
     const currentRouteId = rawMatchState()?.routeId
     return currentRouteId
-      ? Boolean(router.stores.pendingRouteIds.state[currentRouteId])
+      ? Boolean(router.stores.pendingRouteIds.get()[currentRouteId])
       : false
   })
   const nearestMatch = {
@@ -113,7 +113,7 @@ export const Match = (props: { matchId: string }) => {
               >
                 <Dynamic
                   component={ResolvedCatchBoundary()}
-                  getResetKey={() => router.stores.loadedAt.state}
+                  getResetKey={() => router.stores.loadedAt.get()}
                   errorComponent={routeErrorComponent() || ErrorComponent}
                   onCatch={(error: Error) => {
                     // Forward not found errors (we don't want to show the error component for these)
@@ -202,15 +202,15 @@ function OnRendered() {
   const router = useRouter()
 
   const location = Solid.createMemo(
-    () => router.stores.resolvedLocation.state?.state.__TSR_key,
+    () => router.stores.resolvedLocation.get()?.state.__TSR_key,
   )
   Solid.createEffect(
     Solid.on([location], () => {
       router.emit({
         type: 'onRendered',
         ...getLocationChangeInfo(
-          router.stores.location.state,
-          router.stores.resolvedLocation.state,
+          router.stores.location.get(),
+          router.stores.resolvedLocation.get(),
         ),
       })
     }),
@@ -459,14 +459,14 @@ export const Outlet = () => {
   const childMatchId = Solid.createMemo(() => {
     const currentRouteId = routeId()
     return currentRouteId
-      ? router.stores.childMatchIdByRouteId.state[currentRouteId]
+      ? router.stores.childMatchIdByRouteId.get()[currentRouteId]
       : undefined
   })
 
   const childMatchStatus = Solid.createMemo(() => {
     const id = childMatchId()
     if (!id) return undefined
-    return router.stores.activeMatchStoresById.get(id)?.state.status
+    return router.stores.activeMatchStoresById.get(id)?.get().status
   })
 
   // Only show not-found if we're not in a redirected state

--- a/packages/solid-router/src/Matches.tsx
+++ b/packages/solid-router/src/Matches.tsx
@@ -62,17 +62,17 @@ export function Matches() {
 
 function MatchesInner() {
   const router = useRouter()
-  const matchId = () => router.stores.firstMatchId.state
+  const matchId = () => router.stores.firstMatchId.get()
   const routeId = () => (matchId() ? rootRouteId : undefined)
   const match = () =>
     routeId()
-      ? router.stores.getMatchStoreByRouteId(rootRouteId).state
+      ? router.stores.getMatchStoreByRouteId(rootRouteId).get()
       : undefined
   const hasPendingMatch = () =>
     routeId()
-      ? Boolean(router.stores.pendingRouteIds.state[rootRouteId])
+      ? Boolean(router.stores.pendingRouteIds.get()[rootRouteId])
       : false
-  const resetKey = () => router.stores.loadedAt.state
+  const resetKey = () => router.stores.loadedAt.get()
   const nearestMatch = {
     matchId,
     routeId,
@@ -142,7 +142,7 @@ export function useMatchRoute<TRouter extends AnyRouter = RegisteredRouter>() {
     return Solid.createMemo(() => {
       const { pending, caseSensitive, fuzzy, includeSearch, ...rest } = opts
 
-      router.stores.matchRouteReactivity.state
+      router.stores.matchRouteReactivity.get()
       return router.matchRoute(rest as any, {
         pending,
         caseSensitive,
@@ -211,7 +211,7 @@ export function useMatches<
 ): Solid.Accessor<UseMatchesResult<TRouter, TSelected>> {
   const router = useRouter<TRouter>()
   return Solid.createMemo((prev: TSelected | undefined) => {
-    const matches = router.stores.activeMatchesSnapshot.state as Array<
+    const matches = router.stores.activeMatchesSnapshot.get() as Array<
       MakeRouteMatchUnion<TRouter>
     >
     const res = opts?.select ? opts.select(matches) : matches

--- a/packages/solid-router/src/Scripts.tsx
+++ b/packages/solid-router/src/Scripts.tsx
@@ -6,8 +6,8 @@ import type { RouterManagedTag } from '@tanstack/router-core'
 export const Scripts = () => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce
-  const activeMatches = Solid.createMemo(
-    () => router.stores.activeMatchesSnapshot.get(),
+  const activeMatches = Solid.createMemo(() =>
+    router.stores.activeMatchesSnapshot.get(),
   )
   const assetScripts = Solid.createMemo(() => {
     const assetScripts: Array<RouterManagedTag> = []

--- a/packages/solid-router/src/Scripts.tsx
+++ b/packages/solid-router/src/Scripts.tsx
@@ -7,7 +7,7 @@ export const Scripts = () => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce
   const activeMatches = Solid.createMemo(
-    () => router.stores.activeMatchesSnapshot.state,
+    () => router.stores.activeMatchesSnapshot.get(),
   )
   const assetScripts = Solid.createMemo(() => {
     const assetScripts: Array<RouterManagedTag> = []

--- a/packages/solid-router/src/Transitioner.tsx
+++ b/packages/solid-router/src/Transitioner.tsx
@@ -19,8 +19,8 @@ export function Transitioner() {
   const [isSolidTransitioning, startSolidTransition] = Solid.useTransition()
 
   // Track pending state changes
-  const hasPendingMatches = Solid.createMemo(
-    () => router.stores.hasPendingMatches.get(),
+  const hasPendingMatches = Solid.createMemo(() =>
+    router.stores.hasPendingMatches.get(),
   )
 
   const isAnyPending = Solid.createMemo(
@@ -135,9 +135,7 @@ export function Transitioner() {
 
       Solid.batch(() => {
         router.stores.status.set(() => 'idle')
-        router.stores.resolvedLocation.set(
-          () => router.stores.location.get(),
-        )
+        router.stores.resolvedLocation.set(() => router.stores.location.get())
       })
 
       if (changeInfo.hrefChanged) {

--- a/packages/solid-router/src/Transitioner.tsx
+++ b/packages/solid-router/src/Transitioner.tsx
@@ -10,7 +10,7 @@ import { useRouter } from './useRouter'
 export function Transitioner() {
   const router = useRouter()
   let mountLoadForRouter = { router, mounted: false }
-  const isLoading = Solid.createMemo(() => router.stores.isLoading.state)
+  const isLoading = Solid.createMemo(() => router.stores.isLoading.get())
 
   if (isServer ?? router.isServer) {
     return null
@@ -20,7 +20,7 @@ export function Transitioner() {
 
   // Track pending state changes
   const hasPendingMatches = Solid.createMemo(
-    () => router.stores.hasPendingMatches.state,
+    () => router.stores.hasPendingMatches.get(),
   )
 
   const isAnyPending = Solid.createMemo(
@@ -95,8 +95,8 @@ export function Transitioner() {
       router.emit({
         type: 'onLoad',
         ...getLocationChangeInfo(
-          router.stores.location.state,
-          router.stores.resolvedLocation.state,
+          router.stores.location.get(),
+          router.stores.resolvedLocation.get(),
         ),
       })
     }
@@ -111,8 +111,8 @@ export function Transitioner() {
       router.emit({
         type: 'onBeforeRouteMount',
         ...getLocationChangeInfo(
-          router.stores.location.state,
-          router.stores.resolvedLocation.state,
+          router.stores.location.get(),
+          router.stores.resolvedLocation.get(),
         ),
       })
     }
@@ -125,8 +125,8 @@ export function Transitioner() {
 
     if (previousIsAnyPending && !currentIsAnyPending) {
       const changeInfo = getLocationChangeInfo(
-        router.stores.location.state,
-        router.stores.resolvedLocation.state,
+        router.stores.location.get(),
+        router.stores.resolvedLocation.get(),
       )
       router.emit({
         type: 'onResolved',
@@ -134,9 +134,9 @@ export function Transitioner() {
       })
 
       Solid.batch(() => {
-        router.stores.status.setState(() => 'idle')
-        router.stores.resolvedLocation.setState(
-          () => router.stores.location.state,
+        router.stores.status.set(() => 'idle')
+        router.stores.resolvedLocation.set(
+          () => router.stores.location.get(),
         )
       })
 

--- a/packages/solid-router/src/Transitioner.tsx
+++ b/packages/solid-router/src/Transitioner.tsx
@@ -134,8 +134,8 @@ export function Transitioner() {
       })
 
       Solid.batch(() => {
-        router.stores.status.set(() => 'idle')
-        router.stores.resolvedLocation.set(() => router.stores.location.get())
+        router.stores.status.set('idle')
+        router.stores.resolvedLocation.set(router.stores.location.get())
       })
 
       if (changeInfo.hrefChanged) {

--- a/packages/solid-router/src/headContentUtils.tsx
+++ b/packages/solid-router/src/headContentUtils.tsx
@@ -19,7 +19,7 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce
   const activeMatches = Solid.createMemo(
-    () => router.stores.activeMatchesSnapshot.state,
+    () => router.stores.activeMatchesSnapshot.get(),
   )
   const routeMeta = Solid.createMemo(() =>
     activeMatches()

--- a/packages/solid-router/src/headContentUtils.tsx
+++ b/packages/solid-router/src/headContentUtils.tsx
@@ -18,8 +18,8 @@ import type {
 export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce
-  const activeMatches = Solid.createMemo(
-    () => router.stores.activeMatchesSnapshot.get(),
+  const activeMatches = Solid.createMemo(() =>
+    router.stores.activeMatchesSnapshot.get(),
   )
   const routeMeta = Solid.createMemo(() =>
     activeMatches()

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -125,7 +125,7 @@ export function useLinkProps<
   ])
 
   const currentLocation = Solid.createMemo(
-    () => router.stores.location.state,
+    () => router.stores.location.get(),
     undefined,
     { equals: (prev, next) => prev.href === next.href },
   )

--- a/packages/solid-router/src/not-found.tsx
+++ b/packages/solid-router/src/not-found.tsx
@@ -27,8 +27,8 @@ export function CatchNotFound(props: {
 }) {
   const router = useRouter()
   // TODO: Some way for the user to programmatically reset the not-found boundary?
-  const pathname = Solid.createMemo(() => router.stores.location.state.pathname)
-  const status = Solid.createMemo(() => router.stores.status.state)
+  const pathname = Solid.createMemo(() => router.stores.location.get().pathname)
+  const status = Solid.createMemo(() => router.stores.status.get())
 
   return (
     <CatchBoundary

--- a/packages/solid-router/src/routerStores.ts
+++ b/packages/solid-router/src/routerStores.ts
@@ -28,7 +28,7 @@ function initRouterStores(
   ) => RouterReadableStore<TValue>,
 ) {
   stores.childMatchIdByRouteId = createReadonlyStore(() => {
-    const ids = stores.matchesId.state
+    const ids = stores.matchesId.get()
     const obj: Record<string, string> = {}
     for (let i = 0; i < ids.length - 1; i++) {
       const parentStore = stores.activeMatchStoresById.get(ids[i]!)
@@ -40,7 +40,7 @@ function initRouterStores(
   })
 
   stores.pendingRouteIds = createReadonlyStore(() => {
-    const ids = stores.pendingMatchesId.state
+    const ids = stores.pendingMatchesId.get()
     const obj: Record<string, boolean> = {}
     for (const id of ids) {
       const store = stores.pendingMatchStoresById.get(id)
@@ -57,12 +57,7 @@ function createSolidMutableStore<TValue>(
 ): RouterWritableStore<TValue> {
   const [signal, setSignal] = Solid.createSignal(initialValue)
 
-  return {
-    get state() {
-      return signal()
-    },
-    setState: setSignal,
-  }
+  return { get: signal, set: setSignal }
 }
 
 let finalizationRegistry: FinalizationRegistry<() => void> | null = null
@@ -78,11 +73,7 @@ function createSolidReadonlyStore<TValue>(
     dispose = d
     return Solid.createMemo(read)
   })
-  const store = {
-    get state() {
-      return memo()
-    },
-  }
+  const store = { get: memo }
   finalizationRegistry?.register(store, dispose)
   return store
 }

--- a/packages/solid-router/src/ssr/RouterClient.tsx
+++ b/packages/solid-router/src/ssr/RouterClient.tsx
@@ -11,7 +11,7 @@ const Dummy = (props: { children?: JSXElement }) => <>{props.children}</>
 
 export function RouterClient(props: { router: AnyRouter }) {
   if (!hydrationPromise) {
-    if (!props.router.stores.matchesId.state.length) {
+    if (!props.router.stores.matchesId.get().length) {
       hydrationPromise = hydrate(props.router)
     } else {
       hydrationPromise = Promise.resolve()

--- a/packages/solid-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/solid-router/src/ssr/renderRouterToStream.tsx
@@ -52,7 +52,7 @@ export const renderRouterToStream = async ({
     readable as unknown as ReadableStream,
   )
   return new Response(responseStream as any, {
-    status: router.stores.statusCode.state,
+    status: router.stores.statusCode.get(),
     headers: responseHeaders,
   })
 }

--- a/packages/solid-router/src/ssr/renderRouterToString.tsx
+++ b/packages/solid-router/src/ssr/renderRouterToString.tsx
@@ -32,7 +32,7 @@ export const renderRouterToString = ({
       html = html.replace(`</body>`, () => `${injectedHtml}</body>`)
     }
     return new Response(`<!DOCTYPE html>${html}`, {
-      status: router.stores.statusCode.state,
+      status: router.stores.statusCode.get(),
       headers: responseHeaders,
     })
   } catch (error) {

--- a/packages/solid-router/src/useCanGoBack.ts
+++ b/packages/solid-router/src/useCanGoBack.ts
@@ -4,6 +4,6 @@ import { useRouter } from './useRouter'
 export function useCanGoBack() {
   const router = useRouter()
   return Solid.createMemo(
-    () => router.stores.location.state.state.__TSR_index !== 0,
+    () => router.stores.location.get().state.__TSR_index !== 0,
   )
 }

--- a/packages/solid-router/src/useLocation.tsx
+++ b/packages/solid-router/src/useLocation.tsx
@@ -28,7 +28,7 @@ export function useLocation<
   const router = useRouter<TRouter>()
 
   if (!opts?.select) {
-    return (() => router.stores.location.state) as Accessor<
+    return (() => router.stores.location.get()) as Accessor<
       UseLocationResult<TRouter, TSelected>
     >
   }
@@ -36,7 +36,7 @@ export function useLocation<
   const select = opts.select
 
   return Solid.createMemo((prev: TSelected | undefined) => {
-    const res = select(router.stores.location.state)
+    const res = select(router.stores.location.get())
     if (prev === undefined) return res
     return replaceEqualDeep(prev, res)
   }) as Accessor<UseLocationResult<TRouter, TSelected>>

--- a/packages/solid-router/src/useMatch.tsx
+++ b/packages/solid-router/src/useMatch.tsx
@@ -76,7 +76,7 @@ export function useMatch<
 
   const match = () => {
     if (opts.from) {
-      return router.stores.getMatchStoreByRouteId(opts.from).state
+      return router.stores.getMatchStoreByRouteId(opts.from).get()
     }
 
     return nearestMatch?.match()
@@ -88,12 +88,12 @@ export function useMatch<
     }
 
     const hasPendingMatch = opts.from
-      ? Boolean(router.stores.pendingRouteIds.state[opts.from!])
+      ? Boolean(router.stores.pendingRouteIds.get()[opts.from!])
       : (nearestMatch?.hasPending() ?? false)
 
     if (
       !hasPendingMatch &&
-      !router.stores.isTransitioning.state &&
+      !router.stores.isTransitioning.get() &&
       (opts.shouldThrow ?? true)
     ) {
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/solid-router/src/useRouterState.tsx
+++ b/packages/solid-router/src/useRouterState.tsx
@@ -35,7 +35,7 @@ export function useRouterState<
   // implementation does not provide subscribe() semantics.
   const _isServer = isServer ?? router.isServer
   if (_isServer) {
-    const state = router.stores.__store.state as RouterState<
+    const state = router.stores.__store.get() as RouterState<
       TRouter['routeTree']
     >
     const selected = (
@@ -47,7 +47,7 @@ export function useRouterState<
   }
 
   if (!opts?.select) {
-    return (() => router.stores.__store.state) as Accessor<
+    return (() => router.stores.__store.get()) as Accessor<
       UseRouterStateResult<TRouter, TSelected>
     >
   }
@@ -55,7 +55,7 @@ export function useRouterState<
   const select = opts.select
 
   return Solid.createMemo((prev: TSelected | undefined) => {
-    const res = select(router.stores.__store.state)
+    const res = select(router.stores.__store.get())
     if (prev === undefined) return res
     return replaceEqualDeep(prev, res)
   }) as Accessor<UseRouterStateResult<TRouter, TSelected>>

--- a/packages/solid-start/src/useServerFn.ts
+++ b/packages/solid-start/src/useServerFn.ts
@@ -16,7 +16,7 @@ export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
       return res
     } catch (err) {
       if (isRedirect(err)) {
-        err.options._fromLocation = router.stores.location.state
+        err.options._fromLocation = router.stores.location.get()
         return router.navigate(router.resolveRedirect(err).options)
       }
 

--- a/packages/start-client-core/src/client/hydrateStart.ts
+++ b/packages/start-client-core/src/client/hydrateStart.ts
@@ -41,7 +41,7 @@ export async function hydrateStart(): Promise<AnyRouter> {
     basepath: process.env.TSS_ROUTER_BASEPATH,
     ...{ serializationAdapters },
   })
-  if (!router.stores.matchesId.state.length) {
+  if (!router.stores.matchesId.get().length) {
     await hydrate(router)
   }
 

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -202,7 +202,7 @@ function getStartResponseHeaders(opts: { router: AnyRouter }) {
     {
       'Content-Type': 'text/html; charset=utf-8',
     },
-    ...opts.router.stores.activeMatchesSnapshot.state.map((match) => {
+    ...opts.router.stores.activeMatchesSnapshot.get().map((match) => {
       return match.headers
     }),
   )

--- a/packages/vue-router/src/Match.tsx
+++ b/packages/vue-router/src/Match.tsx
@@ -268,8 +268,8 @@ const OnRendered = Vue.defineComponent({
             router.emit({
               type: 'onRendered',
               ...getLocationChangeInfo(
-                router.stores.location.state,
-                router.stores.resolvedLocation.state,
+                router.stores.location.get(),
+                router.stores.resolvedLocation.get(),
               ),
             })
             prevHref = currentHref
@@ -525,7 +525,7 @@ export const Outlet = Vue.defineComponent({
     const childMatchData = Vue.computed(() => {
       const childId = childMatchIdMap.value[parentRouteId]
       if (!childId) return null
-      const child = router.stores.activeMatchStoresById.get(childId)?.state
+      const child = router.stores.activeMatchStoresById.get(childId)?.get()
       if (!child) return null
 
       return {

--- a/packages/vue-router/src/Transitioner.tsx
+++ b/packages/vue-router/src/Transitioner.tsx
@@ -143,9 +143,7 @@ export function useTransitionerSetup() {
       if (router.stores.status.get() === 'pending') {
         batch(() => {
           router.stores.status.set(() => 'idle')
-          router.stores.resolvedLocation.set(
-            () => router.stores.location.get(),
-          )
+          router.stores.resolvedLocation.set(() => router.stores.location.get())
         })
       }
     }
@@ -223,9 +221,7 @@ export function useTransitionerSetup() {
       if (!newValue && router.stores.status.get() === 'pending') {
         batch(() => {
           router.stores.status.set(() => 'idle')
-          router.stores.resolvedLocation.set(
-            () => router.stores.location.get(),
-          )
+          router.stores.resolvedLocation.set(() => router.stores.location.get())
         })
       }
 

--- a/packages/vue-router/src/Transitioner.tsx
+++ b/packages/vue-router/src/Transitioner.tsx
@@ -60,7 +60,7 @@ export function useTransitionerSetup() {
     isTransitioning.value = true
     // Also update the router state so useMatch knows we're transitioning
     try {
-      router.stores.isTransitioning.set(() => true)
+      router.stores.isTransitioning.set(true)
     } catch {
       // Ignore errors if component is unmounted
     }
@@ -71,7 +71,7 @@ export function useTransitionerSetup() {
       Vue.nextTick(() => {
         try {
           isTransitioning.value = false
-          router.stores.isTransitioning.set(() => false)
+          router.stores.isTransitioning.set(false)
         } catch {
           // Ignore errors if component is unmounted
         }
@@ -142,8 +142,8 @@ export function useTransitionerSetup() {
     if (!isAnyPending.value) {
       if (router.stores.status.get() === 'pending') {
         batch(() => {
-          router.stores.status.set(() => 'idle')
-          router.stores.resolvedLocation.set(() => router.stores.location.get())
+          router.stores.status.set('idle')
+          router.stores.resolvedLocation.set(router.stores.location.get())
         })
       }
     }
@@ -220,8 +220,8 @@ export function useTransitionerSetup() {
     try {
       if (!newValue && router.stores.status.get() === 'pending') {
         batch(() => {
-          router.stores.status.set(() => 'idle')
-          router.stores.resolvedLocation.set(() => router.stores.location.get())
+          router.stores.status.set('idle')
+          router.stores.resolvedLocation.set(router.stores.location.get())
         })
       }
 

--- a/packages/vue-router/src/Transitioner.tsx
+++ b/packages/vue-router/src/Transitioner.tsx
@@ -60,7 +60,7 @@ export function useTransitionerSetup() {
     isTransitioning.value = true
     // Also update the router state so useMatch knows we're transitioning
     try {
-      router.stores.isTransitioning.setState(() => true)
+      router.stores.isTransitioning.set(() => true)
     } catch {
       // Ignore errors if component is unmounted
     }
@@ -71,7 +71,7 @@ export function useTransitionerSetup() {
       Vue.nextTick(() => {
         try {
           isTransitioning.value = false
-          router.stores.isTransitioning.setState(() => false)
+          router.stores.isTransitioning.set(() => false)
         } catch {
           // Ignore errors if component is unmounted
         }
@@ -140,11 +140,11 @@ export function useTransitionerSetup() {
   Vue.onMounted(() => {
     isMounted.value = true
     if (!isAnyPending.value) {
-      if (router.stores.status.state === 'pending') {
+      if (router.stores.status.get() === 'pending') {
         batch(() => {
-          router.stores.status.setState(() => 'idle')
-          router.stores.resolvedLocation.setState(
-            () => router.stores.location.state,
+          router.stores.status.set(() => 'idle')
+          router.stores.resolvedLocation.set(
+            () => router.stores.location.get(),
           )
         })
       }
@@ -188,8 +188,8 @@ export function useTransitionerSetup() {
           router.emit({
             type: 'onLoad',
             ...getLocationChangeInfo(
-              router.stores.location.state,
-              router.stores.resolvedLocation.state,
+              router.stores.location.get(),
+              router.stores.resolvedLocation.get(),
             ),
           })
         }
@@ -207,8 +207,8 @@ export function useTransitionerSetup() {
         router.emit({
           type: 'onBeforeRouteMount',
           ...getLocationChangeInfo(
-            router.stores.location.state,
-            router.stores.resolvedLocation.state,
+            router.stores.location.get(),
+            router.stores.resolvedLocation.get(),
           ),
         })
       }
@@ -220,11 +220,11 @@ export function useTransitionerSetup() {
   Vue.watch(isAnyPending, (newValue) => {
     if (!isMounted.value) return
     try {
-      if (!newValue && router.stores.status.state === 'pending') {
+      if (!newValue && router.stores.status.get() === 'pending') {
         batch(() => {
-          router.stores.status.setState(() => 'idle')
-          router.stores.resolvedLocation.setState(
-            () => router.stores.location.state,
+          router.stores.status.set(() => 'idle')
+          router.stores.resolvedLocation.set(
+            () => router.stores.location.get(),
           )
         })
       }
@@ -232,8 +232,8 @@ export function useTransitionerSetup() {
       // The router was pending and now it's not
       if (previousIsAnyPending.value.previous && !newValue) {
         const changeInfo = getLocationChangeInfo(
-          router.stores.location.state,
-          router.stores.resolvedLocation.state,
+          router.stores.location.get(),
+          router.stores.resolvedLocation.get(),
         )
         router.emit({
           type: 'onResolved',

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -186,7 +186,7 @@ export function useLinkProps<
     })
 
     const isActive = getIsActive({
-      loc: router.stores.location.state,
+      loc: router.stores.location.get(),
       nextLoc: next,
       activeOptions: options.activeOptions,
       router,

--- a/packages/vue-router/src/routerStores.ts
+++ b/packages/vue-router/src/routerStores.ts
@@ -1,4 +1,4 @@
-import { batch, createStore } from '@tanstack/vue-store'
+import { batch, createAtom } from '@tanstack/vue-store'
 import type {
   AnyRoute,
   GetStoreConfig,
@@ -18,16 +18,16 @@ declare module '@tanstack/router-core' {
 
 export const getStoreFactory: GetStoreConfig = (_opts) => {
   return {
-    createMutableStore: createStore,
-    createReadonlyStore: createStore,
+    createMutableStore: createAtom,
+    createReadonlyStore: createAtom,
     batch,
     init: (stores: RouterStores<AnyRoute>) => {
       // Single derived store: one reactive node that maps every active
       // routeId to its child's matchId. Depends only on matchesId +
       // the pool's routeId tags (which are set during reconciliation).
       // Outlet reads the map and then does a direct pool lookup.
-      stores.childMatchIdByRouteId = createStore(() => {
-        const ids = stores.matchesId.state
+      stores.childMatchIdByRouteId = createAtom(() => {
+        const ids = stores.matchesId.get()
         const obj: Record<string, string> = {}
         for (let i = 0; i < ids.length - 1; i++) {
           const parentStore = stores.activeMatchStoresById.get(ids[i]!)
@@ -38,8 +38,8 @@ export const getStoreFactory: GetStoreConfig = (_opts) => {
         return obj
       })
 
-      stores.pendingRouteIds = createStore(() => {
-        const ids = stores.pendingMatchesId.state
+      stores.pendingRouteIds = createAtom(() => {
+        const ids = stores.pendingMatchesId.get()
         const obj: Record<string, boolean> = {}
         for (const id of ids) {
           const store = stores.pendingMatchStoresById.get(id)

--- a/packages/vue-router/src/ssr/RouterClient.tsx
+++ b/packages/vue-router/src/ssr/RouterClient.tsx
@@ -18,7 +18,7 @@ export const RouterClient = Vue.defineComponent({
     const isHydrated = Vue.ref(false)
 
     if (!hydrationPromise) {
-      if (!props.router.stores.matchesId.state.length) {
+      if (!props.router.stores.matchesId.get().length) {
         hydrationPromise = hydrate(props.router)
       } else {
         hydrationPromise = Promise.resolve()

--- a/packages/vue-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/vue-router/src/ssr/renderRouterToStream.tsx
@@ -62,7 +62,7 @@ export const renderRouterToStream = async ({
     }
 
     return new Response(`<!DOCTYPE html>${fullHtml}`, {
-      status: router.stores.statusCode.state,
+      status: router.stores.statusCode.get(),
       headers: responseHeaders,
     })
   }
@@ -78,7 +78,7 @@ export const renderRouterToStream = async ({
   )
 
   return new Response(responseStream as any, {
-    status: router.stores.statusCode.state,
+    status: router.stores.statusCode.get(),
     headers: responseHeaders,
   })
 }

--- a/packages/vue-router/src/ssr/renderRouterToString.tsx
+++ b/packages/vue-router/src/ssr/renderRouterToString.tsx
@@ -24,7 +24,7 @@ export const renderRouterToString = async ({
     }
 
     return new Response(`<!DOCTYPE html>${html}`, {
-      status: router.stores.statusCode.state,
+      status: router.stores.statusCode.get(),
       headers: responseHeaders,
     })
   } catch (error) {

--- a/packages/vue-router/src/useMatch.tsx
+++ b/packages/vue-router/src/useMatch.tsx
@@ -85,7 +85,7 @@ export function useMatch<
       (opts.from ?? nearestRouteId)
         ? router.stores.getMatchStoreByRouteId(opts.from ?? nearestRouteId!)
         : undefined
-    const match = matchStore?.state
+    const match = matchStore?.get()
 
     if ((opts.shouldThrow ?? true) && !match) {
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/vue-router/src/useRouterState.tsx
+++ b/packages/vue-router/src/useRouterState.tsx
@@ -42,7 +42,7 @@ export function useRouterState<
   const _isServer = isServer ?? router.isServer
 
   if (_isServer) {
-    const state = router.stores.__store.state as RouterState<
+    const state = router.stores.__store.get() as RouterState<
       TRouter['routeTree']
     >
     return Vue.ref(opts?.select ? opts.select(state) : state) as Vue.Ref<

--- a/packages/vue-start/src/useServerFn.ts
+++ b/packages/vue-start/src/useServerFn.ts
@@ -16,7 +16,7 @@ export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
       return res
     } catch (err) {
       if (isRedirect(err)) {
-        err.options._fromLocation = router.stores.location.state
+        err.options._fromLocation = router.stores.location.get()
         return router.navigate(router.resolveRedirect(err).options)
       }
 


### PR DESCRIPTION
## Summary
- switch the router store contract from `state`/`setState` to `get`/`set` and move the React and Vue adapters from `createStore` to `createAtom`
- update the Solid adapter and replace router store reads and writes across router, start, devtools, and plugin codepaths without keeping a compatibility layer
- refresh affected tests and snapshots to cover the new store API

## Testing
- `CI=1 NX_DAEMON=false pnpm nx affected --target=test:eslint --exclude=examples/**,e2e/** --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx affected --target=test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx affected --target=test:unit --outputStyle=stream --skipRemoteCache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified internal store access and update behavior across router packages (React, Solid, Vue), core, devtools, HMR, SSR/hydration, and tests—improving consistency and reliability for server rendering, hydration, hot-reload, and runtime flows while preserving public APIs and external behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->