### PR TITLE
fix(start-plugin-core): reuse deduped server function ids across compilers

### DIFF
--- a/.changeset/flat-radios-smile.md
+++ b/.changeset/flat-radios-smile.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+Reuse previously discovered server function IDs across compiler instances so custom `generateFunctionId` values stay stable when duplicate IDs are deduplicated during build.
+
+This fixes cases where different build environments could assign different deduped IDs to the same server functions, which could cause requests to resolve to the wrong handler.

--- a/packages/start-plugin-core/src/start-compiler/compiler.ts
+++ b/packages/start-plugin-core/src/start-compiler/compiler.ts
@@ -350,7 +350,7 @@ export class StartCompiler {
        * Returns the currently known server functions from previous builds.
        * Used by server callers to look up canonical extracted filenames.
        */
-      getKnownServerFns?: () => Record<string, ServerFn>
+      getKnownServerFns: () => Record<string, ServerFn>
       devServerFnModuleSpecifierEncoder?: DevServerFnModuleSpecifierEncoder
     },
   ) {
@@ -394,8 +394,18 @@ export class StartCompiler {
     const entryId = `${opts.filename}--${opts.functionName}`
     let functionId = this.entryIdToFunctionId.get(entryId)
     if (functionId === undefined) {
+      const knownFn = Object.values(this.options.getKnownServerFns()).find(
+        (serverFn) =>
+          serverFn.functionName === opts.functionName &&
+          serverFn.extractedFilename === opts.extractedFilename,
+      )
+
+      if (knownFn) {
+        functionId = knownFn.functionId
+      }
+
       if (this.options.generateFunctionId) {
-        functionId = this.options.generateFunctionId({
+        functionId ??= this.options.generateFunctionId({
           filename: opts.filename,
           functionName: opts.functionName,
         })
@@ -920,7 +930,7 @@ export class StartCompiler {
       providerEnvName: this.options.providerEnvName,
 
       generateFunctionId: (opts) => this.generateFunctionId(opts),
-      getKnownServerFns: () => this.options.getKnownServerFns?.() ?? {},
+      getKnownServerFns: this.options.getKnownServerFns,
       onServerFnsById: this.options.onServerFnsById,
     }
 

--- a/packages/start-plugin-core/src/start-compiler/host.ts
+++ b/packages/start-plugin-core/src/start-compiler/host.ts
@@ -16,7 +16,7 @@ export interface CreateStartCompilerOptions {
   mode: 'dev' | 'build'
   generateFunctionId?: GenerateFunctionIdFnOptional
   onServerFnsById?: (d: Record<string, ServerFn>) => void
-  getKnownServerFns?: () => Record<string, ServerFn>
+  getKnownServerFns: () => Record<string, ServerFn>
   encodeModuleSpecifierInDev?: DevServerFnModuleSpecifierEncoder
   loadModule: (id: string) => Promise<void>
   resolveId: (id: string, importer?: string) => Promise<string | null>

--- a/packages/start-plugin-core/tests/clientOnlyJSX/clientOnlyJSX.test.ts
+++ b/packages/start-plugin-core/tests/clientOnlyJSX/clientOnlyJSX.test.ts
@@ -38,6 +38,7 @@ async function compile(opts: {
         kind: 'ClientOnlyJSX',
       },
     ],
+    getKnownServerFns: () => ({}),
     resolveId: async (id) => {
       return id
     },

--- a/packages/start-plugin-core/tests/compiler.test.ts
+++ b/packages/start-plugin-core/tests/compiler.test.ts
@@ -62,6 +62,7 @@ function createFullCompiler(env: 'client' | 'server') {
     ...getDefaultTestOptions(env),
     lookupKinds,
     lookupConfigurations,
+    getKnownServerFns: () => ({}),
     loadModule: async () => {},
     resolveId: async (id) => id,
     mode: 'build',
@@ -438,6 +439,7 @@ test('ingestModule handles empty code gracefully', () => {
     ...getDefaultTestOptions('client'),
     lookupKinds: new Set(['ServerFn']),
     lookupConfigurations: [],
+    getKnownServerFns: () => ({}),
     loadModule: async () => {},
     resolveId: async (id) => id,
   })
@@ -521,6 +523,7 @@ describe('calling result of createServerOnlyFn/createClientOnlyFn', () => {
       providerEnvName: 'ssr',
       lookupKinds: new Set(['ServerOnlyFn', 'ClientOnlyFn']),
       lookupConfigurations: [],
+      getKnownServerFns: () => ({}),
       loadModule: async (id) => {
         const code = virtualModules[id]
         if (code) {
@@ -613,6 +616,7 @@ describe('re-export chain resolution', () => {
       providerEnvName: 'ssr',
       lookupKinds,
       lookupConfigurations: [],
+      getKnownServerFns: () => ({}),
       loadModule: async (id) => {
         const code = virtualModules[id]
         if (code) {
@@ -704,6 +708,7 @@ describe('re-export chain resolution', () => {
       providerEnvName: 'ssr',
       lookupKinds: new Set(['IsomorphicFn', 'ServerOnlyFn', 'ClientOnlyFn']),
       lookupConfigurations: [],
+      getKnownServerFns: () => ({}),
       loadModule: async (id) => {
         const code = deeperVirtualModules[id]
         if (code) {

--- a/packages/start-plugin-core/tests/createIsomorphicFn/createIsomorphicFn.test.ts
+++ b/packages/start-plugin-core/tests/createIsomorphicFn/createIsomorphicFn.test.ts
@@ -34,6 +34,7 @@ async function compile(opts: {
         kind: 'IsomorphicFn',
       },
     ],
+    getKnownServerFns: () => ({}),
     resolveId: async (id) => {
       return id
     },

--- a/packages/start-plugin-core/tests/createMiddleware/createMiddleware.test.ts
+++ b/packages/start-plugin-core/tests/createMiddleware/createMiddleware.test.ts
@@ -42,6 +42,7 @@ async function compile(opts: {
         kind: 'Root',
       },
     ],
+    getKnownServerFns: () => ({}),
     resolveId: async (id) => {
       return id
     },
@@ -93,6 +94,7 @@ describe('createMiddleware compiles correctly', async () => {
           kind: 'Root',
         },
       ],
+      getKnownServerFns: () => ({}),
       resolveId: resolveIdMock,
     })
 
@@ -139,6 +141,7 @@ describe('createMiddleware compiles correctly', async () => {
           kind: 'Root',
         },
       ],
+      getKnownServerFns: () => ({}),
       resolveId: resolveIdMock,
     })
 

--- a/packages/start-plugin-core/tests/createServerFn/createServerFn.test.ts
+++ b/packages/start-plugin-core/tests/createServerFn/createServerFn.test.ts
@@ -47,6 +47,7 @@ async function compile(opts: {
         kind: 'Root',
       },
     ],
+    getKnownServerFns: () => ({}),
     resolveId: async (id) => {
       return id
     },
@@ -250,6 +251,7 @@ describe('createServerFn compiles correctly', async () => {
           kind: 'Root',
         },
       ],
+      getKnownServerFns: () => ({}),
       resolveId: resolveIdMock,
       mode: 'build',
     })
@@ -297,6 +299,7 @@ describe('createServerFn compiles correctly', async () => {
           kind: 'Root',
         },
       ],
+      getKnownServerFns: () => ({}),
       resolveId: resolveIdMock,
       mode: 'build',
     })
@@ -349,6 +352,7 @@ describe('createServerFn compiles correctly', async () => {
           kind: 'Root',
         },
       ],
+      getKnownServerFns: () => ({}),
       resolveId: resolveIdMock,
       mode: 'build',
     })
@@ -407,6 +411,7 @@ describe('createServerFn compiles correctly', async () => {
           kind: 'Root',
         },
       ],
+      getKnownServerFns: () => ({}),
       resolveId: resolveIdMock,
       mode: 'build',
     })
@@ -429,5 +434,87 @@ describe('createServerFn compiles correctly', async () => {
       './factory-inner',
       './factory',
     )
+  })
+
+  test('reuses deduped custom IDs across compiler instances', async () => {
+    const serverFnsById: Record<
+      string,
+      {
+        functionName: string
+        functionId: string
+        extractedFilename: string
+        filename: string
+        isClientReferenced?: boolean
+      }
+    > = {}
+
+    function createCompiler() {
+      return new StartCompiler({
+        env: 'server',
+        ...getDefaultTestOptions('server'),
+        mode: 'build',
+        loadModule: async () => {},
+        lookupKinds: new Set(['ServerFn']),
+        lookupConfigurations: [
+          {
+            libName: '@tanstack/react-start',
+            rootExport: 'createServerFn',
+            kind: 'Root',
+          },
+        ],
+        resolveId: async (id) => id,
+        generateFunctionId: ({ functionName }) =>
+          functionName === 'greetUser_createServerFn_handler'
+            ? 'constant_id'
+            : undefined,
+        getKnownServerFns: () => serverFnsById,
+        onServerFnsById: (discovered) => {
+          Object.assign(serverFnsById, discovered)
+        },
+      })
+    }
+
+    const firstCompiler = createCompiler()
+    await firstCompiler.compile({
+      code: `
+        import { createServerFn } from '@tanstack/react-start'
+        export const greetUser = createServerFn().handler(async () => 'first')
+      `,
+      id: '/test/src/submit-post-formdata.tsx',
+    })
+
+    await firstCompiler.compile({
+      code: `
+        import { createServerFn } from '@tanstack/react-start'
+        export const greetUser = createServerFn().handler(async () => 'second')
+      `,
+      id: '/test/src/formdata-redirect/index.tsx',
+    })
+
+    expect(
+      Object.values(serverFnsById)
+        .map((serverFn) => serverFn.functionId)
+        .sort(),
+    ).toEqual(['constant_id', 'constant_id_1'])
+
+    const secondCompiler = createCompiler()
+    const firstResult = await secondCompiler.compile({
+      code: `
+        import { createServerFn } from '@tanstack/react-start'
+        export const greetUser = createServerFn().handler(async () => 'first')
+      `,
+      id: '/test/src/submit-post-formdata.tsx',
+    })
+
+    const secondResult = await secondCompiler.compile({
+      code: `
+        import { createServerFn } from '@tanstack/react-start'
+        export const greetUser = createServerFn().handler(async () => 'second')
+      `,
+      id: '/test/src/formdata-redirect/index.tsx',
+    })
+
+    expect(firstResult!.code).toContain('createSsrRpc("constant_id"')
+    expect(secondResult!.code).toContain('createSsrRpc("constant_id_1"')
   })
 })

--- a/packages/start-plugin-core/tests/envOnly/envOnly.test.ts
+++ b/packages/start-plugin-core/tests/envOnly/envOnly.test.ts
@@ -39,6 +39,7 @@ async function compile(opts: {
         kind: 'ClientOnlyFn',
       },
     ],
+    getKnownServerFns: () => ({}),
     resolveId: async (id) => {
       return id
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server function ID deduplication to ensure consistency across compiler instances, preventing requests from being routed to incorrect handlers in different build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->