### PR TITLE
chore: add vite 8 to peer deps

### DIFF
--- a/.changeset/vite-8-peer-deps.md
+++ b/.changeset/vite-8-peer-deps.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/router-plugin": patch
+---
+
+add vite 8 to peer deps

--- a/.changeset/vite-8-peer-deps.md
+++ b/.changeset/vite-8-peer-deps.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/router-plugin": patch
+'@tanstack/router-plugin': patch
 ---
 
 add vite 8 to peer deps

--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -131,7 +131,7 @@
   "peerDependencies": {
     "@rsbuild/core": ">=1.0.2",
     "@tanstack/react-router": "workspace:^",
-    "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0",
+    "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0",
     "vite-plugin-solid": "^2.11.10",
     "webpack": ">=5.92.0"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded router plugin compatibility to include Vite 8.x in addition to previously supported Vite ranges, enabling use with newer Vite releases.
  * Updated release metadata and added a changeset to mark a patch-level release for the router plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->