### PR TITLE
refactor: shorten internal router store names

### DIFF
--- a/.changeset/tall-pears-arrive.md
+++ b/.changeset/tall-pears-arrive.md
@@ -1,0 +1,11 @@
+---
+'@tanstack/router-devtools-core': patch
+'@tanstack/start-server-core': patch
+'@tanstack/router-plugin': patch
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/router-core': patch
+'@tanstack/vue-router': patch
+---
+
+shorten internal non-minifiable store names for byte shaving

--- a/e2e/react-start/hmr/tests/app.spec.ts
+++ b/e2e/react-start/hmr/tests/app.spec.ts
@@ -142,7 +142,7 @@ async function waitForRouteLoaderCrumb(
 async function waitForRouteRemovalReload(page: Page) {
   await page.waitForFunction(() => {
     const router = (window as any).__TSR_ROUTER__
-    const match = router?.stores?.activeMatchesSnapshot
+    const match = router?.stores?.matches
       ?.get()
       ?.find((entry: any) => entry.routeId === '/child')
 

--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -30,7 +30,7 @@ export const Match = React.memo(function MatchImpl({
   const router = useRouter()
 
   if (isServer ?? router.isServer) {
-    const match = router.stores.activeMatchStoresById.get(matchId)?.get()
+    const match = router.stores.matchStores.get(matchId)?.get()
     if (!match) {
       if (process.env.NODE_ENV !== 'production') {
         throw new Error(
@@ -64,7 +64,7 @@ export const Match = React.memo(function MatchImpl({
   // The matchId prop is stable for this component's lifetime (set by Outlet),
   // and reconcileMatchPool reuses stores for the same matchId.
 
-  const matchStore = router.stores.activeMatchStoresById.get(matchId)
+  const matchStore = router.stores.matchStores.get(matchId)
   if (!matchStore) {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error(
@@ -278,7 +278,7 @@ export const MatchInner = React.memo(function MatchInnerImpl({
   }
 
   if (isServer ?? router.isServer) {
-    const match = router.stores.activeMatchStoresById.get(matchId)?.get()
+    const match = router.stores.matchStores.get(matchId)?.get()
     if (!match) {
       if (process.env.NODE_ENV !== 'production') {
         throw new Error(
@@ -357,7 +357,7 @@ export const MatchInner = React.memo(function MatchInnerImpl({
     return out
   }
 
-  const matchStore = router.stores.activeMatchStoresById.get(matchId)
+  const matchStore = router.stores.matchStores.get(matchId)
   if (!matchStore) {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error(
@@ -504,7 +504,7 @@ export const Outlet = React.memo(function OutletImpl() {
   let childMatchId: string | undefined
 
   if (isServer ?? router.isServer) {
-    const matches = router.stores.activeMatchesSnapshot.get()
+    const matches = router.stores.matches.get()
     const parentIndex = matchId
       ? matches.findIndex((match) => match.id === matchId)
       : -1
@@ -517,7 +517,7 @@ export const Outlet = React.memo(function OutletImpl() {
     // Subscribe directly to the match store from the pool instead of
     // the two-level byId → matchStore pattern.
     const parentMatchStore = matchId
-      ? router.stores.activeMatchStoresById.get(matchId)
+      ? router.stores.matchStores.get(matchId)
       : undefined
 
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -77,9 +77,9 @@ function MatchesInner() {
   const router = useRouter()
   const _isServer = isServer ?? router.isServer
   const matchId = _isServer
-    ? router.stores.firstMatchId.get()
+    ? router.stores.firstId.get()
     : // eslint-disable-next-line react-hooks/rules-of-hooks
-      useStore(router.stores.firstMatchId, (id) => id)
+      useStore(router.stores.firstId, (id) => id)
   const resetKey = _isServer
     ? router.stores.loadedAt.get()
     : // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -142,7 +142,7 @@ export function useMatchRoute<TRouter extends AnyRouter = RegisteredRouter>() {
 
   if (!(isServer ?? router.isServer)) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useStore(router.stores.matchRouteReactivity, (d) => d)
+    useStore(router.stores.matchRouteDeps, (d) => d)
   }
 
   return React.useCallback(
@@ -240,7 +240,7 @@ export function useMatches<
     )
 
   if (isServer ?? router.isServer) {
-    const matches = router.stores.activeMatchesSnapshot.get() as Array<
+    const matches = router.stores.matches.get() as Array<
       MakeRouteMatchUnion<TRouter>
     >
     return (opts?.select ? opts.select(matches) : matches) as UseMatchesResult<
@@ -250,7 +250,7 @@ export function useMatches<
   }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  return useStore(router.stores.activeMatchesSnapshot, (matches) => {
+  return useStore(router.stores.matches, (matches) => {
     const selected = opts?.select
       ? opts.select(matches as Array<MakeRouteMatchUnion<TRouter>>)
       : (matches as any)

--- a/packages/react-router/src/Scripts.tsx
+++ b/packages/react-router/src/Scripts.tsx
@@ -58,7 +58,7 @@ export const Scripts = () => {
     )
 
   if (isServer ?? router.isServer) {
-    const activeMatches = router.stores.activeMatchesSnapshot.get()
+    const activeMatches = router.stores.matches.get()
     const assetScripts = getAssetScripts(activeMatches)
     const scripts = getScripts(activeMatches)
     return renderScripts(router, scripts, assetScripts)
@@ -66,13 +66,13 @@ export const Scripts = () => {
 
   // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
   const assetScripts = useStore(
-    router.stores.activeMatchesSnapshot,
+    router.stores.matches,
     getAssetScripts,
     deepEqual,
   )
   // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
   const scripts = useStore(
-    router.stores.activeMatchesSnapshot,
+    router.stores.matches,
     getScripts,
     deepEqual,
   )

--- a/packages/react-router/src/Scripts.tsx
+++ b/packages/react-router/src/Scripts.tsx
@@ -71,11 +71,7 @@ export const Scripts = () => {
     deepEqual,
   )
   // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
-  const scripts = useStore(
-    router.stores.matches,
-    getScripts,
-    deepEqual,
-  )
+  const scripts = useStore(router.stores.matches, getScripts, deepEqual)
 
   return renderScripts(router, scripts, assetScripts)
 }

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -17,17 +17,17 @@ export function Transitioner() {
   const [isTransitioning, setIsTransitioning] = React.useState(false)
   // Track pending state changes
   const isLoading = useStore(router.stores.isLoading, (value) => value)
-  const hasPendingMatches = useStore(
-    router.stores.hasPendingMatches,
+  const hasPending = useStore(
+    router.stores.hasPending,
     (value) => value,
   )
 
   const previousIsLoading = usePrevious(isLoading)
 
-  const isAnyPending = isLoading || isTransitioning || hasPendingMatches
+  const isAnyPending = isLoading || isTransitioning || hasPending
   const previousIsAnyPending = usePrevious(isAnyPending)
 
-  const isPagePending = isLoading || hasPendingMatches
+  const isPagePending = isLoading || hasPending
   const previousIsPagePending = usePrevious(isPagePending)
 
   router.startTransition = (fn: () => void) => {

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -17,10 +17,7 @@ export function Transitioner() {
   const [isTransitioning, setIsTransitioning] = React.useState(false)
   // Track pending state changes
   const isLoading = useStore(router.stores.isLoading, (value) => value)
-  const hasPending = useStore(
-    router.stores.hasPending,
-    (value) => value,
-  )
+  const hasPending = useStore(router.stores.hasPending, (value) => value)
 
   const previousIsLoading = usePrevious(isLoading)
 

--- a/packages/react-router/src/headContentUtils.tsx
+++ b/packages/react-router/src/headContentUtils.tsx
@@ -194,14 +194,14 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
     return buildTagsFromMatches(
       router,
       nonce,
-      router.stores.activeMatchesSnapshot.get(),
+      router.stores.matches.get(),
       assetCrossOrigin,
     )
   }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
   const routeMeta = useStore(
-    router.stores.activeMatchesSnapshot,
+    router.stores.matches,
     (matches) => {
       return matches.map((match) => match.meta!).filter(Boolean)
     },
@@ -282,7 +282,7 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
 
   // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
   const links = useStore(
-    router.stores.activeMatchesSnapshot,
+    router.stores.matches,
     (matches) => {
       const constructed = matches
         .map((match) => match.links!)
@@ -327,7 +327,7 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
 
   // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
   const preloadLinks = useStore(
-    router.stores.activeMatchesSnapshot,
+    router.stores.matches,
     (matches) => {
       const preloadLinks: Array<RouterManagedTag> = []
 
@@ -359,7 +359,7 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
 
   // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
   const styles = useStore(
-    router.stores.activeMatchesSnapshot,
+    router.stores.matches,
     (matches) =>
       (
         matches
@@ -379,7 +379,7 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
 
   // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
   const headScripts: Array<RouterManagedTag> = useStore(
-    router.stores.activeMatchesSnapshot,
+    router.stores.matches,
     (matches) =>
       (
         matches

--- a/packages/react-router/src/useMatch.tsx
+++ b/packages/react-router/src/useMatch.tsx
@@ -113,8 +113,8 @@ export function useMatch<
   const key = opts.from ?? nearestMatchId
   const matchStore = key
     ? opts.from
-      ? router.stores.getMatchStoreByRouteId(key)
-      : router.stores.activeMatchStoresById.get(key)
+      ? router.stores.getRouteMatchStore(key)
+      : router.stores.matchStores.get(key)
     : undefined
 
   if (isServer ?? router.isServer) {

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -46,13 +46,13 @@ const triggerOnReady = (inner: InnerLoadContext): void | Promise<void> => {
 
 const hasForcePendingActiveMatch = (router: AnyRouter): boolean => {
   return router.stores.matchesId.get().some((matchId) => {
-    return router.stores.activeMatchStoresById.get(matchId)?.get()._forcePending
+    return router.stores.matchStores.get(matchId)?.get()._forcePending
   })
 }
 
 const resolvePreload = (inner: InnerLoadContext, matchId: string): boolean => {
   return !!(
-    inner.preload && !inner.router.stores.activeMatchStoresById.has(matchId)
+    inner.preload && !inner.router.stores.matchStores.has(matchId)
   )
 }
 
@@ -882,12 +882,12 @@ const loadRouteMatch = async (
     const activeIdAtIndex = inner.router.stores.matchesId.get()[index]
     const activeAtIndex =
       (activeIdAtIndex &&
-        inner.router.stores.activeMatchStoresById.get(activeIdAtIndex)) ||
+        inner.router.stores.matchStores.get(activeIdAtIndex)) ||
       null
     const previousRouteMatchId =
       activeAtIndex?.routeId === routeId
         ? activeIdAtIndex
-        : inner.router.stores.activeMatchesSnapshot
+        : inner.router.stores.matches
             .get()
             .find((d) => d.routeId === routeId)?.id
     const preload = resolvePreload(inner, matchId)
@@ -923,7 +923,7 @@ const loadRouteMatch = async (
       }
     } else {
       const nextPreload =
-        preload && !inner.router.stores.activeMatchStoresById.has(matchId)
+        preload && !inner.router.stores.matchStores.has(matchId)
       const match = inner.router.getMatch(matchId)!
       match._nonReactive.loaderPromise = createControlledPromise<void>()
       if (nextPreload !== match.preload) {

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -51,9 +51,7 @@ const hasForcePendingActiveMatch = (router: AnyRouter): boolean => {
 }
 
 const resolvePreload = (inner: InnerLoadContext, matchId: string): boolean => {
-  return !!(
-    inner.preload && !inner.router.stores.matchStores.has(matchId)
-  )
+  return !!(inner.preload && !inner.router.stores.matchStores.has(matchId))
 }
 
 /**
@@ -887,9 +885,8 @@ const loadRouteMatch = async (
     const previousRouteMatchId =
       activeAtIndex?.routeId === routeId
         ? activeIdAtIndex
-        : inner.router.stores.matches
-            .get()
-            .find((d) => d.routeId === routeId)?.id
+        : inner.router.stores.matches.get().find((d) => d.routeId === routeId)
+            ?.id
     const preload = resolvePreload(inner, matchId)
 
     // there is a loaderPromise, so we are in the middle of a load

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1420,7 +1420,7 @@ export class RouterCore<
     // Snapshot of active match state keyed by routeId, used to stabilise
     // params/search across navigations.
     const previousActiveMatchesByRouteId = new Map<string, AnyRouteMatch>()
-    for (const store of this.stores.activeMatchStoresById.values()) {
+    for (const store of this.stores.matchStores.values()) {
       if (store.routeId) {
         previousActiveMatchesByRouteId.set(store.routeId, store.get())
       }
@@ -1718,7 +1718,7 @@ export class RouterCore<
     const lastStateMatchId = last(this.stores.matchesId.get())
     const lastStateMatch =
       lastStateMatchId &&
-      this.stores.activeMatchStoresById.get(lastStateMatchId)?.get()
+      this.stores.matchStores.get(lastStateMatchId)?.get()
     const canReuseParams =
       lastStateMatch &&
       lastStateMatch.routeId === lastRoute.id &&
@@ -1767,16 +1767,16 @@ export class RouterCore<
   }
 
   cancelMatches = () => {
-    this.stores.pendingMatchesId.get().forEach((matchId) => {
+    this.stores.pendingIds.get().forEach((matchId) => {
       this.cancelMatch(matchId)
     })
 
     this.stores.matchesId.get().forEach((matchId) => {
-      if (this.stores.pendingMatchStoresById.has(matchId)) {
+      if (this.stores.pendingMatchStores.has(matchId)) {
         return
       }
 
-      const match = this.stores.activeMatchStoresById.get(matchId)?.get()
+      const match = this.stores.matchStores.get(matchId)?.get()
       if (!match) {
         return
       }
@@ -2356,7 +2356,7 @@ export class RouterCore<
     // Match the routes
     const pendingMatches = this.matchRoutes(this.latestLocation)
 
-    const nextCachedMatches = this.stores.cachedMatchesSnapshot
+    const nextCachedMatches = this.stores.cachedMatches
       .get()
       .filter((d) => !pendingMatches.some((e) => e.id === d.id))
 
@@ -2366,9 +2366,9 @@ export class RouterCore<
       this.stores.statusCode.set(200)
       this.stores.isLoading.set(true)
       this.stores.location.set(this.latestLocation)
-      this.stores.setPendingMatches(pendingMatches)
+      this.stores.setPending(pendingMatches)
       // If a cached match moved to pending matches, remove it from cached matches
-      this.stores.setCachedMatches(nextCachedMatches)
+      this.stores.setCached(nextCachedMatches)
     })
   }
 
@@ -2404,7 +2404,7 @@ export class RouterCore<
             router: this,
             sync: opts?.sync,
             forceStaleReload: previousLocation.href === next.href,
-            matches: this.stores.pendingMatchesSnapshot.get(),
+            matches: this.stores.pendingMatches.get(),
             location: next,
             updateMatch: this.updateMatch,
             // eslint-disable-next-line @typescript-eslint/require-await
@@ -2429,26 +2429,26 @@ export class RouterCore<
 
                   this.batch(() => {
                     const pendingMatches =
-                      this.stores.pendingMatchesSnapshot.get()
+                      this.stores.pendingMatches.get()
                     const mountPending = pendingMatches.length
                     const currentMatches =
-                      this.stores.activeMatchesSnapshot.get()
+                      this.stores.matches.get()
 
                     exitingMatches = mountPending
                       ? currentMatches.filter(
                           (match) =>
-                            !this.stores.pendingMatchStoresById.has(match.id),
+                            !this.stores.pendingMatchStores.has(match.id),
                         )
                       : null
 
                     // Lifecycle-hook identity: routeId only (route presence in tree)
                     // Build routeId sets from pools to avoid derived stores.
                     const pendingRouteIds = new Set<string>()
-                    for (const s of this.stores.pendingMatchStoresById.values()) {
+                    for (const s of this.stores.pendingMatchStores.values()) {
                       if (s.routeId) pendingRouteIds.add(s.routeId)
                     }
                     const activeRouteIds = new Set<string>()
-                    for (const s of this.stores.activeMatchStoresById.values()) {
+                    for (const s of this.stores.matchStores.values()) {
                       if (s.routeId) activeRouteIds.add(s.routeId)
                     }
 
@@ -2477,10 +2477,10 @@ export class RouterCore<
                      * or reloads re-run their loaders instead of reusing the failed/not-found data.
                      */
                     if (mountPending) {
-                      this.stores.setActiveMatches(pendingMatches)
-                      this.stores.setPendingMatches([])
-                      this.stores.setCachedMatches([
-                        ...this.stores.cachedMatchesSnapshot.get(),
+                      this.stores.setMatches(pendingMatches)
+                      this.stores.setPending([])
+                      this.stores.setCached([
+                        ...this.stores.cachedMatches.get(),
                         ...exitingMatches!.filter(
                           (d) =>
                             d.status !== 'error' &&
@@ -2527,7 +2527,7 @@ export class RouterCore<
             ? redirect.status
             : notFound
               ? 404
-              : this.stores.activeMatchesSnapshot
+              : this.stores.matches
                     .get()
                     .some((d) => d.status === 'error')
                 ? 500
@@ -2564,7 +2564,7 @@ export class RouterCore<
     if (this.hasNotFoundMatch()) {
       newStatusCode = 404
     } else if (
-      this.stores.activeMatchesSnapshot.get().some((d) => d.status === 'error')
+      this.stores.matches.get().some((d) => d.status === 'error')
     ) {
       newStatusCode = 500
     }
@@ -2628,25 +2628,25 @@ export class RouterCore<
 
   updateMatch: UpdateMatchFn = (id, updater) => {
     this.startTransition(() => {
-      const pendingMatch = this.stores.pendingMatchStoresById.get(id)
+      const pendingMatch = this.stores.pendingMatchStores.get(id)
       if (pendingMatch) {
         pendingMatch.set(updater)
         return
       }
 
-      const activeMatch = this.stores.activeMatchStoresById.get(id)
+      const activeMatch = this.stores.matchStores.get(id)
       if (activeMatch) {
         activeMatch.set(updater)
         return
       }
 
-      const cachedMatch = this.stores.cachedMatchStoresById.get(id)
+      const cachedMatch = this.stores.cachedMatchStores.get(id)
       if (cachedMatch) {
         const next = updater(cachedMatch.get())
         if (next.status === 'redirected') {
-          const deleted = this.stores.cachedMatchStoresById.delete(id)
+          const deleted = this.stores.cachedMatchStores.delete(id)
           if (deleted) {
-            this.stores.cachedMatchesId.set((prev) =>
+            this.stores.cachedIds.set((prev) =>
               prev.filter((matchId) => matchId !== id),
             )
           }
@@ -2659,9 +2659,9 @@ export class RouterCore<
 
   getMatch: GetMatchFn = (matchId: string): AnyRouteMatch | undefined => {
     return (
-      this.stores.cachedMatchStoresById.get(matchId)?.get() ??
-      this.stores.pendingMatchStoresById.get(matchId)?.get() ??
-      this.stores.activeMatchStoresById.get(matchId)?.get()
+      this.stores.cachedMatchStores.get(matchId)?.get() ??
+      this.stores.pendingMatchStores.get(matchId)?.get() ??
+      this.stores.matchStores.get(matchId)?.get()
     )
   }
 
@@ -2698,14 +2698,14 @@ export class RouterCore<
     }
 
     this.batch(() => {
-      this.stores.setActiveMatches(
-        this.stores.activeMatchesSnapshot.get().map(invalidate),
+      this.stores.setMatches(
+        this.stores.matches.get().map(invalidate),
       )
-      this.stores.setCachedMatches(
-        this.stores.cachedMatchesSnapshot.get().map(invalidate),
+      this.stores.setCached(
+        this.stores.cachedMatches.get().map(invalidate),
       )
-      this.stores.setPendingMatches(
-        this.stores.pendingMatchesSnapshot.get().map(invalidate),
+      this.stores.setPending(
+        this.stores.pendingMatches.get().map(invalidate),
       )
     })
 
@@ -2764,13 +2764,13 @@ export class RouterCore<
   clearCache: ClearCacheFn<this> = (opts) => {
     const filter = opts?.filter
     if (filter !== undefined) {
-      this.stores.setCachedMatches(
-        this.stores.cachedMatchesSnapshot
+      this.stores.setCached(
+        this.stores.cachedMatches
           .get()
           .filter((m) => !filter(m as MakeRouteMatchUnion<this>)),
       )
     } else {
-      this.stores.setCachedMatches([])
+      this.stores.setCached([])
     }
   }
 
@@ -2819,12 +2819,12 @@ export class RouterCore<
 
     const activeMatchIds = new Set([
       ...this.stores.matchesId.get(),
-      ...this.stores.pendingMatchesId.get(),
+      ...this.stores.pendingIds.get(),
     ])
 
     const loadedMatchIds = new Set([
       ...activeMatchIds,
-      ...this.stores.cachedMatchesId.get(),
+      ...this.stores.cachedIds.get(),
     ])
 
     // If the matches are already loaded, we need to add them to the cached matches.
@@ -2832,8 +2832,8 @@ export class RouterCore<
       (match) => !loadedMatchIds.has(match.id),
     )
     if (matchesToCache.length) {
-      const cachedMatches = this.stores.cachedMatchesSnapshot.get()
-      this.stores.setCachedMatches([...cachedMatches, ...matchesToCache])
+      const cachedMatches = this.stores.cachedMatches.get()
+      this.stores.setCached([...cachedMatches, ...matchesToCache])
     }
 
     try {
@@ -2933,7 +2933,7 @@ export class RouterCore<
   serverSsr?: ServerSsr
 
   hasNotFoundMatch = () => {
-    return this.stores.activeMatchesSnapshot
+    return this.stores.matches
       .get()
       .some((d) => d.status === 'notFound' || d.globalNotFound)
   }

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1717,8 +1717,7 @@ export class RouterCore<
     // Determine params: reuse from state if possible, otherwise parse
     const lastStateMatchId = last(this.stores.matchesId.get())
     const lastStateMatch =
-      lastStateMatchId &&
-      this.stores.matchStores.get(lastStateMatchId)?.get()
+      lastStateMatchId && this.stores.matchStores.get(lastStateMatchId)?.get()
     const canReuseParams =
       lastStateMatch &&
       lastStateMatch.routeId === lastRoute.id &&
@@ -2428,11 +2427,9 @@ export class RouterCore<
                   let hookStayingMatches: Array<AnyRouteMatch> | null = null
 
                   this.batch(() => {
-                    const pendingMatches =
-                      this.stores.pendingMatches.get()
+                    const pendingMatches = this.stores.pendingMatches.get()
                     const mountPending = pendingMatches.length
-                    const currentMatches =
-                      this.stores.matches.get()
+                    const currentMatches = this.stores.matches.get()
 
                     exitingMatches = mountPending
                       ? currentMatches.filter(
@@ -2527,9 +2524,7 @@ export class RouterCore<
             ? redirect.status
             : notFound
               ? 404
-              : this.stores.matches
-                    .get()
-                    .some((d) => d.status === 'error')
+              : this.stores.matches.get().some((d) => d.status === 'error')
                 ? 500
                 : 200
 
@@ -2563,9 +2558,7 @@ export class RouterCore<
     let newStatusCode: number | undefined = undefined
     if (this.hasNotFoundMatch()) {
       newStatusCode = 404
-    } else if (
-      this.stores.matches.get().some((d) => d.status === 'error')
-    ) {
+    } else if (this.stores.matches.get().some((d) => d.status === 'error')) {
       newStatusCode = 500
     }
     if (newStatusCode !== undefined) {
@@ -2698,15 +2691,9 @@ export class RouterCore<
     }
 
     this.batch(() => {
-      this.stores.setMatches(
-        this.stores.matches.get().map(invalidate),
-      )
-      this.stores.setCached(
-        this.stores.cachedMatches.get().map(invalidate),
-      )
-      this.stores.setPending(
-        this.stores.pendingMatches.get().map(invalidate),
-      )
+      this.stores.setMatches(this.stores.matches.get().map(invalidate))
+      this.stores.setCached(this.stores.cachedMatches.get().map(invalidate))
+      this.stores.setPending(this.stores.pendingMatches.get().map(invalidate))
     })
 
     this.shouldViewTransition = false

--- a/packages/router-core/src/ssr/createRequestHandler.ts
+++ b/packages/router-core/src/ssr/createRequestHandler.ts
@@ -78,7 +78,7 @@ export function createRequestHandler<TRouter extends AnyRouter>({
 }
 
 function getRequestHeaders(opts: { router: AnyRouter }): Headers {
-  const matchHeaders = opts.router.stores.activeMatchesSnapshot
+  const matchHeaders = opts.router.stores.matches
     .get()
     .map<AnyHeaders>((match) => match.headers)
 

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -162,7 +162,7 @@ export async function hydrate(router: AnyRouter): Promise<any> {
     }
   })
 
-  router.stores.setActiveMatches(matches)
+  router.stores.setMatches(matches)
 
   // Allow the user to handle custom hydration data
   await router.options.hydrate?.(dehydratedData)
@@ -170,7 +170,7 @@ export async function hydrate(router: AnyRouter): Promise<any> {
   // now that all necessary data is hydrated:
   // 1) fully reconstruct the route context
   // 2) execute `head()` and `scripts()` for each match
-  const activeMatches = router.stores.activeMatchesSnapshot.get()
+  const activeMatches = router.stores.matches.get()
   const location = router.stores.location.get()
   await Promise.all(
     activeMatches.map(async (match) => {

--- a/packages/router-core/src/ssr/ssr-server.ts
+++ b/packages/router-core/src/ssr/ssr-server.ts
@@ -228,7 +228,7 @@ export function attachRouterServerSsrUtils({
 
         invariant()
       }
-      let matchesToDehydrate = router.stores.activeMatchesSnapshot.get()
+      let matchesToDehydrate = router.stores.matches.get()
       if (router.isShell()) {
         // In SPA mode we only want to dehydrate the root match
         matchesToDehydrate = matchesToDehydrate.slice(0, 1)

--- a/packages/router-core/src/stores.ts
+++ b/packages/router-core/src/stores.ts
@@ -81,24 +81,24 @@ export interface RouterStores<in out TRouteTree extends AnyRoute> {
   statusCode: RouterWritableStore<number>
   redirect: RouterWritableStore<AnyRedirect | undefined>
   matchesId: RouterWritableStore<Array<string>>
-  pendingMatchesId: RouterWritableStore<Array<string>>
+  pendingIds: RouterWritableStore<Array<string>>
   /** @internal */
-  cachedMatchesId: RouterWritableStore<Array<string>>
-  activeMatchesSnapshot: ReadableStore<Array<AnyRouteMatch>>
-  pendingMatchesSnapshot: ReadableStore<Array<AnyRouteMatch>>
-  cachedMatchesSnapshot: ReadableStore<Array<AnyRouteMatch>>
-  firstMatchId: ReadableStore<string | undefined>
-  hasPendingMatches: ReadableStore<boolean>
-  matchRouteReactivity: ReadableStore<{
+  cachedIds: RouterWritableStore<Array<string>>
+  matches: ReadableStore<Array<AnyRouteMatch>>
+  pendingMatches: ReadableStore<Array<AnyRouteMatch>>
+  cachedMatches: ReadableStore<Array<AnyRouteMatch>>
+  firstId: ReadableStore<string | undefined>
+  hasPending: ReadableStore<boolean>
+  matchRouteDeps: ReadableStore<{
     locationHref: string
     resolvedLocationHref: string | undefined
     status: RouterState<TRouteTree>['status']
   }>
   __store: RouterReadableStore<RouterState<TRouteTree>>
 
-  activeMatchStoresById: Map<string, MatchStore>
-  pendingMatchStoresById: Map<string, MatchStore>
-  cachedMatchStoresById: Map<string, MatchStore>
+  matchStores: Map<string, MatchStore>
+  pendingMatchStores: Map<string, MatchStore>
+  cachedMatchStores: Map<string, MatchStore>
 
   /**
    * Get a computed store that resolves a routeId to its current match state.
@@ -106,13 +106,13 @@ export interface RouterStores<in out TRouteTree extends AnyRoute> {
    * The computed depends on matchesId + the individual match store, so
    * subscribers are only notified when the resolved match state changes.
    */
-  getMatchStoreByRouteId: (
+  getRouteMatchStore: (
     routeId: string,
   ) => RouterReadableStore<AnyRouteMatch | undefined>
 
-  setActiveMatches: (nextMatches: Array<AnyRouteMatch>) => void
-  setPendingMatches: (nextMatches: Array<AnyRouteMatch>) => void
-  setCachedMatches: (nextMatches: Array<AnyRouteMatch>) => void
+  setMatches: (nextMatches: Array<AnyRouteMatch>) => void
+  setPending: (nextMatches: Array<AnyRouteMatch>) => void
+  setCached: (nextMatches: Array<AnyRouteMatch>) => void
 }
 
 export function createRouterStores<TRouteTree extends AnyRoute>(
@@ -122,9 +122,9 @@ export function createRouterStores<TRouteTree extends AnyRoute>(
   const { createMutableStore, createReadonlyStore, batch, init } = config
 
   // non reactive utilities
-  const activeMatchStoresById = new Map<string, MatchStore>()
-  const pendingMatchStoresById = new Map<string, MatchStore>()
-  const cachedMatchStoresById = new Map<string, MatchStore>()
+  const matchStores = new Map<string, MatchStore>()
+  const pendingMatchStores = new Map<string, MatchStore>()
+  const cachedMatchStores = new Map<string, MatchStore>()
 
   // atoms
   const status = createMutableStore(initialState.status)
@@ -136,27 +136,27 @@ export function createRouterStores<TRouteTree extends AnyRoute>(
   const statusCode = createMutableStore(initialState.statusCode)
   const redirect = createMutableStore(initialState.redirect)
   const matchesId = createMutableStore<Array<string>>([])
-  const pendingMatchesId = createMutableStore<Array<string>>([])
-  const cachedMatchesId = createMutableStore<Array<string>>([])
+  const pendingIds = createMutableStore<Array<string>>([])
+  const cachedIds = createMutableStore<Array<string>>([])
 
   // 1st order derived stores
-  const activeMatchesSnapshot = createReadonlyStore(() =>
-    readPoolMatches(activeMatchStoresById, matchesId.get()),
+  const matches = createReadonlyStore(() =>
+    readPoolMatches(matchStores, matchesId.get()),
   )
-  const pendingMatchesSnapshot = createReadonlyStore(() =>
-    readPoolMatches(pendingMatchStoresById, pendingMatchesId.get()),
+  const pendingMatches = createReadonlyStore(() =>
+    readPoolMatches(pendingMatchStores, pendingIds.get()),
   )
-  const cachedMatchesSnapshot = createReadonlyStore(() =>
-    readPoolMatches(cachedMatchStoresById, cachedMatchesId.get()),
+  const cachedMatches = createReadonlyStore(() =>
+    readPoolMatches(cachedMatchStores, cachedIds.get()),
   )
-  const firstMatchId = createReadonlyStore(() => matchesId.get()[0])
-  const hasPendingMatches = createReadonlyStore(() =>
+  const firstId = createReadonlyStore(() => matchesId.get()[0])
+  const hasPending = createReadonlyStore(() =>
     matchesId.get().some((matchId) => {
-      const store = activeMatchStoresById.get(matchId)
+      const store = matchStores.get(matchId)
       return store?.get().status === 'pending'
     }),
   )
-  const matchRouteReactivity = createReadonlyStore(() => ({
+  const matchRouteDeps = createReadonlyStore(() => ({
     locationHref: location.get().href,
     resolvedLocationHref: resolvedLocation.get()?.href,
     status: status.get(),
@@ -168,7 +168,7 @@ export function createRouterStores<TRouteTree extends AnyRoute>(
     loadedAt: loadedAt.get(),
     isLoading: isLoading.get(),
     isTransitioning: isTransitioning.get(),
-    matches: activeMatchesSnapshot.get(),
+    matches: matches.get(),
     location: location.get(),
     resolvedLocation: resolvedLocation.get(),
     statusCode: statusCode.get(),
@@ -188,7 +188,7 @@ export function createRouterStores<TRouteTree extends AnyRoute>(
     RouterReadableStore<AnyRouteMatch | undefined>
   >(64)
 
-  function getMatchStoreByRouteId(
+  function getRouteMatchStore(
     routeId: string,
   ): RouterReadableStore<AnyRouteMatch | undefined> {
     let cached = matchStoreByRouteIdCache.get(routeId)
@@ -198,7 +198,7 @@ export function createRouterStores<TRouteTree extends AnyRoute>(
         // When matchesId changes (navigation), this computed re-evaluates.
         const ids = matchesId.get()
         for (const id of ids) {
-          const matchStore = activeMatchStoresById.get(id)
+          const matchStore = matchStores.get(id)
           if (matchStore && matchStore.routeId === routeId) {
             // Reading matchStore.get() tracks it as a dependency.
             // When the match store's state changes, this re-evaluates.
@@ -223,64 +223,64 @@ export function createRouterStores<TRouteTree extends AnyRoute>(
     statusCode,
     redirect,
     matchesId,
-    pendingMatchesId,
-    cachedMatchesId,
+    pendingIds,
+    cachedIds,
 
     // derived
-    activeMatchesSnapshot,
-    pendingMatchesSnapshot,
-    cachedMatchesSnapshot,
-    firstMatchId,
-    hasPendingMatches,
-    matchRouteReactivity,
+    matches,
+    pendingMatches,
+    cachedMatches,
+    firstId,
+    hasPending,
+    matchRouteDeps,
 
     // non-reactive state
-    activeMatchStoresById,
-    pendingMatchStoresById,
-    cachedMatchStoresById,
+    matchStores,
+    pendingMatchStores,
+    cachedMatchStores,
 
     // compatibility "big" state
     __store,
 
     // per-key computed stores
-    getMatchStoreByRouteId,
+    getRouteMatchStore,
 
     // methods
-    setActiveMatches,
-    setPendingMatches,
-    setCachedMatches,
+    setMatches,
+    setPending,
+    setCached,
   }
 
   // initialize the active matches
-  setActiveMatches(initialState.matches as Array<AnyRouteMatch>)
+  setMatches(initialState.matches as Array<AnyRouteMatch>)
   init?.(store)
 
   // setters to update non-reactive utilities in sync with the reactive stores
-  function setActiveMatches(nextMatches: Array<AnyRouteMatch>) {
+  function setMatches(nextMatches: Array<AnyRouteMatch>) {
     reconcileMatchPool(
       nextMatches,
-      activeMatchStoresById,
+      matchStores,
       matchesId,
       createMutableStore,
       batch,
     )
   }
 
-  function setPendingMatches(nextMatches: Array<AnyRouteMatch>) {
+  function setPending(nextMatches: Array<AnyRouteMatch>) {
     reconcileMatchPool(
       nextMatches,
-      pendingMatchStoresById,
-      pendingMatchesId,
+      pendingMatchStores,
+      pendingIds,
       createMutableStore,
       batch,
     )
   }
 
-  function setCachedMatches(nextMatches: Array<AnyRouteMatch>) {
+  function setCached(nextMatches: Array<AnyRouteMatch>) {
     reconcileMatchPool(
       nextMatches,
-      cachedMatchStoresById,
-      cachedMatchesId,
+      cachedMatchStores,
+      cachedIds,
       createMutableStore,
       batch,
     )

--- a/packages/router-core/tests/callbacks.test.ts
+++ b/packages/router-core/tests/callbacks.test.ts
@@ -201,7 +201,7 @@ describe('callbacks', () => {
       expect(page2MatchId).toBeDefined()
       expect(page2MatchId).not.toBe(page1MatchId)
       expect(
-        router.stores.cachedMatchesId.get().some((id) => id === page1MatchId),
+        router.stores.cachedIds.get().some((id) => id === page1MatchId),
       ).toBe(true)
 
       await router.navigate({ to: '/foo', search: { page: '1' } })
@@ -226,7 +226,7 @@ describe('callbacks', () => {
       expect(post2MatchId).toBeDefined()
       expect(post2MatchId).not.toBe(post1MatchId)
       expect(
-        router.stores.cachedMatchesId.get().some((id) => id === post1MatchId),
+        router.stores.cachedIds.get().some((id) => id === post1MatchId),
       ).toBe(true)
 
       await router.navigate({ to: '/posts/$postId', params: { postId: '1' } })

--- a/packages/router-core/tests/granular-stores.test.ts
+++ b/packages/router-core/tests/granular-stores.test.ts
@@ -201,16 +201,12 @@ describe('granular stores', () => {
 
     const postsStore = router.stores.getRouteMatchStore('/posts/$postId')
 
-    expect(router.stores.getRouteMatchStore('/posts/$postId')).toBe(
-      postsStore,
-    )
+    expect(router.stores.getRouteMatchStore('/posts/$postId')).toBe(postsStore)
     expect(postsStore.get()?.routeId).toBe('/posts/$postId')
 
     await router.navigate({ to: '/about' })
 
-    expect(router.stores.getRouteMatchStore('/posts/$postId')).toBe(
-      postsStore,
-    )
+    expect(router.stores.getRouteMatchStore('/posts/$postId')).toBe(postsStore)
     expect(postsStore.get()).toBeUndefined()
   })
 
@@ -290,9 +286,7 @@ describe('granular stores', () => {
     const pendingStore = router.stores.pendingMatchStores.get(activeLeaf.id)
 
     expect(pendingStore).toBeDefined()
-    expect(router.stores.matchStores.get(activeLeaf.id)).toBe(
-      activeStore,
-    )
+    expect(router.stores.matchStores.get(activeLeaf.id)).toBe(activeStore)
 
     if (!pendingStore) {
       throw new Error('Expected pending leaf store to exist')
@@ -343,9 +337,9 @@ describe('granular stores', () => {
       ),
     )
 
-    expect(
-      router.stores.matchStores.get(duplicatedId)?.get().status,
-    ).toBe('error')
+    expect(router.stores.matchStores.get(duplicatedId)?.get().status).toBe(
+      'error',
+    )
     expect(
       router.stores.getRouteMatchStore(activeLeaf.routeId).get()?.status,
     ).toBe('error')
@@ -353,9 +347,7 @@ describe('granular stores', () => {
     expect(
       router.stores.pendingMatchStores.get(duplicatedId)?.get().status,
     ).toBe('pending')
-    expect(router.stores.pendingMatches.get()[0]?.status).toBe(
-      'pending',
-    )
+    expect(router.stores.pendingMatches.get()[0]?.status).toBe('pending')
     expect(router.stores.cachedMatches.get()[0]?.status).toBe('success')
     expect(router.getMatch(duplicatedId)?.status).toBe('success')
   })

--- a/packages/router-core/tests/granular-stores.test.ts
+++ b/packages/router-core/tests/granular-stores.test.ts
@@ -95,11 +95,11 @@ describe('granular stores', () => {
       activeMatches.map((match) => match.id),
     )
     activeMatches.forEach((match) => {
-      const store = router.stores.activeMatchStoresById.get(match.id)
+      const store = router.stores.matchStores.get(match.id)
       expect(store).toBeDefined()
       expect(store!.routeId).toBe(match.routeId)
-      // getMatchStoreByRouteId resolves to the same state
-      expect(router.stores.getMatchStoreByRouteId(match.routeId).get()).toBe(
+      // getRouteMatchStore resolves to the same state
+      expect(router.stores.getRouteMatchStore(match.routeId).get()).toBe(
         store!.get(),
       )
     })
@@ -113,29 +113,29 @@ describe('granular stores', () => {
       id: `${match.id}__cached_${index}`,
     }))
 
-    router.stores.setPendingMatches(pendingMatches)
-    router.stores.setCachedMatches(cachedMatches)
+    router.stores.setPending(pendingMatches)
+    router.stores.setCached(cachedMatches)
 
     expect(router.stores.matchesId.get()).toEqual(
       activeMatches.map((match) => match.id),
     )
-    expect(router.stores.pendingMatchesId.get()).toEqual(
+    expect(router.stores.pendingIds.get()).toEqual(
       pendingMatches.map((match) => match.id),
     )
-    expect(router.stores.cachedMatchesId.get()).toEqual(
+    expect(router.stores.cachedIds.get()).toEqual(
       cachedMatches.map((match) => match.id),
     )
 
     // Pending pool has correct routeIds
     pendingMatches.forEach((match) => {
-      const pendingStore = router.stores.pendingMatchStoresById.get(match.id)
+      const pendingStore = router.stores.pendingMatchStores.get(match.id)
       expect(pendingStore).toBeDefined()
       expect(pendingStore!.routeId).toBe(match.routeId)
       // Pending match is NOT in the active pool
-      expect(router.stores.activeMatchStoresById.get(match.id)).toBeUndefined()
+      expect(router.stores.matchStores.get(match.id)).toBeUndefined()
       // Active pool still has a match for this routeId
       expect(
-        router.stores.getMatchStoreByRouteId(match.routeId).get(),
+        router.stores.getRouteMatchStore(match.routeId).get(),
       ).toBeDefined()
     })
 
@@ -143,16 +143,16 @@ describe('granular stores', () => {
       ...match,
       id: `${match.id}__active_next_${index}`,
     }))
-    router.stores.setActiveMatches(nextActiveMatches)
+    router.stores.setMatches(nextActiveMatches)
 
     expect(router.stores.matchesId.get()).toEqual(
       nextActiveMatches.map((match) => match.id),
     )
     nextActiveMatches.forEach((match) => {
-      const store = router.stores.activeMatchStoresById.get(match.id)
+      const store = router.stores.matchStores.get(match.id)
       expect(store).toBeDefined()
       expect(store!.routeId).toBe(match.routeId)
-      expect(router.stores.getMatchStoreByRouteId(match.routeId).get()).toBe(
+      expect(router.stores.getRouteMatchStore(match.routeId).get()).toBe(
         store!.get(),
       )
     })
@@ -172,8 +172,8 @@ describe('granular stores', () => {
       throw new Error('Expected root and leaf matches to exist')
     }
 
-    const rootStore = router.stores.activeMatchStoresById.get(rootMatch.id)
-    const leafStore = router.stores.activeMatchStoresById.get(leafMatch.id)
+    const rootStore = router.stores.matchStores.get(rootMatch.id)
+    const leafStore = router.stores.matchStores.get(leafMatch.id)
 
     expect(rootStore).toBeDefined()
     expect(leafStore).toBeDefined()
@@ -195,20 +195,20 @@ describe('granular stores', () => {
     expect(leafStore.get().status).toBe('pending')
   })
 
-  test('getMatchStoreByRouteId caches store instances and clears when route is inactive', async () => {
+  test('getRouteMatchStore caches store instances and clears when route is inactive', async () => {
     const router = createRouter()
     await router.navigate({ to: '/posts/123' })
 
-    const postsStore = router.stores.getMatchStoreByRouteId('/posts/$postId')
+    const postsStore = router.stores.getRouteMatchStore('/posts/$postId')
 
-    expect(router.stores.getMatchStoreByRouteId('/posts/$postId')).toBe(
+    expect(router.stores.getRouteMatchStore('/posts/$postId')).toBe(
       postsStore,
     )
     expect(postsStore.get()?.routeId).toBe('/posts/$postId')
 
     await router.navigate({ to: '/about' })
 
-    expect(router.stores.getMatchStoreByRouteId('/posts/$postId')).toBe(
+    expect(router.stores.getRouteMatchStore('/posts/$postId')).toBe(
       postsStore,
     )
     expect(postsStore.get()).toBeUndefined()
@@ -221,17 +221,17 @@ describe('granular stores', () => {
     const activeMatches = router.state.matches
     const activeIdsBefore = router.stores.matchesId.get()
     const activeStoresBefore = activeMatches.map((match) =>
-      router.stores.activeMatchStoresById.get(match.id),
+      router.stores.matchStores.get(match.id),
     )
     const activeStatesBefore = activeStoresBefore.map((store) => store?.get())
 
-    router.stores.setActiveMatches(activeMatches)
+    router.stores.setMatches(activeMatches)
 
     expect(router.stores.matchesId.get()).toBe(activeIdsBefore)
-    expect(router.stores.activeMatchesSnapshot.get()).toBe(activeMatches)
+    expect(router.stores.matches.get()).toBe(activeMatches)
     for (let i = 0; i < activeMatches.length; i++) {
       const match = activeMatches[i]!
-      const store = router.stores.activeMatchStoresById.get(match.id)
+      const store = router.stores.matchStores.get(match.id)
       expect(store).toBe(activeStoresBefore[i])
       expect(store?.get()).toBe(activeStatesBefore[i])
     }
@@ -242,20 +242,20 @@ describe('granular stores', () => {
       status: 'pending' as const,
     }))
 
-    router.stores.setPendingMatches(pendingMatches)
+    router.stores.setPending(pendingMatches)
 
-    const pendingIdsBefore = router.stores.pendingMatchesId.get()
+    const pendingIdsBefore = router.stores.pendingIds.get()
     const pendingStoresBefore = pendingMatches.map((match) =>
-      router.stores.pendingMatchStoresById.get(match.id),
+      router.stores.pendingMatchStores.get(match.id),
     )
     const pendingStatesBefore = pendingStoresBefore.map((store) => store?.get())
 
-    router.stores.setPendingMatches(pendingMatches)
+    router.stores.setPending(pendingMatches)
 
-    expect(router.stores.pendingMatchesId.get()).toBe(pendingIdsBefore)
+    expect(router.stores.pendingIds.get()).toBe(pendingIdsBefore)
     for (let i = 0; i < pendingMatches.length; i++) {
       const match = pendingMatches[i]!
-      const store = router.stores.pendingMatchStoresById.get(match.id)
+      const store = router.stores.pendingMatchStores.get(match.id)
       expect(store).toBe(pendingStoresBefore[i])
       expect(store?.get()).toBe(pendingStatesBefore[i])
     }
@@ -274,7 +274,7 @@ describe('granular stores', () => {
       throw new Error('Expected active leaf match to exist')
     }
 
-    const activeStore = router.stores.activeMatchStoresById.get(activeLeaf.id)
+    const activeStore = router.stores.matchStores.get(activeLeaf.id)
 
     expect(activeStore).toBeDefined()
 
@@ -287,10 +287,10 @@ describe('granular stores', () => {
     const reloadPromise = router.load()
     await Promise.resolve()
 
-    const pendingStore = router.stores.pendingMatchStoresById.get(activeLeaf.id)
+    const pendingStore = router.stores.pendingMatchStores.get(activeLeaf.id)
 
     expect(pendingStore).toBeDefined()
-    expect(router.stores.activeMatchStoresById.get(activeLeaf.id)).toBe(
+    expect(router.stores.matchStores.get(activeLeaf.id)).toBe(
       activeStore,
     )
 
@@ -328,10 +328,10 @@ describe('granular stores', () => {
       status: 'success' as const,
     }
 
-    router.stores.setPendingMatches([pendingDuplicate])
-    router.stores.setCachedMatches([cachedDuplicate])
+    router.stores.setPending([pendingDuplicate])
+    router.stores.setCached([cachedDuplicate])
 
-    router.stores.setActiveMatches(
+    router.stores.setMatches(
       router.state.matches.map((match) =>
         match.id === duplicatedId
           ? {
@@ -344,19 +344,19 @@ describe('granular stores', () => {
     )
 
     expect(
-      router.stores.activeMatchStoresById.get(duplicatedId)?.get().status,
+      router.stores.matchStores.get(duplicatedId)?.get().status,
     ).toBe('error')
     expect(
-      router.stores.getMatchStoreByRouteId(activeLeaf.routeId).get()?.status,
+      router.stores.getRouteMatchStore(activeLeaf.routeId).get()?.status,
     ).toBe('error')
     // Pending pool has its own store for this id
     expect(
-      router.stores.pendingMatchStoresById.get(duplicatedId)?.get().status,
+      router.stores.pendingMatchStores.get(duplicatedId)?.get().status,
     ).toBe('pending')
-    expect(router.stores.pendingMatchesSnapshot.get()[0]?.status).toBe(
+    expect(router.stores.pendingMatches.get()[0]?.status).toBe(
       'pending',
     )
-    expect(router.stores.cachedMatchesSnapshot.get()[0]?.status).toBe('success')
+    expect(router.stores.cachedMatches.get()[0]?.status).toBe('success')
     expect(router.getMatch(duplicatedId)?.status).toBe('success')
   })
 })

--- a/packages/router-core/tests/load.test.ts
+++ b/packages/router-core/tests/load.test.ts
@@ -203,18 +203,14 @@ describe('beforeLoad skip or exec', () => {
     })
     await router.preloadRoute({ to: '/foo' })
     expect(
-      router.stores.cachedMatches
-        .get()
-        .some((d) => d.status === 'redirected'),
+      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
     ).toBe(false)
     await sleep(10)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatches
-        .get()
-        .some((d) => d.status === 'redirected'),
+      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
     ).toBe(false)
     expect(beforeLoad).toHaveBeenCalledTimes(2)
   })
@@ -230,17 +226,13 @@ describe('beforeLoad skip or exec', () => {
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
     expect(
-      router.stores.cachedMatches
-        .get()
-        .some((d) => d.status === 'redirected'),
+      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
     ).toBe(false)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatches
-        .get()
-        .some((d) => d.status === 'redirected'),
+      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
     ).toBe(false)
     expect(beforeLoad).toHaveBeenCalledTimes(2)
   })
@@ -456,18 +448,14 @@ describe('loader skip or exec', () => {
     })
     await router.preloadRoute({ to: '/foo' })
     expect(
-      router.stores.cachedMatches
-        .get()
-        .some((d) => d.status === 'redirected'),
+      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
     ).toBe(false)
     await sleep(10)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatches
-        .get()
-        .some((d) => d.status === 'redirected'),
+      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
     ).toBe(false)
     expect(loader).toHaveBeenCalledTimes(2)
   })
@@ -483,17 +471,13 @@ describe('loader skip or exec', () => {
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
     expect(
-      router.stores.cachedMatches
-        .get()
-        .some((d) => d.status === 'redirected'),
+      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
     ).toBe(false)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/bar')
     expect(
-      router.stores.cachedMatches
-        .get()
-        .some((d) => d.status === 'redirected'),
+      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
     ).toBe(false)
     expect(loader).toHaveBeenCalledTimes(1)
   })
@@ -513,14 +497,10 @@ describe('loader skip or exec', () => {
     }))
 
     expect(
-      router.stores.cachedMatches
-        .get()
-        .some((d) => d.id === '/foo/foo'),
+      router.stores.cachedMatches.get().some((d) => d.id === '/foo/foo'),
     ).toBe(false)
     expect(
-      router.stores.cachedMatches
-        .get()
-        .some((d) => d.status === 'redirected'),
+      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
     ).toBe(false)
   })
 
@@ -648,9 +628,7 @@ describe('stale loader reload triggers', () => {
     id: string,
   ) =>
     router.state.matches.find((match) => match.id === id) ??
-    router.stores.pendingMatches
-      .get()
-      .find((match) => match.id === id) ??
+    router.stores.pendingMatches.get().find((match) => match.id === id) ??
     router.stores.cachedMatches.get().find((match) => match.id === id)
 
   const hasActiveMatch = (
@@ -662,9 +640,7 @@ describe('stale loader reload triggers', () => {
     router: RouterCore<any, any, any, any, any>,
     id: string,
   ) =>
-    router.stores.pendingMatches
-      .get()
-      .some((match) => match.id === id) ?? false
+    router.stores.pendingMatches.get().some((match) => match.id === id) ?? false
 
   const setup = ({
     loader,

--- a/packages/router-core/tests/load.test.ts
+++ b/packages/router-core/tests/load.test.ts
@@ -119,7 +119,7 @@ describe('beforeLoad skip or exec', () => {
     const router = setup({ beforeLoad })
     const navigation = router.navigate({ to: '/foo' })
     expect(beforeLoad).toHaveBeenCalledTimes(1)
-    expect(router.stores.pendingMatchesSnapshot.get()).toEqual(
+    expect(router.stores.pendingMatches.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await navigation
@@ -141,7 +141,7 @@ describe('beforeLoad skip or exec', () => {
     const beforeLoad = vi.fn()
     const router = setup({ beforeLoad })
     await router.preloadRoute({ to: '/foo' })
-    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
+    expect(router.stores.cachedMatches.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await sleep(10)
@@ -155,7 +155,7 @@ describe('beforeLoad skip or exec', () => {
     const router = setup({ beforeLoad })
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
-    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
+    expect(router.stores.cachedMatches.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await router.navigate({ to: '/foo' })
@@ -203,7 +203,7 @@ describe('beforeLoad skip or exec', () => {
     })
     await router.preloadRoute({ to: '/foo' })
     expect(
-      router.stores.cachedMatchesSnapshot
+      router.stores.cachedMatches
         .get()
         .some((d) => d.status === 'redirected'),
     ).toBe(false)
@@ -212,7 +212,7 @@ describe('beforeLoad skip or exec', () => {
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatchesSnapshot
+      router.stores.cachedMatches
         .get()
         .some((d) => d.status === 'redirected'),
     ).toBe(false)
@@ -230,7 +230,7 @@ describe('beforeLoad skip or exec', () => {
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
     expect(
-      router.stores.cachedMatchesSnapshot
+      router.stores.cachedMatches
         .get()
         .some((d) => d.status === 'redirected'),
     ).toBe(false)
@@ -238,7 +238,7 @@ describe('beforeLoad skip or exec', () => {
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatchesSnapshot
+      router.stores.cachedMatches
         .get()
         .some((d) => d.status === 'redirected'),
     ).toBe(false)
@@ -359,7 +359,7 @@ describe('loader skip or exec', () => {
     const router = setup({ loader })
     const navigation = router.navigate({ to: '/foo' })
     expect(loader).toHaveBeenCalledTimes(1)
-    expect(router.stores.pendingMatchesSnapshot.get()).toEqual(
+    expect(router.stores.pendingMatches.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await navigation
@@ -381,7 +381,7 @@ describe('loader skip or exec', () => {
     const loader = vi.fn()
     const router = setup({ loader })
     await router.preloadRoute({ to: '/foo' })
-    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
+    expect(router.stores.cachedMatches.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await sleep(10)
@@ -394,7 +394,7 @@ describe('loader skip or exec', () => {
     const loader = vi.fn()
     const router = setup({ loader, staleTime: 1000 })
     await router.preloadRoute({ to: '/foo' })
-    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
+    expect(router.stores.cachedMatches.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await sleep(10)
@@ -408,7 +408,7 @@ describe('loader skip or exec', () => {
     const router = setup({ loader })
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
-    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
+    expect(router.stores.cachedMatches.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
     await router.navigate({ to: '/foo' })
@@ -456,7 +456,7 @@ describe('loader skip or exec', () => {
     })
     await router.preloadRoute({ to: '/foo' })
     expect(
-      router.stores.cachedMatchesSnapshot
+      router.stores.cachedMatches
         .get()
         .some((d) => d.status === 'redirected'),
     ).toBe(false)
@@ -465,7 +465,7 @@ describe('loader skip or exec', () => {
 
     expect(router.state.location.pathname).toBe('/foo')
     expect(
-      router.stores.cachedMatchesSnapshot
+      router.stores.cachedMatches
         .get()
         .some((d) => d.status === 'redirected'),
     ).toBe(false)
@@ -483,7 +483,7 @@ describe('loader skip or exec', () => {
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
     expect(
-      router.stores.cachedMatchesSnapshot
+      router.stores.cachedMatches
         .get()
         .some((d) => d.status === 'redirected'),
     ).toBe(false)
@@ -491,7 +491,7 @@ describe('loader skip or exec', () => {
 
     expect(router.state.location.pathname).toBe('/bar')
     expect(
-      router.stores.cachedMatchesSnapshot
+      router.stores.cachedMatches
         .get()
         .some((d) => d.status === 'redirected'),
     ).toBe(false)
@@ -503,7 +503,7 @@ describe('loader skip or exec', () => {
     const router = setup({ loader })
 
     await router.preloadRoute({ to: '/foo' })
-    expect(router.stores.cachedMatchesSnapshot.get()).toEqual(
+    expect(router.stores.cachedMatches.get()).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
     )
 
@@ -513,12 +513,12 @@ describe('loader skip or exec', () => {
     }))
 
     expect(
-      router.stores.cachedMatchesSnapshot
+      router.stores.cachedMatches
         .get()
         .some((d) => d.id === '/foo/foo'),
     ).toBe(false)
     expect(
-      router.stores.cachedMatchesSnapshot
+      router.stores.cachedMatches
         .get()
         .some((d) => d.status === 'redirected'),
     ).toBe(false)
@@ -648,10 +648,10 @@ describe('stale loader reload triggers', () => {
     id: string,
   ) =>
     router.state.matches.find((match) => match.id === id) ??
-    router.stores.pendingMatchesSnapshot
+    router.stores.pendingMatches
       .get()
       .find((match) => match.id === id) ??
-    router.stores.cachedMatchesSnapshot.get().find((match) => match.id === id)
+    router.stores.cachedMatches.get().find((match) => match.id === id)
 
   const hasActiveMatch = (
     router: RouterCore<any, any, any, any, any>,
@@ -662,7 +662,7 @@ describe('stale loader reload triggers', () => {
     router: RouterCore<any, any, any, any, any>,
     id: string,
   ) =>
-    router.stores.pendingMatchesSnapshot
+    router.stores.pendingMatches
       .get()
       .some((match) => match.id === id) ?? false
 
@@ -1350,7 +1350,7 @@ describe('head execution', () => {
 
     const location = router.latestLocation
     const matches = router.matchRoutes(location)
-    router.stores.setPendingMatches(matches)
+    router.stores.setPending(matches)
 
     await expect(
       loadMatches({
@@ -1401,7 +1401,7 @@ describe('head execution', () => {
 
     const location = router.latestLocation
     const matches = router.matchRoutes(location)
-    router.stores.setPendingMatches(matches)
+    router.stores.setPending(matches)
 
     await expect(
       loadMatches({
@@ -1548,7 +1548,7 @@ describe('head execution', () => {
     const runLoadMatchesAndCapture = async (router: AnyRouter) => {
       const location = router.latestLocation
       const matches = router.matchRoutes(location)
-      router.stores.setPendingMatches(matches)
+      router.stores.setPending(matches)
 
       try {
         await loadMatches({
@@ -1766,7 +1766,7 @@ describe('head execution', () => {
         }),
       )
 
-      const rootMatch = router.stores.pendingMatchesSnapshot
+      const rootMatch = router.stores.pendingMatches
         .get()
         .find((m) => m.routeId === routes[0].id)
 
@@ -1795,7 +1795,7 @@ describe('head execution', () => {
       const second = await runLoadMatchesAndCapture(router)
       expect(second.error).toBeUndefined()
 
-      const rootMatch = router.stores.pendingMatchesSnapshot
+      const rootMatch = router.stores.pendingMatches
         .get()
         .find((m) => m.routeId === routes[0].id)
 
@@ -1831,7 +1831,7 @@ describe('head execution', () => {
       expect(rootLoader).toHaveBeenCalledTimes(1)
 
       const staleRootNotFound = notFound({ data: { source: 'stale-root' } })
-      const currentRootMatchId = router.stores.pendingMatchesSnapshot
+      const currentRootMatchId = router.stores.pendingMatches
         .get()
         .find((m) => m.routeId === rootRoute.id)!.id
 
@@ -1848,7 +1848,7 @@ describe('head execution', () => {
       pendingRootMatch.status = 'success'
       pendingRootMatch.globalNotFound = false
       pendingRootMatch.error = undefined
-      router.stores.setPendingMatches(matches)
+      router.stores.setPending(matches)
 
       await expect(
         loadMatches({
@@ -1861,7 +1861,7 @@ describe('head execution', () => {
 
       expect(rootLoader).toHaveBeenCalledTimes(1)
 
-      const rootMatch = router.stores.pendingMatchesSnapshot
+      const rootMatch = router.stores.pendingMatches
         .get()
         .find((m) => m.routeId === rootRoute.id)
 
@@ -1895,7 +1895,7 @@ describe('params.parse notFound', () => {
 
     await router.load()
 
-    const match = router.stores.activeMatchesSnapshot
+    const match = router.stores.matches
       .get()
       .find((m) => m.routeId === testRoute.id)
 

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -281,14 +281,12 @@ export const BaseTanStackRouterDevtoolsPanel =
     let cachedMatches: Accessor<Array<AnyRouteMatch>>
     // subscribable implementation
     if ('subscribe' in router().stores.pendingMatches) {
-      const [_pendingMatches, setPending] = createSignal<
-        Array<AnyRouteMatch>
-      >([])
+      const [_pendingMatches, setPending] = createSignal<Array<AnyRouteMatch>>(
+        [],
+      )
       pendingMatches = _pendingMatches
 
-      const [_cachedMatches, setCached] = createSignal<
-        Array<AnyRouteMatch>
-      >([])
+      const [_cachedMatches, setCached] = createSignal<Array<AnyRouteMatch>>([])
       cachedMatches = _cachedMatches
 
       type Subscribe = (fn: () => void) => { unsubscribe: () => void }

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -280,44 +280,44 @@ export const BaseTanStackRouterDevtoolsPanel =
     let pendingMatches: Accessor<Array<AnyRouteMatch>>
     let cachedMatches: Accessor<Array<AnyRouteMatch>>
     // subscribable implementation
-    if ('subscribe' in router().stores.pendingMatchesSnapshot) {
-      const [_pendingMatches, setPendingMatches] = createSignal<
+    if ('subscribe' in router().stores.pendingMatches) {
+      const [_pendingMatches, setPending] = createSignal<
         Array<AnyRouteMatch>
       >([])
       pendingMatches = _pendingMatches
 
-      const [_cachedMatches, setCachedMatches] = createSignal<
+      const [_cachedMatches, setCached] = createSignal<
         Array<AnyRouteMatch>
       >([])
       cachedMatches = _cachedMatches
 
       type Subscribe = (fn: () => void) => { unsubscribe: () => void }
       createEffect(() => {
-        const pendingMatchesStore = router().stores.pendingMatchesSnapshot
-        setPendingMatches(pendingMatchesStore.get())
+        const pendingMatchesStore = router().stores.pendingMatches
+        setPending(pendingMatchesStore.get())
         const subscription = (
           (pendingMatchesStore as any).subscribe as Subscribe
         )(() => {
-          setPendingMatches(pendingMatchesStore.get())
+          setPending(pendingMatchesStore.get())
         })
         onCleanup(() => subscription.unsubscribe())
       })
 
       createEffect(() => {
-        const cachedMatchesStore = router().stores.cachedMatchesSnapshot
-        setCachedMatches(cachedMatchesStore.get())
+        const cachedMatchesStore = router().stores.cachedMatches
+        setCached(cachedMatchesStore.get())
         const subscription = (
           (cachedMatchesStore as any).subscribe as Subscribe
         )(() => {
-          setCachedMatches(cachedMatchesStore.get())
+          setCached(cachedMatchesStore.get())
         })
         onCleanup(() => subscription.unsubscribe())
       })
     }
     // signal implementation
     else {
-      pendingMatches = () => router().stores.pendingMatchesSnapshot.get()
-      cachedMatches = () => router().stores.cachedMatchesSnapshot.get()
+      pendingMatches = () => router().stores.pendingMatches.get()
+      cachedMatches = () => router().stores.cachedMatches.get()
     }
 
     createEffect(() => {

--- a/packages/router-plugin/src/core/route-hmr-statement.ts
+++ b/packages/router-plugin/src/core/route-hmr-statement.ts
@@ -22,15 +22,15 @@ type AnyRouterWithPrivateMaps = AnyRouter & {
   routesById: Record<string, AnyRoute>
   routesByPath: Record<string, AnyRoute>
   stores: AnyRouter['stores'] & {
-    cachedMatchStoresById: Map<
+    cachedMatchStores: Map<
       string,
       Pick<RouterWritableStore<AnyRouteMatch>, 'set'>
     >
-    pendingMatchStoresById: Map<
+    pendingMatchStores: Map<
       string,
       Pick<RouterWritableStore<AnyRouteMatch>, 'set'>
     >
-    activeMatchStoresById: Map<
+    matchStores: Map<
       string,
       Pick<RouterWritableStore<AnyRouteMatch>, 'set'>
     >
@@ -95,9 +95,9 @@ function handleRouteUpdate(
   walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree)
 
   const filter = (m: AnyRouteMatch) => m.routeId === oldRoute.id
-  const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter)
-  const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter)
-  const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter)
+  const activeMatch = router.stores.matches.get().find(filter)
+  const pendingMatch = router.stores.pendingMatches.get().find(filter)
+  const cachedMatches = router.stores.cachedMatches.get().filter(filter)
 
   if (activeMatch || pendingMatch || cachedMatches.length > 0) {
     // Clear stale match data for removed route options BEFORE invalidating.
@@ -117,9 +117,9 @@ function handleRouteUpdate(
       router.batch(() => {
         for (const matchId of matchIds) {
           const store =
-            router.stores.pendingMatchStoresById.get(matchId) ||
-            router.stores.activeMatchStoresById.get(matchId) ||
-            router.stores.cachedMatchStoresById.get(matchId)
+            router.stores.pendingMatchStores.get(matchId) ||
+            router.stores.matchStores.get(matchId) ||
+            router.stores.cachedMatchStores.get(matchId)
           if (store) {
             store.set((prev) => {
               const next: AnyRouteMatchWithPrivateProps = { ...prev }

--- a/packages/router-plugin/src/core/route-hmr-statement.ts
+++ b/packages/router-plugin/src/core/route-hmr-statement.ts
@@ -30,10 +30,7 @@ type AnyRouterWithPrivateMaps = AnyRouter & {
       string,
       Pick<RouterWritableStore<AnyRouteMatch>, 'set'>
     >
-    matchStores: Map<
-      string,
-      Pick<RouterWritableStore<AnyRouteMatch>, 'set'>
-    >
+    matchStores: Map<string, Pick<RouterWritableStore<AnyRouteMatch>, 'set'>>
   }
 }
 

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@true.tsx
@@ -77,15 +77,15 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
+        const activeMatch = router.stores.matches.get().find(filter);
+        const pendingMatch = router.stores.pendingMatches.get().find(filter);
+        const cachedMatches = router.stores.cachedMatches.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
             router.batch(() => {
               for (const matchId of matchIds) {
-                const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
+                const store = router.stores.pendingMatchStores.get(matchId) || router.stores.matchStores.get(matchId) || router.stores.cachedMatchStores.get(matchId);
                 if (store) {
                   store.set(prev => {
                     const next = {

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@webpack-hot.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@webpack-hot.tsx
@@ -77,15 +77,15 @@ if (import.meta.webpackHot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
+        const activeMatch = router.stores.matches.get().find(filter);
+        const pendingMatch = router.stores.pendingMatches.get().find(filter);
+        const cachedMatches = router.stores.cachedMatches.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
             router.batch(() => {
               for (const matchId of matchIds) {
-                const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
+                const store = router.stores.pendingMatchStores.get(matchId) || router.stores.matchStores.get(matchId) || router.stores.cachedMatchStores.get(matchId);
                 if (store) {
                   store.set(prev => {
                     const next = {

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRoute-inline-component@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRoute-inline-component@true.tsx
@@ -66,15 +66,15 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
+        const activeMatch = router.stores.matches.get().find(filter);
+        const pendingMatch = router.stores.pendingMatches.get().find(filter);
+        const cachedMatches = router.stores.cachedMatches.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
             router.batch(() => {
               for (const matchId of matchIds) {
-                const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
+                const store = router.stores.pendingMatchStores.get(matchId) || router.stores.matchStores.get(matchId) || router.stores.cachedMatchStores.get(matchId);
                 if (store) {
                   store.set(prev => {
                     const next = {

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/explicit-undefined-component@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/explicit-undefined-component@true.tsx
@@ -65,15 +65,15 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
+        const activeMatch = router.stores.matches.get().find(filter);
+        const pendingMatch = router.stores.pendingMatches.get().find(filter);
+        const cachedMatches = router.stores.cachedMatches.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
             router.batch(() => {
               for (const matchId of matchIds) {
-                const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
+                const store = router.stores.pendingMatchStores.get(matchId) || router.stores.matchStores.get(matchId) || router.stores.cachedMatchStores.get(matchId);
                 if (store) {
                   store.set(prev => {
                     const next = {

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/function-declaration@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/function-declaration@true.tsx
@@ -77,15 +77,15 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
+        const activeMatch = router.stores.matches.get().find(filter);
+        const pendingMatch = router.stores.pendingMatches.get().find(filter);
+        const cachedMatches = router.stores.cachedMatches.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
             router.batch(() => {
               for (const matchId of matchIds) {
-                const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
+                const store = router.stores.pendingMatchStores.get(matchId) || router.stores.matchStores.get(matchId) || router.stores.cachedMatchStores.get(matchId);
                 if (store) {
                   store.set(prev => {
                     const next = {

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/multi-component@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/multi-component@true.tsx
@@ -87,15 +87,15 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
+        const activeMatch = router.stores.matches.get().find(filter);
+        const pendingMatch = router.stores.pendingMatches.get().find(filter);
+        const cachedMatches = router.stores.cachedMatches.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
             router.batch(() => {
               for (const matchId of matchIds) {
-                const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
+                const store = router.stores.pendingMatchStores.get(matchId) || router.stores.matchStores.get(matchId) || router.stores.cachedMatchStores.get(matchId);
                 if (store) {
                   store.set(prev => {
                     const next = {

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/string-literal-keys@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/string-literal-keys@true.tsx
@@ -87,15 +87,15 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
+        const activeMatch = router.stores.matches.get().find(filter);
+        const pendingMatch = router.stores.pendingMatches.get().find(filter);
+        const cachedMatches = router.stores.cachedMatches.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
             router.batch(() => {
               for (const matchId of matchIds) {
-                const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
+                const store = router.stores.pendingMatchStores.get(matchId) || router.stores.matchStores.get(matchId) || router.stores.cachedMatchStores.get(matchId);
                 if (store) {
                   store.set(prev => {
                     const next = {

--- a/packages/router-plugin/tests/add-hmr/snapshots/solid/arrow-function@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/solid/arrow-function@true.tsx
@@ -47,15 +47,15 @@ if (import.meta.hot) {
         router.resolvePathCache.clear();
         walkReplaceSegmentTree(oldRoute, router.processedTree.segmentTree);
         const filter = m => m.routeId === oldRoute.id;
-        const activeMatch = router.stores.activeMatchesSnapshot.get().find(filter);
-        const pendingMatch = router.stores.pendingMatchesSnapshot.get().find(filter);
-        const cachedMatches = router.stores.cachedMatchesSnapshot.get().filter(filter);
+        const activeMatch = router.stores.matches.get().find(filter);
+        const pendingMatch = router.stores.pendingMatches.get().find(filter);
+        const cachedMatches = router.stores.cachedMatches.get().filter(filter);
         if (activeMatch || pendingMatch || cachedMatches.length > 0) {
           if (removedKeys.has("loader") || removedKeys.has("beforeLoad")) {
             const matchIds = [activeMatch?.id, pendingMatch?.id, ...cachedMatches.map(match => match.id)].filter(Boolean);
             router.batch(() => {
               for (const matchId of matchIds) {
-                const store = router.stores.pendingMatchStoresById.get(matchId) || router.stores.activeMatchStoresById.get(matchId) || router.stores.cachedMatchStoresById.get(matchId);
+                const store = router.stores.pendingMatchStores.get(matchId) || router.stores.matchStores.get(matchId) || router.stores.cachedMatchStores.get(matchId);
                 if (store) {
                   store.set(prev => {
                     const next = {

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -24,7 +24,7 @@ export const Match = (props: { matchId: string }) => {
   const match = Solid.createMemo(() => {
     const id = props.matchId
     if (!id) return undefined
-    return router.stores.activeMatchStoresById.get(id)?.get()
+    return router.stores.matchStores.get(id)?.get()
   })
 
   const rawMatchState = Solid.createMemo(() => {
@@ -466,7 +466,7 @@ export const Outlet = () => {
   const childMatchStatus = Solid.createMemo(() => {
     const id = childMatchId()
     if (!id) return undefined
-    return router.stores.activeMatchStoresById.get(id)?.get().status
+    return router.stores.matchStores.get(id)?.get().status
   })
 
   // Only show not-found if we're not in a redirected state

--- a/packages/solid-router/src/Matches.tsx
+++ b/packages/solid-router/src/Matches.tsx
@@ -62,11 +62,11 @@ export function Matches() {
 
 function MatchesInner() {
   const router = useRouter()
-  const matchId = () => router.stores.firstMatchId.get()
+  const matchId = () => router.stores.firstId.get()
   const routeId = () => (matchId() ? rootRouteId : undefined)
   const match = () =>
     routeId()
-      ? router.stores.getMatchStoreByRouteId(rootRouteId).get()
+      ? router.stores.getRouteMatchStore(rootRouteId).get()
       : undefined
   const hasPendingMatch = () =>
     routeId()
@@ -142,7 +142,7 @@ export function useMatchRoute<TRouter extends AnyRouter = RegisteredRouter>() {
     return Solid.createMemo(() => {
       const { pending, caseSensitive, fuzzy, includeSearch, ...rest } = opts
 
-      router.stores.matchRouteReactivity.get()
+      router.stores.matchRouteDeps.get()
       return router.matchRoute(rest as any, {
         pending,
         caseSensitive,
@@ -211,7 +211,7 @@ export function useMatches<
 ): Solid.Accessor<UseMatchesResult<TRouter, TSelected>> {
   const router = useRouter<TRouter>()
   return Solid.createMemo((prev: TSelected | undefined) => {
-    const matches = router.stores.activeMatchesSnapshot.get() as Array<
+    const matches = router.stores.matches.get() as Array<
       MakeRouteMatchUnion<TRouter>
     >
     const res = opts?.select ? opts.select(matches) : matches

--- a/packages/solid-router/src/Matches.tsx
+++ b/packages/solid-router/src/Matches.tsx
@@ -65,9 +65,7 @@ function MatchesInner() {
   const matchId = () => router.stores.firstId.get()
   const routeId = () => (matchId() ? rootRouteId : undefined)
   const match = () =>
-    routeId()
-      ? router.stores.getRouteMatchStore(rootRouteId).get()
-      : undefined
+    routeId() ? router.stores.getRouteMatchStore(rootRouteId).get() : undefined
   const hasPendingMatch = () =>
     routeId()
       ? Boolean(router.stores.pendingRouteIds.get()[rootRouteId])

--- a/packages/solid-router/src/Scripts.tsx
+++ b/packages/solid-router/src/Scripts.tsx
@@ -6,9 +6,7 @@ import type { RouterManagedTag } from '@tanstack/router-core'
 export const Scripts = () => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce
-  const activeMatches = Solid.createMemo(() =>
-    router.stores.matches.get(),
-  )
+  const activeMatches = Solid.createMemo(() => router.stores.matches.get())
   const assetScripts = Solid.createMemo(() => {
     const assetScripts: Array<RouterManagedTag> = []
     const manifest = router.ssr?.manifest

--- a/packages/solid-router/src/Scripts.tsx
+++ b/packages/solid-router/src/Scripts.tsx
@@ -7,7 +7,7 @@ export const Scripts = () => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce
   const activeMatches = Solid.createMemo(() =>
-    router.stores.activeMatchesSnapshot.get(),
+    router.stores.matches.get(),
   )
   const assetScripts = Solid.createMemo(() => {
     const assetScripts: Array<RouterManagedTag> = []

--- a/packages/solid-router/src/Transitioner.tsx
+++ b/packages/solid-router/src/Transitioner.tsx
@@ -19,16 +19,16 @@ export function Transitioner() {
   const [isSolidTransitioning, startSolidTransition] = Solid.useTransition()
 
   // Track pending state changes
-  const hasPendingMatches = Solid.createMemo(() =>
-    router.stores.hasPendingMatches.get(),
+  const hasPending = Solid.createMemo(() =>
+    router.stores.hasPending.get(),
   )
 
   const isAnyPending = Solid.createMemo(
-    () => isLoading() || isSolidTransitioning() || hasPendingMatches(),
+    () => isLoading() || isSolidTransitioning() || hasPending(),
   )
 
   const isPagePending = Solid.createMemo(
-    () => isLoading() || hasPendingMatches(),
+    () => isLoading() || hasPending(),
   )
 
   router.startTransition = (fn: () => void | Promise<void>) => {

--- a/packages/solid-router/src/Transitioner.tsx
+++ b/packages/solid-router/src/Transitioner.tsx
@@ -19,17 +19,13 @@ export function Transitioner() {
   const [isSolidTransitioning, startSolidTransition] = Solid.useTransition()
 
   // Track pending state changes
-  const hasPending = Solid.createMemo(() =>
-    router.stores.hasPending.get(),
-  )
+  const hasPending = Solid.createMemo(() => router.stores.hasPending.get())
 
   const isAnyPending = Solid.createMemo(
     () => isLoading() || isSolidTransitioning() || hasPending(),
   )
 
-  const isPagePending = Solid.createMemo(
-    () => isLoading() || hasPending(),
-  )
+  const isPagePending = Solid.createMemo(() => isLoading() || hasPending())
 
   router.startTransition = (fn: () => void | Promise<void>) => {
     Solid.startTransition(() => {

--- a/packages/solid-router/src/headContentUtils.tsx
+++ b/packages/solid-router/src/headContentUtils.tsx
@@ -18,9 +18,7 @@ import type {
 export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce
-  const activeMatches = Solid.createMemo(() =>
-    router.stores.matches.get(),
-  )
+  const activeMatches = Solid.createMemo(() => router.stores.matches.get())
   const routeMeta = Solid.createMemo(() =>
     activeMatches()
       .map((match) => match.meta!)

--- a/packages/solid-router/src/headContentUtils.tsx
+++ b/packages/solid-router/src/headContentUtils.tsx
@@ -19,7 +19,7 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce
   const activeMatches = Solid.createMemo(() =>
-    router.stores.activeMatchesSnapshot.get(),
+    router.stores.matches.get(),
   )
   const routeMeta = Solid.createMemo(() =>
     activeMatches()

--- a/packages/solid-router/src/routerStores.ts
+++ b/packages/solid-router/src/routerStores.ts
@@ -31,7 +31,7 @@ function initRouterStores(
     const ids = stores.matchesId.get()
     const obj: Record<string, string> = {}
     for (let i = 0; i < ids.length - 1; i++) {
-      const parentStore = stores.activeMatchStoresById.get(ids[i]!)
+      const parentStore = stores.matchStores.get(ids[i]!)
       if (parentStore?.routeId) {
         obj[parentStore.routeId] = ids[i + 1]!
       }
@@ -40,10 +40,10 @@ function initRouterStores(
   })
 
   stores.pendingRouteIds = createReadonlyStore(() => {
-    const ids = stores.pendingMatchesId.get()
+    const ids = stores.pendingIds.get()
     const obj: Record<string, boolean> = {}
     for (const id of ids) {
-      const store = stores.pendingMatchStoresById.get(id)
+      const store = stores.pendingMatchStores.get(id)
       if (store?.routeId) {
         obj[store.routeId] = true
       }

--- a/packages/solid-router/src/useMatch.tsx
+++ b/packages/solid-router/src/useMatch.tsx
@@ -76,7 +76,7 @@ export function useMatch<
 
   const match = () => {
     if (opts.from) {
-      return router.stores.getMatchStoreByRouteId(opts.from).get()
+      return router.stores.getRouteMatchStore(opts.from).get()
     }
 
     return nearestMatch?.match()

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -202,7 +202,7 @@ function getStartResponseHeaders(opts: { router: AnyRouter }) {
     {
       'Content-Type': 'text/html; charset=utf-8',
     },
-    ...opts.router.stores.activeMatchesSnapshot.get().map((match) => {
+    ...opts.router.stores.matches.get().map((match) => {
       return match.headers
     }),
   )

--- a/packages/vue-router/src/Match.tsx
+++ b/packages/vue-router/src/Match.tsx
@@ -37,9 +37,7 @@ export const Match = Vue.defineComponent({
     // Derive routeId from initial props.matchId — stable for this component's
     // lifetime. The routeId never changes for a given route position in the
     // tree, even when matchId changes (loaderDepsHash, etc).
-    const routeId = router.stores.matchStores.get(
-      props.matchId,
-    )?.routeId
+    const routeId = router.stores.matchStores.get(props.matchId)?.routeId
 
     if (!routeId) {
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/vue-router/src/Match.tsx
+++ b/packages/vue-router/src/Match.tsx
@@ -37,7 +37,7 @@ export const Match = Vue.defineComponent({
     // Derive routeId from initial props.matchId — stable for this component's
     // lifetime. The routeId never changes for a given route position in the
     // tree, even when matchId changes (loaderDepsHash, etc).
-    const routeId = router.stores.activeMatchStoresById.get(
+    const routeId = router.stores.matchStores.get(
       props.matchId,
     )?.routeId
 
@@ -56,11 +56,11 @@ export const Match = Vue.defineComponent({
     const isChildOfRoot =
       (router.routesById[routeId] as AnyRoute)?.parentRoute?.id === rootRouteId
 
-    // Single stable store subscription — getMatchStoreByRouteId returns a
+    // Single stable store subscription — getRouteMatchStore returns a
     // cached computed store that resolves routeId → current match state
     // through the signal graph. No bridge needed.
     const activeMatch = useStore(
-      router.stores.getMatchStoreByRouteId(routeId),
+      router.stores.getRouteMatchStore(routeId),
       (value) => value,
     )
     const isPendingMatchRef = useStore(
@@ -297,7 +297,7 @@ export const MatchInner = Vue.defineComponent({
     // Use routeId from context (provided by parent Match) — stable string.
     const routeId = Vue.inject(routeIdContext)!
     const activeMatch = useStore(
-      router.stores.getMatchStoreByRouteId(routeId),
+      router.stores.getRouteMatchStore(routeId),
       (value) => value,
     )
 
@@ -500,7 +500,7 @@ export const Outlet = Vue.defineComponent({
 
     // Parent state via stable routeId store — single subscription
     const parentMatch = useStore(
-      router.stores.getMatchStoreByRouteId(parentRouteId),
+      router.stores.getRouteMatchStore(parentRouteId),
       (v) => v,
     )
 
@@ -525,7 +525,7 @@ export const Outlet = Vue.defineComponent({
     const childMatchData = Vue.computed(() => {
       const childId = childMatchIdMap.value[parentRouteId]
       if (!childId) return null
-      const child = router.stores.activeMatchStoresById.get(childId)?.get()
+      const child = router.stores.matchStores.get(childId)?.get()
       if (!child) return null
 
       return {

--- a/packages/vue-router/src/Matches.tsx
+++ b/packages/vue-router/src/Matches.tsx
@@ -152,10 +152,7 @@ export type UseMatchRouteOptions<
 export function useMatchRoute<TRouter extends AnyRouter = RegisteredRouter>() {
   const router = useRouter()
 
-  const routerState = useStore(
-    router.stores.matchRouteDeps,
-    (value) => value,
-  )
+  const routerState = useStore(router.stores.matchRouteDeps, (value) => value)
 
   return <
     const TFrom extends string = string,

--- a/packages/vue-router/src/Matches.tsx
+++ b/packages/vue-router/src/Matches.tsx
@@ -99,7 +99,7 @@ const MatchesInner = Vue.defineComponent({
   setup() {
     const router = useRouter()
 
-    const matchId = useStore(router.stores.firstMatchId, (id) => id)
+    const matchId = useStore(router.stores.firstId, (id) => id)
     const resetKey = useStore(router.stores.loadedAt, (loadedAt) => loadedAt)
 
     // Create a ref for the match id to provide
@@ -153,7 +153,7 @@ export function useMatchRoute<TRouter extends AnyRouter = RegisteredRouter>() {
   const router = useRouter()
 
   const routerState = useStore(
-    router.stores.matchRouteReactivity,
+    router.stores.matchRouteDeps,
     (value) => value,
   )
 
@@ -253,7 +253,7 @@ export const MatchRoute = Vue.defineComponent({
   setup(props, { slots }) {
     const router = useRouter()
     const status = useStore(
-      router.stores.matchRouteReactivity,
+      router.stores.matchRouteDeps,
       (value) => value.status,
     )
 
@@ -296,7 +296,7 @@ export function useMatches<
   opts?: UseMatchesBaseOptions<TRouter, TSelected>,
 ): Vue.Ref<UseMatchesResult<TRouter, TSelected>> {
   const router = useRouter<TRouter>()
-  return useStore(router.stores.activeMatchesSnapshot, (matches) => {
+  return useStore(router.stores.matches, (matches) => {
     return opts?.select
       ? opts.select(matches as Array<MakeRouteMatchUnion<TRouter>>)
       : (matches as any)

--- a/packages/vue-router/src/Scripts.tsx
+++ b/packages/vue-router/src/Scripts.tsx
@@ -9,10 +9,7 @@ export const Scripts = Vue.defineComponent({
   setup() {
     const router = useRouter()
     const nonce = router.options.ssr?.nonce
-    const matches = useStore(
-      router.stores.matches,
-      (value) => value,
-    )
+    const matches = useStore(router.stores.matches, (value) => value)
 
     const assetScripts = Vue.computed<Array<RouterManagedTag>>(() => {
       const assetScripts: Array<RouterManagedTag> = []

--- a/packages/vue-router/src/Scripts.tsx
+++ b/packages/vue-router/src/Scripts.tsx
@@ -10,7 +10,7 @@ export const Scripts = Vue.defineComponent({
     const router = useRouter()
     const nonce = router.options.ssr?.nonce
     const matches = useStore(
-      router.stores.activeMatchesSnapshot,
+      router.stores.matches,
       (value) => value,
     )
 

--- a/packages/vue-router/src/Transitioner.tsx
+++ b/packages/vue-router/src/Transitioner.tsx
@@ -36,20 +36,20 @@ export function useTransitionerSetup() {
   const isTransitioning = Vue.ref(false)
 
   // Track pending state changes
-  const hasPendingMatches = useStore(
-    router.stores.hasPendingMatches,
+  const hasPending = useStore(
+    router.stores.hasPending,
     (value) => value,
   )
 
   const previousIsLoading = usePrevious(() => isLoading.value)
 
   const isAnyPending = Vue.computed(
-    () => isLoading.value || isTransitioning.value || hasPendingMatches.value,
+    () => isLoading.value || isTransitioning.value || hasPending.value,
   )
   const previousIsAnyPending = usePrevious(() => isAnyPending.value)
 
   const isPagePending = Vue.computed(
-    () => isLoading.value || hasPendingMatches.value,
+    () => isLoading.value || hasPending.value,
   )
   const previousIsPagePending = usePrevious(() => isPagePending.value)
 

--- a/packages/vue-router/src/Transitioner.tsx
+++ b/packages/vue-router/src/Transitioner.tsx
@@ -36,10 +36,7 @@ export function useTransitionerSetup() {
   const isTransitioning = Vue.ref(false)
 
   // Track pending state changes
-  const hasPending = useStore(
-    router.stores.hasPending,
-    (value) => value,
-  )
+  const hasPending = useStore(router.stores.hasPending, (value) => value)
 
   const previousIsLoading = usePrevious(() => isLoading.value)
 
@@ -48,9 +45,7 @@ export function useTransitionerSetup() {
   )
   const previousIsAnyPending = usePrevious(() => isAnyPending.value)
 
-  const isPagePending = Vue.computed(
-    () => isLoading.value || hasPending.value,
-  )
+  const isPagePending = Vue.computed(() => isLoading.value || hasPending.value)
   const previousIsPagePending = usePrevious(() => isPagePending.value)
 
   // Implement startTransition similar to React/Solid

--- a/packages/vue-router/src/headContentUtils.tsx
+++ b/packages/vue-router/src/headContentUtils.tsx
@@ -14,7 +14,7 @@ import type {
 export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
   const router = useRouter()
   const matches = useStore(
-    router.stores.activeMatchesSnapshot,
+    router.stores.matches,
     (value) => value,
   )
 

--- a/packages/vue-router/src/headContentUtils.tsx
+++ b/packages/vue-router/src/headContentUtils.tsx
@@ -13,10 +13,7 @@ import type {
 
 export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
   const router = useRouter()
-  const matches = useStore(
-    router.stores.matches,
-    (value) => value,
-  )
+  const matches = useStore(router.stores.matches, (value) => value)
 
   const meta = Vue.computed<Array<RouterManagedTag>>(() => {
     const resultMeta: Array<RouterManagedTag> = []

--- a/packages/vue-router/src/routerStores.ts
+++ b/packages/vue-router/src/routerStores.ts
@@ -30,7 +30,7 @@ export const getStoreFactory: GetStoreConfig = (_opts) => {
         const ids = stores.matchesId.get()
         const obj: Record<string, string> = {}
         for (let i = 0; i < ids.length - 1; i++) {
-          const parentStore = stores.activeMatchStoresById.get(ids[i]!)
+          const parentStore = stores.matchStores.get(ids[i]!)
           if (parentStore?.routeId) {
             obj[parentStore.routeId] = ids[i + 1]!
           }
@@ -39,10 +39,10 @@ export const getStoreFactory: GetStoreConfig = (_opts) => {
       })
 
       stores.pendingRouteIds = createAtom(() => {
-        const ids = stores.pendingMatchesId.get()
+        const ids = stores.pendingIds.get()
         const obj: Record<string, boolean> = {}
         for (const id of ids) {
-          const store = stores.pendingMatchStoresById.get(id)
+          const store = stores.pendingMatchStores.get(id)
           if (store?.routeId) {
             obj[store.routeId] = true
           }

--- a/packages/vue-router/src/useMatch.tsx
+++ b/packages/vue-router/src/useMatch.tsx
@@ -83,7 +83,7 @@ export function useMatch<
     const nearestRouteId = opts.from ? undefined : Vue.inject(routeIdContext)
     const matchStore =
       (opts.from ?? nearestRouteId)
-        ? router.stores.getMatchStoreByRouteId(opts.from ?? nearestRouteId!)
+        ? router.stores.getRouteMatchStore(opts.from ?? nearestRouteId!)
         : undefined
     const match = matchStore?.get()
 
@@ -123,7 +123,7 @@ export function useMatch<
   if (opts.from) {
     // routeId case: single subscription via per-routeId computed store.
     // The store reference is stable (cached by routeId).
-    const matchStore = router.stores.getMatchStoreByRouteId(opts.from)
+    const matchStore = router.stores.getRouteMatchStore(opts.from)
     match = useStore(matchStore, (value) => value)
   } else {
     // matchId case: use routeId from context for stable store lookup.
@@ -132,7 +132,7 @@ export function useMatch<
     const nearestRouteId = Vue.inject(routeIdContext)
     if (nearestRouteId) {
       match = useStore(
-        router.stores.getMatchStoreByRouteId(nearestRouteId),
+        router.stores.getRouteMatchStore(nearestRouteId),
         (value) => value,
       )
     } else {


### PR DESCRIPTION
## Summary
- Shorten the internal router store keys in `router-core` to reduce emitted bundle bytes.
- Update React, Solid, Vue, devtools, HMR helpers, tests, and snapshots to use the renamed store API directly.
- Keep behavior the same while trimming internal store names throughout the generated output.

## Testing
- `CI=1 NX_DAEMON=false pnpm nx affected --target=test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx affected --target=test:unit --outputStyle=stream --skipRemoteCache --exclude=examples/**,e2e/**`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and renamed internal router stores and accessors across frameworks to use unified match/pool stores and streamlined setters/getters. No public API or behavior changes; user-facing routing, hydration, HMR, head/script generation, and devtools behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->