### PR TITLE
fix(react-router): prevent webpack static analysis of React.use with let binding

### DIFF
--- a/.changeset/fix-react-router-webpack-use-analysis.md
+++ b/.changeset/fix-react-router-webpack-use-analysis.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+fix(react-router): prevent webpack static analysis of `React.use` with let binding

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -5,6 +5,7 @@ import * as React from 'react'
 // React 18 with Webpack, which statically analyzes imports and fails when it
 // sees React.use referenced (since 'use' is not exported from React 18).
 // This uses a dynamic string lookup to avoid the static analysis.
+// eslint-disable-next-line prefer-const -- Must be `let` to prevent bundler constant-folding
 let REACT_USE = 'use'
 
 /**

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -5,7 +5,7 @@ import * as React from 'react'
 // React 18 with Webpack, which statically analyzes imports and fails when it
 // sees React.use referenced (since 'use' is not exported from React 18).
 // This uses a dynamic string lookup to avoid the static analysis.
-const REACT_USE = 'use'
+let REACT_USE = 'use'
 
 /**
  * React.use if available (React 19+), undefined otherwise.


### PR DESCRIPTION
Fixes #7176

In #6926, the `const REACT_USE = 'use'` statement started getting optimized away by the bundler (constant folding), replacing `React[REACT_USE]` with `React['use']` in the published ESM output. This caused Webpack to fail on React 18 apps again since it statically analyzes the `'use'` property access.

Changing `const` to `let` prevents the bundler from inlining the string literal, restoring the dynamic lookup behaviour in the compiled output:
```js
let REACT_USE = 'use';
var reactUse = React[REACT_USE];
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal change to preserve runtime behavior and avoid build-time optimization altering how a React hook is accessed. No user-visible changes or API differences.
  * Added release metadata for a patch update reflecting the internal fix; no functional impact for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->