### PR TITLE
fix(docs): remove duplicate code block in query integration guide

### DIFF
--- a/docs/router/integrations/query.md
+++ b/docs/router/integrations/query.md
@@ -77,6 +77,10 @@ By default, the integration wraps your router with a `QueryClientProvider`. If y
 - `useSuspenseQuery`: runs on the server during SSR when its data is required and will be streamed to the client as it resolves.
 - `useQuery`: does not execute on the server; it will fetch on the client after hydration. Use this for data that is not required for SSR.
 
+<!-- ::start:framework -->
+
+# React
+
 ```tsx
 // Suspense: executes on server and streams
 const { data } = useSuspenseQuery(postsQuery)
@@ -85,9 +89,7 @@ const { data } = useSuspenseQuery(postsQuery)
 const { data, isLoading } = useQuery(postsQuery)
 ```
 
-<!-- ::start:framework -->
-
-# React
+# Solid
 
 ```tsx
 // Suspense: executes on server and streams

--- a/docs/router/integrations/query.md
+++ b/docs/router/integrations/query.md
@@ -89,16 +89,6 @@ const { data } = useSuspenseQuery(postsQuery)
 const { data, isLoading } = useQuery(postsQuery)
 ```
 
-# Solid
-
-```tsx
-// Suspense: executes on server and streams
-const { data } = useSuspenseQuery(postsQuery)
-
-// Non-suspense: executes only on client
-const { data, isLoading } = useQuery(postsQuery)
-```
-
 <!-- ::end:framework -->
 
 ### Preload with a loader and read with a hook


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed an unscoped example and left the framework-scoped examples in the "Using useSuspenseQuery vs useQuery" section to reduce duplication and ensure framework-specific samples are shown consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->