### PR TITLE
fix(docs): correct server function name in example

### DIFF
--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -52,7 +52,7 @@ Call server functions from:
 ```tsx
 // In a route loader
 export const Route = createFileRoute('/posts')({
-  loader: () => getPosts(),
+  loader: () => getServerPosts(),
 })
 
 // In a component


### PR DESCRIPTION
This updates the route loader example in `docs/start/framework/react/guide/server-functions.md`.

The loader example was calling `getPosts()`, while the rest of the snippet references `getServerPosts` as the server function.

Related issue: TanStack/tanstack.com#819


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated server functions guide example for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->