### PR TITLE
fix(react-router): avoid Webpack inlining React.use static analysis

### DIFF
--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -4,16 +4,19 @@ import * as React from 'react'
 // Safe version of React.use() that will not cause compilation errors against
 // React 18 with Webpack, which statically analyzes imports and fails when it
 // sees React.use referenced (since 'use' is not exported from React 18).
-// This uses a dynamic string lookup to avoid the static analysis.
-const REACT_USE = 'use'
-
+//
+// We previously used `const REACT_USE = 'use'; React[REACT_USE]`, but recent
+// bundler updates inline that constant back into the literal `React['use']`,
+// re-triggering Webpack's static analysis (#7176). Using `Reflect.get` keeps
+// the lookup as an actual runtime call that bundlers won't fold into a
+// direct property access.
 /**
  * React.use if available (React 19+), undefined otherwise.
  * Use dynamic lookup to avoid Webpack compilation errors with React 18.
  */
 export const reactUse:
   | (<T>(usable: Promise<T> | React.Context<T>) => T)
-  | undefined = (React as any)[REACT_USE]
+  | undefined = Reflect.get(React, 'use')
 
 export function useStableCallback<T extends (...args: Array<any>) => any>(
   fn: T,

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -14,9 +14,14 @@ import * as React from 'react'
  * React.use if available (React 19+), undefined otherwise.
  * Use dynamic lookup to avoid Webpack compilation errors with React 18.
  */
+const _reactUseCandidate = Reflect.get(React, 'use')
+
 export const reactUse:
   | (<T>(usable: Promise<T> | React.Context<T>) => T)
-  | undefined = Reflect.get(React, 'use')
+  | undefined =
+  typeof _reactUseCandidate === 'function'
+    ? (_reactUseCandidate as <T>(usable: Promise<T> | React.Context<T>) => T)
+    : undefined
 
 export function useStableCallback<T extends (...args: Array<any>) => any>(
   fn: T,


### PR DESCRIPTION
Per #7176, recent bundler updates inline `const REACT_USE = 'use'; React[REACT_USE]` back into the literal `React['use']` in the published package, which re-triggers Webpack's static analysis and breaks builds against React 18 (which doesn't export `use`).

This was previously fixed by #6355, but the bundled output regressed somewhere between #6355 and #6926.

This PR replaces the manual indirection with `Reflect.get(React, 'use')`. `Reflect.get` is a real runtime call — bundlers don't fold it into a direct property access — so the property name never appears as a static literal in the bundled output, and Webpack's static analyzer has nothing to flag.

Closes #7176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal runtime lookup logic adjusted to be safer and more defensive; preserves existing behavior while improving robustness and maintainability, with no changes to public APIs or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->