### PR TITLE
fix(start-rsc): avoid Promise.withResolvers browser dependency

### DIFF
--- a/.changeset/sharp-peaches-jump.md
+++ b/.changeset/sharp-peaches-jump.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/react-start-rsc': patch
+'@tanstack/react-start': patch
+---
+
+Avoid requiring `Promise.withResolvers` in the RSC replay stream runtime so client bootstrap and hard refreshes do not fail in browsers that do not implement it.

--- a/packages/react-start-rsc/src/ReplayableStream.ts
+++ b/packages/react-start-rsc/src/ReplayableStream.ts
@@ -37,6 +37,20 @@ export interface ReplayableStreamOptions {
   signal?: AbortSignal
 }
 
+interface Waiter<T> {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+}
+
+function createWaiter<T>(): Waiter<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
 // Use Symbol.for to ensure the same symbol across different module instances
 export const REPLAYABLE_STREAM_MARKER = Symbol.for(
   'tanstack.rsc.ReplayableStream',
@@ -49,7 +63,7 @@ export class ReplayableStream<T = Uint8Array> {
   private chunks: Array<T> = []
   private done = false
   private error: unknown = null
-  private waiter: PromiseWithResolvers<void> | null = null
+  private waiter: Waiter<void> | null = null
   private aborted = false
   private released = false
 
@@ -165,7 +179,7 @@ export class ReplayableStream<T = Uint8Array> {
   private wait(): Promise<void> {
     if (this.done || this.released) return Promise.resolve()
     if (!this.waiter) {
-      this.waiter = Promise.withResolvers<void>()
+      this.waiter = createWaiter<void>()
     }
     return this.waiter.promise
   }


### PR DESCRIPTION
## Summary
- replace `Promise.withResolvers` in `ReplayableStream` with a local deferred helper so the RSC runtime does not depend on a newer Promise API
- avoid client bootstrap and hard refresh failures on RSC pages in browsers where `Promise.withResolvers` is unavailable
- add patch changesets for `@tanstack/react-start-rsc` and `@tanstack/react-start`

## Validation
- `pnpm exec eslint src/ReplayableStream.ts`
- `pnpm exec tsc --noEmit -p tsconfig.json`
- `pnpm exec vitest run tests/ReplayableStream.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved React Server Components replay stream compatibility by removing dependency on unsupported JavaScript APIs, preventing client bootstrap and hard refresh failures in browsers lacking newer standard support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->