### PR TITLE
fix(router-plugin): update vite-plugin-solid peer dependency to support version 3.0.0-0

### DIFF
--- a/.changeset/witty-nails-tickle.md
+++ b/.changeset/witty-nails-tickle.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-plugin': patch
+---
+
+fix: update vite-plugin-solid peer dependency to support version 3.0.0-0

--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -132,7 +132,7 @@
     "@rsbuild/core": ">=1.0.2",
     "@tanstack/react-router": "workspace:^",
     "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0",
-    "vite-plugin-solid": "^2.11.10",
+		"vite-plugin-solid": "^2.11.10 || ^3.0.0-0",
     "webpack": ">=5.92.0"
   },
   "peerDependenciesMeta": {

--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -132,7 +132,7 @@
     "@rsbuild/core": ">=1.0.2",
     "@tanstack/react-router": "workspace:^",
     "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0",
-		"vite-plugin-solid": "^2.11.10 || ^3.0.0-0",
+    "vite-plugin-solid": "^2.11.10 || ^3.0.0-0",
     "webpack": ">=5.92.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12565,8 +12565,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vite-plugin-solid:
-        specifier: ^2.11.10
-        version: 2.11.10(@testing-library/jest-dom@6.6.3)(solid-js@1.9.10)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
+        specifier: ^2.11.10 || ^3.0.0-0
+        version: 2.11.11(@testing-library/jest-dom@6.6.3)(solid-js@1.9.10)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
       webpack:
         specifier: '>=5.92.0'
         version: 5.97.1(esbuild@0.27.4)


### PR DESCRIPTION
for the solid v2 beta, we need the vite-plugin-solid v3.0.0-next.4, but that's outside the range of the current router-plugin peerDeps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated peer dependency compatibility to accept the newer prerelease of the Solid tooling while retaining support for existing stable releases.
  * This broadens compatibility with newer toolchain versions without changing public APIs or runtime behavior.
  * No user-facing features or exported interfaces were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->