### PR TITLE
fix: pin solid v2 beta.6

### DIFF
--- a/.changeset/modern-islands-enjoy.md
+++ b/.changeset/modern-islands-enjoy.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/solid-router-ssr-query': patch
+'@tanstack/solid-router-devtools': patch
+'@tanstack/solid-start-client': patch
+'@tanstack/solid-start-server': patch
+'@tanstack/solid-router': patch
+'@tanstack/solid-start': patch
+---
+
+fix: pin solid 2 beta.6 due to server range with -experimental tag

--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-start": "workspace:^",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^2.0.0-beta.5",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.5",
     "vue": "^3.5.16"
   },

--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -14,7 +14,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.5",
+    "@solidjs/web": "2.0.0-beta.6",
     "vue": "^3.5.16"
   },
   "devDependencies": {

--- a/benchmarks/client-nav/package.json
+++ b/benchmarks/client-nav/package.json
@@ -25,7 +25,7 @@
     "@tanstack/vue-router": "workspace:^",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^2.0.0-beta.5",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.5",
     "vue": "^3.5.16"
   },

--- a/benchmarks/client-nav/package.json
+++ b/benchmarks/client-nav/package.json
@@ -26,7 +26,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.5",
+    "@solidjs/web": "2.0.0-beta.6",
     "vue": "^3.5.16"
   },
   "devDependencies": {

--- a/benchmarks/ssr/package.json
+++ b/benchmarks/ssr/package.json
@@ -24,7 +24,7 @@
     "@tanstack/vue-start": "workspace:^",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "^2.0.0-beta.5",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.5",
     "vue": "^3.5.16"
   },

--- a/benchmarks/ssr/package.json
+++ b/benchmarks/ssr/package.json
@@ -25,7 +25,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.5",
+    "@solidjs/web": "2.0.0-beta.6",
     "vue": "^3.5.16"
   },
   "devDependencies": {

--- a/e2e/solid-router/basepath-file-based/package.json
+++ b/e2e/solid-router/basepath-file-based/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/router-plugin": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",

--- a/e2e/solid-router/basepath-file-based/package.json
+++ b/e2e/solid-router/basepath-file-based/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/router-plugin": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/e2e/solid-router/basic-file-based-code-splitting/package.json
+++ b/e2e/solid-router/basic-file-based-code-splitting/package.json
@@ -18,7 +18,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/e2e/solid-router/basic-file-based-code-splitting/package.json
+++ b/e2e/solid-router/basic-file-based-code-splitting/package.json
@@ -17,7 +17,7 @@
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/e2e/solid-router/basic-file-based/package.json
+++ b/e2e/solid-router/basic-file-based/package.json
@@ -19,7 +19,7 @@
     "@tanstack/zod-adapter": "workspace:^",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/e2e/solid-router/basic-file-based/package.json
+++ b/e2e/solid-router/basic-file-based/package.json
@@ -18,7 +18,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/zod-adapter": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/e2e/solid-router/basic-scroll-restoration/package.json
+++ b/e2e/solid-router/basic-scroll-restoration/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-virtual": "^3.13.0",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/e2e/solid-router/basic-scroll-restoration/package.json
+++ b/e2e/solid-router/basic-scroll-restoration/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-virtual": "^3.13.0",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },

--- a/e2e/solid-router/basic-solid-query-file-based/package.json
+++ b/e2e/solid-router/basic-solid-query-file-based/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-query": "^6.0.0-beta.3",

--- a/e2e/solid-router/basic-solid-query-file-based/package.json
+++ b/e2e/solid-router/basic-solid-query-file-based/package.json
@@ -19,7 +19,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/e2e/solid-router/basic-solid-query/package.json
+++ b/e2e/solid-router/basic-solid-query/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.3",

--- a/e2e/solid-router/basic-solid-query/package.json
+++ b/e2e/solid-router/basic-solid-query/package.json
@@ -18,7 +18,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/e2e/solid-router/basic-virtual-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-file-based/package.json
@@ -18,7 +18,7 @@
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/e2e/solid-router/basic-virtual-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-file-based/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
@@ -18,7 +18,7 @@
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/e2e/solid-router/basic/package.json
+++ b/e2e/solid-router/basic/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },

--- a/e2e/solid-router/basic/package.json
+++ b/e2e/solid-router/basic/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/e2e/solid-router/generator-cli-only/package.json
+++ b/e2e/solid-router/generator-cli-only/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/router-cli": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2"
   },

--- a/e2e/solid-router/generator-cli-only/package.json
+++ b/e2e/solid-router/generator-cli-only/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/router-cli": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2"

--- a/e2e/solid-router/js-only-file-based/package.json
+++ b/e2e/solid-router/js-only-file-based/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2"
   },

--- a/e2e/solid-router/js-only-file-based/package.json
+++ b/e2e/solid-router/js-only-file-based/package.json
@@ -14,7 +14,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2"

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
@@ -20,7 +20,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/zod-adapter": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
@@ -21,7 +21,7 @@
     "@tanstack/zod-adapter": "workspace:^",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/e2e/solid-router/sentry-integration/package.json
+++ b/e2e/solid-router/sentry-integration/package.json
@@ -17,7 +17,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2"

--- a/e2e/solid-router/sentry-integration/package.json
+++ b/e2e/solid-router/sentry-integration/package.json
@@ -18,7 +18,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2"
   },

--- a/e2e/solid-router/view-transitions/package.json
+++ b/e2e/solid-router/view-transitions/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/router-plugin": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/e2e/solid-router/view-transitions/package.json
+++ b/e2e/solid-router/view-transitions/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/router-plugin": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",

--- a/e2e/solid-start/basic-auth/package.json
+++ b/e2e/solid-start/basic-auth/package.json
@@ -20,7 +20,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0"

--- a/e2e/solid-start/basic-auth/package.json
+++ b/e2e/solid-start/basic-auth/package.json
@@ -21,7 +21,7 @@
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0"
   },

--- a/e2e/solid-start/basic-cloudflare/package.json
+++ b/e2e/solid-start/basic-cloudflare/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/e2e/solid-start/basic-cloudflare/package.json
+++ b/e2e/solid-start/basic-cloudflare/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.0",

--- a/e2e/solid-start/basic-solid-query/package.json
+++ b/e2e/solid-start/basic-solid-query/package.json
@@ -20,7 +20,7 @@
     "@tanstack/solid-router-ssr-query": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",
     "zod": "^4.1.12"

--- a/e2e/solid-start/basic-solid-query/package.json
+++ b/e2e/solid-start/basic-solid-query/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.3",
     "@tanstack/solid-router": "workspace:^",

--- a/e2e/solid-start/basic-tsr-config/package.json
+++ b/e2e/solid-start/basic-tsr-config/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "vite": "^8.0.0"
   },
   "devDependencies": {

--- a/e2e/solid-start/basic-tsr-config/package.json
+++ b/e2e/solid-start/basic-tsr-config/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "vite": "^8.0.0"
   },

--- a/e2e/solid-start/basic/package.json
+++ b/e2e/solid-start/basic/package.json
@@ -24,7 +24,7 @@
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",
     "zod": "^3.24.2"

--- a/e2e/solid-start/basic/package.json
+++ b/e2e/solid-start/basic/package.json
@@ -23,7 +23,7 @@
     "http-proxy-middleware": "^3.0.5",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",

--- a/e2e/solid-start/csp/package.json
+++ b/e2e/solid-start/csp/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "vite": "^8.0.0"
   },

--- a/e2e/solid-start/csp/package.json
+++ b/e2e/solid-start/csp/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "vite": "^8.0.0"
   },
   "devDependencies": {

--- a/e2e/solid-start/css-modules/package.json
+++ b/e2e/solid-start/css-modules/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-router": "workspace:*",
     "@tanstack/solid-start": "workspace:*",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",

--- a/e2e/solid-start/css-modules/package.json
+++ b/e2e/solid-start/css-modules/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@tanstack/solid-router": "workspace:*",
     "@tanstack/solid-start": "workspace:*",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/e2e/solid-start/custom-basepath/package.json
+++ b/e2e/solid-start/custom-basepath/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-start": "workspace:^",
     "express": "^5.1.0",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/e2e/solid-start/custom-basepath/package.json
+++ b/e2e/solid-start/custom-basepath/package.json
@@ -17,7 +17,7 @@
     "express": "^5.1.0",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",

--- a/e2e/solid-start/query-integration/package.json
+++ b/e2e/solid-start/query-integration/package.json
@@ -18,7 +18,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-router-ssr-query": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",

--- a/e2e/solid-start/query-integration/package.json
+++ b/e2e/solid-start/query-integration/package.json
@@ -19,7 +19,7 @@
     "@tanstack/solid-router-ssr-query": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",
     "zod": "^3.24.2"

--- a/e2e/solid-start/scroll-restoration/package.json
+++ b/e2e/solid-start/scroll-restoration/package.json
@@ -18,7 +18,7 @@
     "@tanstack/zod-adapter": "workspace:^",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",
     "zod": "^3.24.2"

--- a/e2e/solid-start/scroll-restoration/package.json
+++ b/e2e/solid-start/scroll-restoration/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-start": "workspace:^",
     "@tanstack/zod-adapter": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",

--- a/e2e/solid-start/selective-ssr/package.json
+++ b/e2e/solid-start/selective-ssr/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/e2e/solid-start/selective-ssr/package.json
+++ b/e2e/solid-start/selective-ssr/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "zod": "^3.24.2"
   },

--- a/e2e/solid-start/serialization-adapters/package.json
+++ b/e2e/solid-start/serialization-adapters/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "vite": "^8.0.0",
     "vite-tsconfig-paths": "^5.1.4",

--- a/e2e/solid-start/serialization-adapters/package.json
+++ b/e2e/solid-start/serialization-adapters/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "vite": "^8.0.0",
     "vite-tsconfig-paths": "^5.1.4",
     "zod": "^3.24.2"

--- a/e2e/solid-start/server-functions/package.json
+++ b/e2e/solid-start/server-functions/package.json
@@ -21,7 +21,7 @@
     "@tanstack/solid-start": "workspace:^",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",
     "zod": "^3.24.2"

--- a/e2e/solid-start/server-functions/package.json
+++ b/e2e/solid-start/server-functions/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.3",
     "@tanstack/solid-router": "workspace:^",

--- a/e2e/solid-start/server-routes/package.json
+++ b/e2e/solid-start/server-routes/package.json
@@ -20,7 +20,7 @@
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",
     "zod": "^3.24.2"

--- a/e2e/solid-start/server-routes/package.json
+++ b/e2e/solid-start/server-routes/package.json
@@ -19,7 +19,7 @@
     "@tanstack/solid-start": "workspace:^",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",

--- a/e2e/solid-start/spa-mode/package.json
+++ b/e2e/solid-start/spa-mode/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/e2e/solid-start/spa-mode/package.json
+++ b/e2e/solid-start/spa-mode/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "zod": "^3.24.2"
   },

--- a/e2e/solid-start/virtual-routes/package.json
+++ b/e2e/solid-start/virtual-routes/package.json
@@ -18,7 +18,7 @@
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",
     "zod": "^3.24.2"

--- a/e2e/solid-start/virtual-routes/package.json
+++ b/e2e/solid-start/virtual-routes/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-start": "workspace:^",
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",

--- a/e2e/solid-start/website/package.json
+++ b/e2e/solid-start/website/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",

--- a/e2e/solid-start/website/package.json
+++ b/e2e/solid-start/website/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",
     "zod": "^3.24.2"

--- a/examples/solid/authenticated-routes-firebase/package.json
+++ b/examples/solid/authenticated-routes-firebase/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
     "firebase": "^11.4.0",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "simple-icons": "^14.9.0",

--- a/examples/solid/authenticated-routes-firebase/package.json
+++ b/examples/solid/authenticated-routes-firebase/package.json
@@ -15,7 +15,7 @@
     "@tanstack/router-plugin": "^1.167.12",
     "firebase": "^11.4.0",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "simple-icons": "^14.9.0",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/authenticated-routes/package.json
+++ b/examples/solid/authenticated-routes/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/authenticated-routes/package.json
+++ b/examples/solid/authenticated-routes/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/basic-default-search-params/package.json
+++ b/examples/solid/basic-default-search-params/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/basic-default-search-params/package.json
+++ b/examples/solid/basic-default-search-params/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/basic-devtools-panel/package.json
+++ b/examples/solid/basic-devtools-panel/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/examples/solid/basic-devtools-panel/package.json
+++ b/examples/solid/basic-devtools-panel/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },

--- a/examples/solid/basic-file-based/package.json
+++ b/examples/solid/basic-file-based/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/examples/solid/basic-file-based/package.json
+++ b/examples/solid/basic-file-based/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/basic-non-nested-devtools/package.json
+++ b/examples/solid/basic-non-nested-devtools/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/examples/solid/basic-non-nested-devtools/package.json
+++ b/examples/solid/basic-non-nested-devtools/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },

--- a/examples/solid/basic-solid-query-file-based/package.json
+++ b/examples/solid/basic-solid-query-file-based/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/examples/solid/basic-solid-query-file-based/package.json
+++ b/examples/solid/basic-solid-query-file-based/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/basic-solid-query/package.json
+++ b/examples/solid/basic-solid-query/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/examples/solid/basic-solid-query/package.json
+++ b/examples/solid/basic-solid-query/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },

--- a/examples/solid/basic-ssr-file-based/package.json
+++ b/examples/solid/basic-ssr-file-based/package.json
@@ -17,7 +17,7 @@
     "express": "^4.21.2",
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/basic-ssr-file-based/package.json
+++ b/examples/solid/basic-ssr-file-based/package.json
@@ -18,7 +18,7 @@
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",

--- a/examples/solid/basic-ssr-streaming-file-based/package.json
+++ b/examples/solid/basic-ssr-streaming-file-based/package.json
@@ -19,7 +19,7 @@
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/basic-ssr-streaming-file-based/package.json
+++ b/examples/solid/basic-ssr-streaming-file-based/package.json
@@ -20,7 +20,7 @@
     "node-fetch": "^3.3.2",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/examples/solid/basic-virtual-file-based/package.json
+++ b/examples/solid/basic-virtual-file-based/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
     "@tanstack/virtual-file-routes": "^1.161.7",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/basic-virtual-file-based/package.json
+++ b/examples/solid/basic-virtual-file-based/package.json
@@ -15,7 +15,7 @@
     "@tanstack/router-plugin": "^1.167.12",
     "@tanstack/virtual-file-routes": "^1.161.7",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/basic-virtual-inside-file-based/package.json
+++ b/examples/solid/basic-virtual-inside-file-based/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
     "@tanstack/virtual-file-routes": "^1.161.7",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/basic-virtual-inside-file-based/package.json
+++ b/examples/solid/basic-virtual-inside-file-based/package.json
@@ -15,7 +15,7 @@
     "@tanstack/router-plugin": "^1.167.12",
     "@tanstack/virtual-file-routes": "^1.161.7",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },

--- a/examples/solid/deferred-data/package.json
+++ b/examples/solid/deferred-data/package.json
@@ -12,7 +12,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/deferred-data/package.json
+++ b/examples/solid/deferred-data/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/i18n-paraglide/package.json
+++ b/examples/solid/i18n-paraglide/package.json
@@ -13,7 +13,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/router-plugin": "^1.167.12",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },

--- a/examples/solid/i18n-paraglide/package.json
+++ b/examples/solid/i18n-paraglide/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/router-plugin": "^1.167.12",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/examples/solid/kitchen-sink-file-based/package.json
+++ b/examples/solid/kitchen-sink-file-based/package.json
@@ -15,7 +15,7 @@
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/examples/solid/kitchen-sink-file-based/package.json
+++ b/examples/solid/kitchen-sink-file-based/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/kitchen-sink-solid-query-file-based/package.json
+++ b/examples/solid/kitchen-sink-solid-query-file-based/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/kitchen-sink-solid-query-file-based/package.json
+++ b/examples/solid/kitchen-sink-solid-query-file-based/package.json
@@ -18,7 +18,7 @@
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/examples/solid/kitchen-sink-solid-query/package.json
+++ b/examples/solid/kitchen-sink-solid-query/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/kitchen-sink-solid-query/package.json
+++ b/examples/solid/kitchen-sink-solid-query/package.json
@@ -17,7 +17,7 @@
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/examples/solid/kitchen-sink/package.json
+++ b/examples/solid/kitchen-sink/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "immer": "^10.1.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/kitchen-sink/package.json
+++ b/examples/solid/kitchen-sink/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "immer": "^10.1.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/large-file-based/package.json
+++ b/examples/solid/large-file-based/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/large-file-based/package.json
+++ b/examples/solid/large-file-based/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/location-masking/package.json
+++ b/examples/solid/location-masking/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2"
   },

--- a/examples/solid/location-masking/package.json
+++ b/examples/solid/location-masking/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2"

--- a/examples/solid/navigation-blocking/package.json
+++ b/examples/solid/navigation-blocking/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2"
   },

--- a/examples/solid/navigation-blocking/package.json
+++ b/examples/solid/navigation-blocking/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2"

--- a/examples/solid/quickstart-file-based/package.json
+++ b/examples/solid/quickstart-file-based/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"
   },

--- a/examples/solid/quickstart-file-based/package.json
+++ b/examples/solid/quickstart-file-based/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/quickstart/package.json
+++ b/examples/solid/quickstart/package.json
@@ -12,7 +12,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },

--- a/examples/solid/quickstart/package.json
+++ b/examples/solid/quickstart/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-simple-lazy/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/package.json
@@ -12,7 +12,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-simple-lazy/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/package.json
@@ -11,7 +11,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1"
   },

--- a/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
@@ -19,7 +19,7 @@
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@router-solid-mono-simple-lazy/router": "workspace:*",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "vite-plugin-solid": "^3.0.0-next.4",

--- a/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@router-solid-mono-simple-lazy/router": "workspace:*",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-simple-lazy/packages/router/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/router/package.json
@@ -14,7 +14,7 @@
     "redaxios": "^0.5.1",
     "zod": "^3.24.2",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "vite-plugin-solid": "^3.0.0-next.4",

--- a/examples/solid/router-monorepo-simple-lazy/packages/router/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/router/package.json
@@ -13,7 +13,7 @@
     "@tanstack/router-plugin": "^1.167.12",
     "redaxios": "^0.5.1",
     "zod": "^3.24.2",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-simple/package.json
+++ b/examples/solid/router-monorepo-simple/package.json
@@ -12,7 +12,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-simple/package.json
+++ b/examples/solid/router-monorepo-simple/package.json
@@ -11,7 +11,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1"
   },

--- a/examples/solid/router-monorepo-simple/packages/app/package.json
+++ b/examples/solid/router-monorepo-simple/packages/app/package.json
@@ -12,7 +12,7 @@
     "@router-solid-mono-simple/post-feature": "workspace:*",
     "@router-solid-mono-simple/router": "workspace:*",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "vite-plugin-solid": "^3.0.0-next.4",

--- a/examples/solid/router-monorepo-simple/packages/app/package.json
+++ b/examples/solid/router-monorepo-simple/packages/app/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@router-solid-mono-simple/post-feature": "workspace:*",
     "@router-solid-mono-simple/router": "workspace:*",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-simple/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple/packages/post-feature/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@router-solid-mono-simple/router": "workspace:*",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-simple/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple/packages/post-feature/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@router-solid-mono-simple/router": "workspace:*",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "vite-plugin-solid": "^3.0.0-next.4",

--- a/examples/solid/router-monorepo-simple/packages/router/package.json
+++ b/examples/solid/router-monorepo-simple/packages/router/package.json
@@ -14,7 +14,7 @@
     "redaxios": "^0.5.1",
     "zod": "^3.24.2",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "vite-plugin-solid": "^3.0.0-next.4",

--- a/examples/solid/router-monorepo-simple/packages/router/package.json
+++ b/examples/solid/router-monorepo-simple/packages/router/package.json
@@ -13,7 +13,7 @@
     "@tanstack/router-plugin": "^1.167.12",
     "redaxios": "^0.5.1",
     "zod": "^3.24.2",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-solid-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-solid-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1"
   },

--- a/examples/solid/router-monorepo-solid-query/packages/app/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/app/package.json
@@ -13,7 +13,7 @@
     "@router-solid-mono-solid-query/post-feature": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "vite-plugin-solid": "^3.0.0-next.4",

--- a/examples/solid/router-monorepo-solid-query/packages/app/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/app/package.json
@@ -12,7 +12,7 @@
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@router-solid-mono-solid-query/post-feature": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
@@ -11,7 +11,7 @@
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@router-solid-mono-solid-query/post-query": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
@@ -12,7 +12,7 @@
     "@router-solid-mono-solid-query/post-query": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "vite-plugin-solid": "^3.0.0-next.4",

--- a/examples/solid/router-monorepo-solid-query/packages/router/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/router/package.json
@@ -16,7 +16,7 @@
     "redaxios": "^0.5.1",
     "zod": "^3.24.2",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "vite-plugin-solid": "^3.0.0-next.4",

--- a/examples/solid/router-monorepo-solid-query/packages/router/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/router/package.json
@@ -15,7 +15,7 @@
     "@router-solid-mono-solid-query/post-query": "workspace:*",
     "redaxios": "^0.5.1",
     "zod": "^3.24.2",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/scroll-restoration/package.json
+++ b/examples/solid/scroll-restoration/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-virtual": "^3.13.0",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/examples/solid/scroll-restoration/package.json
+++ b/examples/solid/scroll-restoration/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-virtual": "^3.13.0",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },

--- a/examples/solid/search-validator-adapters/package.json
+++ b/examples/solid/search-validator-adapters/package.json
@@ -19,7 +19,7 @@
     "@tanstack/valibot-adapter": "^1.166.9",
     "@tanstack/zod-adapter": "^1.166.9",
     "arktype": "^2.1.7",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "valibot": "1.0.0-beta.15",

--- a/examples/solid/search-validator-adapters/package.json
+++ b/examples/solid/search-validator-adapters/package.json
@@ -20,7 +20,7 @@
     "@tanstack/zod-adapter": "^1.166.9",
     "arktype": "^2.1.7",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2",
     "valibot": "1.0.0-beta.15",
     "zod": "^3.24.2"

--- a/examples/solid/start-basic-auth/package.json
+++ b/examples/solid/start-basic-auth/package.json
@@ -19,7 +19,7 @@
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/examples/solid/start-basic-auth/package.json
+++ b/examples/solid/start-basic-auth/package.json
@@ -18,7 +18,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0"
   },

--- a/examples/solid/start-basic-authjs/package.json
+++ b/examples/solid/start-basic-authjs/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "start-authjs": "^1.0.0",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/examples/solid/start-basic-authjs/package.json
+++ b/examples/solid/start-basic-authjs/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "start-authjs": "^1.0.0",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0"
   },

--- a/examples/solid/start-basic-cloudflare/package.json
+++ b/examples/solid/start-basic-cloudflare/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.0",

--- a/examples/solid/start-basic-cloudflare/package.json
+++ b/examples/solid/start-basic-cloudflare/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/start-basic-netlify/package.json
+++ b/examples/solid/start-basic-netlify/package.json
@@ -12,7 +12,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/start-basic-netlify/package.json
+++ b/examples/solid/start-basic-netlify/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@netlify/vite-plugin-tanstack-start": "^1.1.4",

--- a/examples/solid/start-basic-nitro/package.json
+++ b/examples/solid/start-basic-nitro/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/examples/solid/start-basic-nitro/package.json
+++ b/examples/solid/start-basic-nitro/package.json
@@ -12,7 +12,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/start-basic-solid-query/package.json
+++ b/examples/solid/start-basic-solid-query/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-router-ssr-query": "^2.0.0-beta.14",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0"
   },

--- a/examples/solid/start-basic-solid-query/package.json
+++ b/examples/solid/start-basic-solid-query/package.json
@@ -18,7 +18,7 @@
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/examples/solid/start-basic-static/package.json
+++ b/examples/solid/start-basic-static/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "@tanstack/start-static-server-functions": "^1.166.25",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwind-merge": "^2.6.0"
   },

--- a/examples/solid/start-basic-static/package.json
+++ b/examples/solid/start-basic-static/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "@tanstack/start-static-server-functions": "^1.166.25",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwind-merge": "^2.6.0"

--- a/examples/solid/start-basic/package.json
+++ b/examples/solid/start-basic/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0"
   },

--- a/examples/solid/start-basic/package.json
+++ b/examples/solid/start-basic/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/examples/solid/start-bun/package.json
+++ b/examples/solid/start-bun/package.json
@@ -21,7 +21,7 @@
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "@tanstack/router-plugin": "^1.167.12",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/examples/solid/start-bun/package.json
+++ b/examples/solid/start-bun/package.json
@@ -20,7 +20,7 @@
     "@tanstack/solid-router-ssr-query": "^2.0.0-beta.14",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "@tanstack/router-plugin": "^1.167.12",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwindcss": "^4.2.2"
   },

--- a/examples/solid/start-convex-better-auth/package.json
+++ b/examples/solid/start-convex-better-auth/package.json
@@ -22,7 +22,7 @@
     "convex-solidjs": "^0.0.3",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/start-convex-better-auth/package.json
+++ b/examples/solid/start-convex-better-auth/package.json
@@ -21,7 +21,7 @@
     "convex": "^1.28.2",
     "convex-solidjs": "^0.0.3",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/start-counter/package.json
+++ b/examples/solid/start-counter/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwind-merge": "^2.6.0",
     "zod": "^3.24.2"

--- a/examples/solid/start-counter/package.json
+++ b/examples/solid/start-counter/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwind-merge": "^2.6.0",

--- a/examples/solid/start-i18n-paraglide/package.json
+++ b/examples/solid/start-i18n-paraglide/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@types/node": "^22.18.6",

--- a/examples/solid/start-i18n-paraglide/package.json
+++ b/examples/solid/start-i18n-paraglide/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "devDependencies": {

--- a/examples/solid/start-large/package.json
+++ b/examples/solid/start-large/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwind-merge": "^2.6.0",
     "valibot": "^1.0.0-beta.15"

--- a/examples/solid/start-large/package.json
+++ b/examples/solid/start-large/package.json
@@ -16,7 +16,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwind-merge": "^2.6.0",

--- a/examples/solid/start-streaming-data-from-server-functions/package.json
+++ b/examples/solid/start-streaming-data-from-server-functions/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "zod": "^3.24.2"
   },

--- a/examples/solid/start-streaming-data-from-server-functions/package.json
+++ b/examples/solid/start-streaming-data-from-server-functions/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/examples/solid/start-supabase-basic/package.json
+++ b/examples/solid/start-supabase-basic/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.48.1",
     "@tanstack/solid-router": "^2.0.0-beta.12",

--- a/examples/solid/start-supabase-basic/package.json
+++ b/examples/solid/start-supabase-basic/package.json
@@ -19,7 +19,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6"
+    "solid-js": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/examples/solid/start-tailwind-v4/package.json
+++ b/examples/solid/start-tailwind-v4/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "zod": "^3.24.2"

--- a/examples/solid/start-tailwind-v4/package.json
+++ b/examples/solid/start-tailwind-v4/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/solid-start": "^2.0.0-beta.13",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "tailwind-merge": "^2.6.0",
     "zod": "^3.24.2"
   },

--- a/examples/solid/view-transitions/package.json
+++ b/examples/solid/view-transitions/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/view-transitions/package.json
+++ b/examples/solid/view-transitions/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "@tanstack/router-plugin": "^1.167.12",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/with-framer-motion/package.json
+++ b/examples/solid/with-framer-motion/package.json
@@ -13,7 +13,7 @@
     "@tanstack/solid-router": "^2.0.0-beta.12",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "solid-motionone": "^1.0.4",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/with-framer-motion/package.json
+++ b/examples/solid/with-framer-motion/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.9",
     "redaxios": "^0.5.1",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "solid-motionone": "^1.0.4",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/with-trpc/package.json
+++ b/examples/solid/with-trpc/package.json
@@ -18,7 +18,7 @@
     "@trpc/server": "^11.4.3",
     "express": "^4.21.2",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",
     "zod": "^3.24.2"

--- a/examples/solid/with-trpc/package.json
+++ b/examples/solid/with-trpc/package.json
@@ -17,7 +17,7 @@
     "@trpc/client": "^11.4.3",
     "@trpc/server": "^11.4.3",
     "express": "^4.21.2",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "redaxios": "^0.5.1",
     "tailwindcss": "^4.2.2",

--- a/packages/solid-router-devtools/package.json
+++ b/packages/solid-router-devtools/package.json
@@ -70,7 +70,7 @@
     "@tanstack/router-devtools-core": "workspace:*"
   },
   "devDependencies": {
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "vite": "*",
     "vite-plugin-solid": "^3.0.0-next.4",
@@ -79,7 +79,7 @@
   "peerDependencies": {
     "@tanstack/router-core": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "peerDependenciesMeta": {

--- a/packages/solid-router-devtools/package.json
+++ b/packages/solid-router-devtools/package.json
@@ -66,12 +66,12 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "@tanstack/router-devtools-core": "workspace:*"
   },
   "devDependencies": {
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "vite": "*",
     "vite-plugin-solid": "^3.0.0-next.4",
     "@types/node": ">=20"
@@ -80,7 +80,7 @@
     "@tanstack/router-core": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "@solidjs/web": "2.0.0-beta.6"
   },
   "peerDependenciesMeta": {
     "@tanstack/router-core": {

--- a/packages/solid-router-ssr-query/package.json
+++ b/packages/solid-router-ssr-query/package.json
@@ -67,7 +67,7 @@
     "@tanstack/router-ssr-query-core": "workspace:*"
   },
   "devDependencies": {
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@tanstack/solid-router": "workspace:*",
     "eslint-plugin-solid": "^0.14.5",

--- a/packages/solid-router-ssr-query/package.json
+++ b/packages/solid-router-ssr-query/package.json
@@ -71,7 +71,7 @@
     "@tanstack/solid-query": "^6.0.0-beta.3",
     "@tanstack/solid-router": "workspace:*",
     "eslint-plugin-solid": "^0.14.5",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "vite": "*",
     "vite-plugin-solid": "^3.0.0-next.4"
   },

--- a/packages/solid-router/package.json
+++ b/packages/solid-router/package.json
@@ -117,7 +117,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "combinate": "^1.1.11",
     "eslint-plugin-solid": "^0.14.5",
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "vite": "*",
     "vite-plugin-solid": "^3.0.0-next.4",
@@ -125,7 +125,7 @@
     "@types/node": ">=20"
   },
   "peerDependencies": {
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   },
   "bin": {

--- a/packages/solid-router/package.json
+++ b/packages/solid-router/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "@solid-devtools/logger": "^0.9.4",
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "@tanstack/history": "workspace:*",
     "@tanstack/router-core": "workspace:*",
     "isbot": "^5.1.22"
@@ -118,15 +118,15 @@
     "combinate": "^1.1.11",
     "eslint-plugin-solid": "^0.14.5",
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "vite": "*",
     "vite-plugin-solid": "^3.0.0-next.4",
     "zod": "^3.23.8",
     "@types/node": ">=20"
   },
   "peerDependencies": {
-    "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "solid-js": ">=2.0.0-0 <3.0.0",
+    "@solidjs/web": ">=2.0.0-0 <3.0.0"
   },
   "bin": {
     "intent": "./bin/intent.js"

--- a/packages/solid-start-client/package.json
+++ b/packages/solid-start-client/package.json
@@ -70,7 +70,7 @@
     "vite-plugin-solid": "^3.0.0-next.4"
   },
   "peerDependencies": {
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   }
 }

--- a/packages/solid-start-client/package.json
+++ b/packages/solid-start-client/package.json
@@ -70,7 +70,7 @@
     "vite-plugin-solid": "^3.0.0-next.4"
   },
   "peerDependencies": {
-    "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+    "solid-js": ">=2.0.0-0 <3.0.0",
+    "@solidjs/web": ">=2.0.0-0 <3.0.0"
   }
 }

--- a/packages/solid-start-server/package.json
+++ b/packages/solid-start-server/package.json
@@ -66,14 +66,14 @@
     "@tanstack/start-server-core": "workspace:*"
   },
   "devDependencies": {
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "typescript": "^6.0.2",
     "vite": "*",
     "vite-plugin-solid": "^3.0.0-next.4"
   },
   "peerDependencies": {
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6"
   }
 }

--- a/packages/solid-start-server/package.json
+++ b/packages/solid-start-server/package.json
@@ -67,13 +67,13 @@
   },
   "devDependencies": {
     "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "@solidjs/web": "2.0.0-beta.6",
     "typescript": "^6.0.2",
     "vite": "*",
     "vite-plugin-solid": "^3.0.0-next.4"
   },
   "peerDependencies": {
-    "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6"
+		"solid-js": ">=2.0.0-0 <3.0.0",
+    "@solidjs/web": ">=2.0.0-0 <3.0.0"
   }
 }

--- a/packages/solid-start-server/package.json
+++ b/packages/solid-start-server/package.json
@@ -73,7 +73,7 @@
     "vite-plugin-solid": "^3.0.0-next.4"
   },
   "peerDependencies": {
-		"solid-js": ">=2.0.0-0 <3.0.0",
+    "solid-js": ">=2.0.0-0 <3.0.0",
     "@solidjs/web": ">=2.0.0-0 <3.0.0"
   }
 }

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -121,8 +121,8 @@
     "@types/node": ">=20"
   },
   "peerDependencies": {
-    "solid-js": "2.0.0-beta.6",
-    "@solidjs/web": "^2.0.0-beta.6",
+    "solid-js": ">=2.0.0-0 <3.0.0",
+    "@solidjs/web": ">=2.0.0-0 <3.0.0",
     "vite": ">=7.0.0"
   },
   "bin": {

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -121,7 +121,7 @@
     "@types/node": ">=20"
   },
   "peerDependencies": {
-    "solid-js": "^2.0.0-beta.6",
+    "solid-js": "2.0.0-beta.6",
     "@solidjs/web": "^2.0.0-beta.6",
     "vite": ">=7.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
   benchmarks/bundle-size:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.5
-        version: 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
+        specifier: 2.0.0-beta.6
+        version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -225,13 +225,13 @@ importers:
         version: 8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vite-plugin-solid:
         specifier: ^3.0.0-next.4
-        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
+        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
 
   benchmarks/client-nav:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.5
-        version: 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
+        specifier: 2.0.0-beta.6
+        version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -286,7 +286,7 @@ importers:
         version: 8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vite-plugin-solid:
         specifier: ^3.0.0-next.4
-        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
+        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
       vitest:
         specifier: ^4.0.17
         version: 4.0.17(@types/node@25.0.9)(@vitest/ui@4.0.17)(esbuild@0.27.4)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.8))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
@@ -294,8 +294,8 @@ importers:
   benchmarks/ssr:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.5
-        version: 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
+        specifier: 2.0.0-beta.6
+        version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -344,7 +344,7 @@ importers:
         version: 8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vite-plugin-solid:
         specifier: ^3.0.0-next.4
-        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
+        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
       vitest:
         specifier: ^4.0.17
         version: 4.0.17(@types/node@25.0.9)(@vitest/ui@4.0.17)(esbuild@0.27.4)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.8))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
@@ -3033,7 +3033,7 @@ importers:
   e2e/solid-router/basepath-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/router-plugin':
         specifier: workspace:*
@@ -3064,7 +3064,7 @@ importers:
   e2e/solid-router/basic:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3141,7 +3141,7 @@ importers:
   e2e/solid-router/basic-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3190,7 +3190,7 @@ importers:
   e2e/solid-router/basic-file-based-code-splitting:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3230,7 +3230,7 @@ importers:
   e2e/solid-router/basic-scroll-restoration:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3273,7 +3273,7 @@ importers:
   e2e/solid-router/basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3316,7 +3316,7 @@ importers:
   e2e/solid-router/basic-solid-query-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3365,7 +3365,7 @@ importers:
   e2e/solid-router/basic-virtual-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3411,7 +3411,7 @@ importers:
   e2e/solid-router/basic-virtual-named-export-config-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3457,7 +3457,7 @@ importers:
   e2e/solid-router/generator-cli-only:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3497,7 +3497,7 @@ importers:
   e2e/solid-router/js-only-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3638,7 +3638,7 @@ importers:
   e2e/solid-router/scroll-restoration-sandbox-vite:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3693,7 +3693,7 @@ importers:
         specifier: ^4.6.1
         version: 4.6.1(encoding@0.1.13)
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3730,7 +3730,7 @@ importers:
   e2e/solid-router/view-transitions:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -3776,7 +3776,7 @@ importers:
   e2e/solid-start/basic:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -3858,7 +3858,7 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(prisma@7.0.0(@types/react@19.2.8)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2)
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -3916,7 +3916,7 @@ importers:
   e2e/solid-start/basic-cloudflare:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -3998,7 +3998,7 @@ importers:
   e2e/solid-start/basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.3
@@ -4092,7 +4092,7 @@ importers:
   e2e/solid-start/basic-tsr-config:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -4129,7 +4129,7 @@ importers:
   e2e/solid-start/csp:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -4166,7 +4166,7 @@ importers:
   e2e/solid-start/css-modules:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:*
@@ -4209,7 +4209,7 @@ importers:
   e2e/solid-start/custom-basepath:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -4273,7 +4273,7 @@ importers:
   e2e/solid-start/query-integration:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.3
@@ -4331,7 +4331,7 @@ importers:
   e2e/solid-start/scroll-restoration:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -4392,7 +4392,7 @@ importers:
   e2e/solid-start/selective-ssr:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -4435,7 +4435,7 @@ importers:
   e2e/solid-start/serialization-adapters:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -4484,7 +4484,7 @@ importers:
   e2e/solid-start/server-functions:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.3
@@ -4557,7 +4557,7 @@ importers:
   e2e/solid-start/server-routes:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.3
@@ -4627,7 +4627,7 @@ importers:
   e2e/solid-start/spa-mode:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -4670,7 +4670,7 @@ importers:
   e2e/solid-start/virtual-routes:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -4731,7 +4731,7 @@ importers:
   e2e/solid-start/website:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:^
@@ -9784,7 +9784,7 @@ importers:
   examples/solid/authenticated-routes:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -9824,7 +9824,7 @@ importers:
   examples/solid/authenticated-routes-firebase:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -9870,7 +9870,7 @@ importers:
   examples/solid/basic:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -9910,7 +9910,7 @@ importers:
   examples/solid/basic-default-search-params:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -9950,7 +9950,7 @@ importers:
   examples/solid/basic-devtools-panel:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -9984,7 +9984,7 @@ importers:
   examples/solid/basic-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10024,7 +10024,7 @@ importers:
   examples/solid/basic-non-nested-devtools:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10064,7 +10064,7 @@ importers:
   examples/solid/basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10107,7 +10107,7 @@ importers:
   examples/solid/basic-solid-query-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10153,7 +10153,7 @@ importers:
   examples/solid/basic-ssr-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/router-plugin':
         specifier: workspace:*
@@ -10196,7 +10196,7 @@ importers:
   examples/solid/basic-ssr-streaming-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10251,7 +10251,7 @@ importers:
   examples/solid/basic-virtual-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10294,7 +10294,7 @@ importers:
   examples/solid/basic-virtual-inside-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10337,7 +10337,7 @@ importers:
   examples/solid/deferred-data:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10374,7 +10374,7 @@ importers:
   examples/solid/i18n-paraglide:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10411,7 +10411,7 @@ importers:
   examples/solid/kitchen-sink:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10451,7 +10451,7 @@ importers:
   examples/solid/kitchen-sink-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10494,7 +10494,7 @@ importers:
   examples/solid/kitchen-sink-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10540,7 +10540,7 @@ importers:
   examples/solid/kitchen-sink-solid-query-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10589,7 +10589,7 @@ importers:
   examples/solid/large-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10632,7 +10632,7 @@ importers:
   examples/solid/location-masking:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10669,7 +10669,7 @@ importers:
   examples/solid/navigation-blocking:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10706,7 +10706,7 @@ importers:
   examples/solid/quickstart:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10771,7 +10771,7 @@ importers:
   examples/solid/quickstart-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -10912,7 +10912,7 @@ importers:
   examples/solid/router-monorepo-simple:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/router-plugin':
         specifier: workspace:*
@@ -10949,7 +10949,7 @@ importers:
   examples/solid/router-monorepo-simple-lazy:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/router-plugin':
         specifier: workspace:*
@@ -10986,7 +10986,7 @@ importers:
   examples/solid/router-monorepo-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/router-plugin':
         specifier: workspace:*
@@ -11029,7 +11029,7 @@ importers:
   examples/solid/scroll-restoration:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -11063,7 +11063,7 @@ importers:
   examples/solid/search-validator-adapters:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -11124,7 +11124,7 @@ importers:
   examples/solid/start-basic:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.12
@@ -11182,7 +11182,7 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(prisma@7.0.0(@types/react@19.2.8)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2)
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.12
@@ -11237,7 +11237,7 @@ importers:
         specifier: ^0.41.1
         version: 0.41.1
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.12
@@ -11283,7 +11283,7 @@ importers:
   examples/solid/start-basic-cloudflare:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.12
@@ -11329,7 +11329,7 @@ importers:
   examples/solid/start-basic-netlify:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.12
@@ -11372,7 +11372,7 @@ importers:
   examples/solid/start-basic-nitro:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.12
@@ -11415,7 +11415,7 @@ importers:
   examples/solid/start-basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.3
@@ -11470,7 +11470,7 @@ importers:
   examples/solid/start-basic-static:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.12
@@ -11519,7 +11519,7 @@ importers:
   examples/solid/start-bun:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -11592,7 +11592,7 @@ importers:
         specifier: ^0.9.7
         version: 0.9.7(@standard-schema/spec@1.0.0)(better-auth@1.3.27(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.6))(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2)
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -11656,7 +11656,7 @@ importers:
   examples/solid/start-counter:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.12
@@ -11699,7 +11699,7 @@ importers:
   examples/solid/start-i18n-paraglide:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-devtools':
         specifier: ^0.7.0
@@ -11742,7 +11742,7 @@ importers:
   examples/solid/start-large:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.3
@@ -11791,7 +11791,7 @@ importers:
   examples/solid/start-streaming-data-from-server-functions:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.12
@@ -11825,7 +11825,7 @@ importers:
   examples/solid/start-supabase-basic:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@supabase/ssr':
         specifier: ^0.5.2
@@ -11874,7 +11874,7 @@ importers:
   examples/solid/start-tailwind-v4:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.12
@@ -11920,7 +11920,7 @@ importers:
   examples/solid/view-transitions:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -11960,7 +11960,7 @@ importers:
   examples/solid/with-framer-motion:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -12000,7 +12000,7 @@ importers:
   examples/solid/with-trpc:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -12757,7 +12757,7 @@ importers:
         specifier: ^0.29.4
         version: 0.29.4(solid-js@2.0.0-beta.6)
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/history':
         specifier: workspace:*
@@ -12803,7 +12803,7 @@ importers:
   packages/solid-router-devtools:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/router-core':
         specifier: workspace:*
@@ -12838,7 +12838,7 @@ importers:
         version: link:../router-ssr-query-core
     devDependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.3
@@ -12862,7 +12862,7 @@ importers:
   packages/solid-start:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: '>=2.0.0-0 <3.0.0'
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/solid-router':
         specifier: workspace:*
@@ -12886,7 +12886,7 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       solid-js:
-        specifier: 2.0.0-beta.6
+        specifier: '>=2.0.0-0 <3.0.0'
         version: 2.0.0-beta.6
     devDependencies:
       '@tanstack/intent':
@@ -12905,7 +12905,7 @@ importers:
   packages/solid-start-client:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: '>=2.0.0-0 <3.0.0'
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/router-core':
         specifier: workspace:*
@@ -12917,7 +12917,7 @@ importers:
         specifier: workspace:*
         version: link:../start-client-core
       solid-js:
-        specifier: 2.0.0-beta.6
+        specifier: '>=2.0.0-0 <3.0.0'
         version: 2.0.0-beta.6
     devDependencies:
       '@solidjs/testing-library':
@@ -12955,7 +12955,7 @@ importers:
         version: link:../start-server-core
     devDependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       solid-js:
         specifier: 2.0.0-beta.6
@@ -18191,12 +18191,6 @@ packages:
     peerDependenciesMeta:
       '@solidjs/router':
         optional: true
-
-  '@solidjs/web@2.0.0-beta.5':
-    resolution: {integrity: sha512-BEw/jZilhnHiP/rQz+p4JaZemSShaZRABD/4YsA8B62A7FD4PhCLb7fD9wQTofwkMouxBxW7pbGDdcVGaoA9QQ==}
-    peerDependencies:
-      '@solidjs/signals': ^0.13.9
-      solid-js: ^2.0.0-beta.5
 
   '@solidjs/web@2.0.0-beta.6':
     resolution: {integrity: sha512-yAU2CWp20gNI++rUucSRYdxL1IFhu0Rl3sH2teZjNj4/GwOTGJawei4qC0ttHRabtgO5K2zJ3GvNLm8FKVaXwQ==}
@@ -30980,13 +30974,6 @@ snapshots:
       '@testing-library/dom': 10.4.1
       solid-js: 2.0.0-beta.6
 
-  '@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)':
-    dependencies:
-      '@solidjs/signals': 0.13.11
-      seroval: 1.4.2
-      seroval-plugins: 1.4.2(seroval@1.4.2)
-      solid-js: 2.0.0-beta.6
-
   '@solidjs/web@2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)':
     dependencies:
       '@solidjs/signals': 0.13.11
@@ -39478,22 +39465,6 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 2.0.0-beta.6
       solid-refresh: 0.6.3(solid-js@2.0.0-beta.6)
-      vite: 8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
-    optionalDependencies:
-      '@testing-library/jest-dom': 6.6.3
-    transitivePeerDependencies:
-      - supports-color
-
-  vite-plugin-solid@3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@solidjs/web': 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.5(@babel/core@7.29.0)(solid-js@2.0.0-beta.6)
-      merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.6
-      solid-refresh: 0.8.0-next.6(solid-js@2.0.0-beta.6)
       vite: 8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vitefu: 1.1.1(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,7 +170,7 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: ^2.0.0-beta.5
-        version: 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.5)
+        version: 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -193,8 +193,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: ^2.0.0-beta.5
-        version: 2.0.0-beta.5
+        specifier: 2.0.0-beta.6
+        version: 2.0.0-beta.6
       vue:
         specifier: ^3.5.16
         version: 3.5.25(typescript@6.0.2)
@@ -225,13 +225,13 @@ importers:
         version: 8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vite-plugin-solid:
         specifier: ^3.0.0-next.4
-        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.5))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.5)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
+        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
 
   benchmarks/client-nav:
     dependencies:
       '@solidjs/web':
         specifier: ^2.0.0-beta.5
-        version: 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.5)
+        version: 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -251,8 +251,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: ^2.0.0-beta.5
-        version: 2.0.0-beta.5
+        specifier: 2.0.0-beta.6
+        version: 2.0.0-beta.6
       vue:
         specifier: ^3.5.16
         version: 3.5.25(typescript@6.0.2)
@@ -286,7 +286,7 @@ importers:
         version: 8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vite-plugin-solid:
         specifier: ^3.0.0-next.4
-        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.5))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.5)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
+        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
       vitest:
         specifier: ^4.0.17
         version: 4.0.17(@types/node@25.0.9)(@vitest/ui@4.0.17)(esbuild@0.27.4)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.8))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
@@ -295,7 +295,7 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: ^2.0.0-beta.5
-        version: 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.5)
+        version: 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -321,8 +321,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: ^2.0.0-beta.5
-        version: 2.0.0-beta.5
+        specifier: 2.0.0-beta.6
+        version: 2.0.0-beta.6
       vue:
         specifier: ^3.5.16
         version: 3.5.25(typescript@6.0.2)
@@ -344,7 +344,7 @@ importers:
         version: 8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vite-plugin-solid:
         specifier: ^3.0.0-next.4
-        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.5))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.5)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
+        version: 3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
       vitest:
         specifier: ^4.0.17
         version: 4.0.17(@types/node@25.0.9)(@vitest/ui@4.0.17)(esbuild@0.27.4)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.8))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
@@ -3045,7 +3045,7 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@playwright/test':
@@ -3079,7 +3079,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3162,7 +3162,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3205,7 +3205,7 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3248,7 +3248,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3294,7 +3294,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3340,7 +3340,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3386,7 +3386,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3432,7 +3432,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3475,7 +3475,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3512,7 +3512,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3659,7 +3659,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3708,7 +3708,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3748,7 +3748,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -3800,7 +3800,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -3873,7 +3873,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -3928,7 +3928,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@cloudflare/vite-plugin':
@@ -4022,7 +4022,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -4104,7 +4104,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       vite:
         specifier: ^8.0.0
@@ -4138,7 +4138,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       vite:
         specifier: ^8.0.0
@@ -4175,7 +4175,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@playwright/test':
@@ -4227,7 +4227,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@playwright/test':
@@ -4294,7 +4294,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -4349,7 +4349,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -4401,7 +4401,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       zod:
         specifier: ^3.24.2
@@ -4447,7 +4447,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       vite:
         specifier: ^8.0.0
@@ -4511,7 +4511,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -4581,7 +4581,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -4639,7 +4639,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       zod:
         specifier: ^3.24.2
@@ -4688,7 +4688,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -4746,7 +4746,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -9802,7 +9802,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -9848,7 +9848,7 @@ importers:
         specifier: ^14.9.0
         version: 14.9.0
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -9885,7 +9885,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -9928,7 +9928,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -9965,7 +9965,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -9999,7 +9999,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10039,7 +10039,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10085,7 +10085,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10128,7 +10128,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10174,7 +10174,7 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@tanstack/solid-router-devtools':
@@ -10223,7 +10223,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10272,7 +10272,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10315,7 +10315,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10352,7 +10352,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10386,7 +10386,7 @@ importers:
         specifier: ^2.0.0-beta.12
         version: link:../../../packages/solid-router
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10429,7 +10429,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10469,7 +10469,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10518,7 +10518,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10567,7 +10567,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10610,7 +10610,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10650,7 +10650,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10687,7 +10687,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10718,7 +10718,7 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10786,7 +10786,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -10927,7 +10927,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@types/node':
@@ -10964,7 +10964,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@types/node':
@@ -11007,7 +11007,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@types/node':
@@ -11044,7 +11044,7 @@ importers:
         specifier: ^3.13.0
         version: 3.13.12(solid-js@2.0.0-beta.6)
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -11093,7 +11093,7 @@ importers:
         specifier: ^2.1.7
         version: 2.1.7
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -11139,7 +11139,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -11197,7 +11197,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -11249,7 +11249,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       start-authjs:
         specifier: ^1.0.0
@@ -11295,7 +11295,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@cloudflare/vite-plugin':
@@ -11341,7 +11341,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@netlify/vite-plugin-tanstack-start':
@@ -11384,7 +11384,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@tailwindcss/vite':
@@ -11439,7 +11439,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -11488,7 +11488,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -11543,7 +11543,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -11622,7 +11622,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -11671,7 +11671,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -11714,7 +11714,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@inlang/paraglide-js':
@@ -11760,7 +11760,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -11803,7 +11803,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       zod:
         specifier: ^3.24.2
@@ -11846,7 +11846,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@tailwindcss/vite':
@@ -11886,7 +11886,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwind-merge:
         specifier: ^2.6.0
@@ -11938,7 +11938,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -11975,7 +11975,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       solid-motionone:
         specifier: ^1.0.4
@@ -12027,7 +12027,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       tailwindcss:
         specifier: ^4.2.2
@@ -12788,7 +12788,7 @@ importers:
         specifier: ^0.14.5
         version: 0.14.5(eslint@9.22.0(jiti@2.6.1))(typescript@6.0.2)
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       vite:
         specifier: ^8.0.0
@@ -12819,7 +12819,7 @@ importers:
         specifier: 25.0.9
         version: 25.0.9
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       vite:
         specifier: ^8.0.0
@@ -12850,7 +12850,7 @@ importers:
         specifier: ^0.14.5
         version: 0.14.5(eslint@9.22.0(jiti@2.6.1))(typescript@6.0.2)
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       vite:
         specifier: ^8.0.0
@@ -12886,7 +12886,7 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@tanstack/intent':
@@ -12917,7 +12917,7 @@ importers:
         specifier: workspace:*
         version: link:../start-client-core
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
     devDependencies:
       '@solidjs/testing-library':
@@ -12958,7 +12958,7 @@ importers:
         specifier: ^2.0.0-beta.6
         version: 2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       solid-js:
-        specifier: ^2.0.0-beta.6
+        specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
       typescript:
         specifier: ^6.0.2
@@ -18181,9 +18181,6 @@ packages:
 
   '@solidjs/signals@0.13.11':
     resolution: {integrity: sha512-EHrJONVsjvCeWSWTRhDWqqbT9MsP3IVZzBrprw6H1OTU99FBoo+oQ9JX976bhY6zAn/WApsAp/M5i92VVRtKCQ==}
-
-  '@solidjs/signals@0.13.9':
-    resolution: {integrity: sha512-+w+ShIB3hunVM0HZcXnhUhfLQvSdKlZflTQ0q3P9B/IfDOS8GPelY28wGouGt/6QzfJ1ueqx8bOg1TFQutPuaQ==}
 
   '@solidjs/testing-library@0.8.10':
     resolution: {integrity: sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==}
@@ -24481,9 +24478,6 @@ packages:
 
   solid-js@1.9.10:
     resolution: {integrity: sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==}
-
-  solid-js@2.0.0-beta.5:
-    resolution: {integrity: sha512-1yeOXw21iWoKOxEZdbBjvKr5rPogd+m7SMffVxbPVanoxMZNxIJd9lmM9o6gCS9WLvvPLV4B/BhU3tHETphX6g==}
 
   solid-js@2.0.0-beta.6:
     resolution: {integrity: sha512-C0IYMgZPPM0NKgonHNlWMDUwRKC88rII+5z8pFtAkqi/cHfdiUkpYLPtxP8YsqH7TwLRQGyB8/NgiVzkxNwPGA==}
@@ -30981,19 +30975,17 @@ snapshots:
 
   '@solidjs/signals@0.13.11': {}
 
-  '@solidjs/signals@0.13.9': {}
-
   '@solidjs/testing-library@0.8.10(solid-js@2.0.0-beta.6)':
     dependencies:
       '@testing-library/dom': 10.4.1
       solid-js: 2.0.0-beta.6
 
-  '@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.5)':
+  '@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)':
     dependencies:
       '@solidjs/signals': 0.13.11
       seroval: 1.4.2
       seroval-plugins: 1.4.2(seroval@1.4.2)
-      solid-js: 2.0.0-beta.5
+      solid-js: 2.0.0-beta.6
 
   '@solidjs/web@2.0.0-beta.6(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)':
     dependencies:
@@ -33191,13 +33183,6 @@ snapshots:
       babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.29.0)
     optionalDependencies:
       solid-js: 2.0.0-beta.6
-
-  babel-preset-solid@2.0.0-beta.5(@babel/core@7.29.0)(solid-js@2.0.0-beta.5):
-    dependencies:
-      '@babel/core': 7.29.0
-      babel-plugin-jsx-dom-expressions: 0.41.0-next.17(@babel/core@7.29.0)
-    optionalDependencies:
-      solid-js: 2.0.0-beta.5
 
   babel-preset-solid@2.0.0-beta.5(@babel/core@7.29.0)(solid-js@2.0.0-beta.6):
     dependencies:
@@ -38573,13 +38558,6 @@ snapshots:
       seroval: 1.3.2
       seroval-plugins: 1.3.2(seroval@1.3.2)
 
-  solid-js@2.0.0-beta.5:
-    dependencies:
-      '@solidjs/signals': 0.13.9
-      csstype: 3.2.3
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
-
   solid-js@2.0.0-beta.6:
     dependencies:
       '@solidjs/signals': 0.13.11
@@ -38614,12 +38592,6 @@ snapshots:
       solid-js: 2.0.0-beta.6
     transitivePeerDependencies:
       - supports-color
-
-  solid-refresh@0.8.0-next.6(solid-js@2.0.0-beta.5):
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@babel/types': 7.29.0
-      solid-js: 2.0.0-beta.5
 
   solid-refresh@0.8.0-next.6(solid-js@2.0.0-beta.6):
     dependencies:
@@ -39513,15 +39485,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.5))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.5)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)):
+  vite-plugin-solid@3.0.0-next.4(@solidjs/web@2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.6)(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)):
     dependencies:
       '@babel/core': 7.29.0
-      '@solidjs/web': 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.5)
+      '@solidjs/web': 2.0.0-beta.5(@solidjs/signals@0.13.11)(solid-js@2.0.0-beta.6)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.5(@babel/core@7.29.0)(solid-js@2.0.0-beta.5)
+      babel-preset-solid: 2.0.0-beta.5(@babel/core@7.29.0)(solid-js@2.0.0-beta.6)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.5
-      solid-refresh: 0.8.0-next.6(solid-js@2.0.0-beta.5)
+      solid-js: 2.0.0-beta.6
+      solid-refresh: 0.8.0-next.6(solid-js@2.0.0-beta.6)
       vite: 8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
       vitefu: 1.1.1(vite@8.0.0(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
     optionalDependencies:


### PR DESCRIPTION
even though solid 2.0.0-experimental.x was released before 2.0.0-beta.x, the semver is opposite. Since `b` comes before `e` alphabetically, the semver is that `experimental` will be the "newer" version.