### PR TITLE
fix: filter route-owned chunks and CSS from root route's entry preloads/assets

### DIFF
--- a/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
@@ -395,17 +395,22 @@ export function buildRouteManifestRoutes(options: {
     }
   }
 
-  // Collect filenames of chunks that belong to specific routes so we can
-  // exclude them from the root route's entry-chunk preloads. Without this,
-  // when Rolldown moves route chunks into the entry's static `imports`
-  // (common in large projects), every route chunk leaks into root preloads
-  // and gets modulepreloaded on every page.
+  // Collect filenames of chunks and CSS that belong to specific routes so we
+  // can exclude them from the root route's entry-chunk preloads and assets.
+  // Without this, when Rolldown moves route chunks into the entry's static
+  // `imports` (common in large projects), every route chunk leaks into root
+  // preloads and every route-owned CSS leaks into root assets.
   const routeChunkFileNames = new Set<string>()
   for (const chunks of options.routeChunksByFilePath.values()) {
     for (const chunk of chunks) {
       routeChunkFileNames.add(
         options.assetResolvers.getAssetPath(chunk.fileName),
       )
+      for (const cssFile of chunk.css) {
+        routeChunkFileNames.add(
+          options.assetResolvers.getAssetPath(cssFile),
+        )
+      }
     }
   }
 
@@ -413,7 +418,10 @@ export function buildRouteManifestRoutes(options: {
   mergeRouteChunkData({
     route: rootRoute,
     chunk: options.entryChunk,
-    getChunkCssAssets,
+    getChunkCssAssets: (chunk) => {
+      const assets = getChunkCssAssets(chunk)
+      return assets.filter((a) => !routeChunkFileNames.has(a.attrs.href))
+    },
     getChunkPreloads: (chunk) => {
       const preloads = options.assetResolvers.getChunkPreloads(chunk)
       return preloads.filter((p) => !routeChunkFileNames.has(p))

--- a/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
@@ -395,20 +395,9 @@ export function buildRouteManifestRoutes(options: {
     }
   }
 
-  // Collect all preloads already owned by specific routes so we can exclude
-  // them from the root route's entry-chunk preloads. Without this, when
-  // Rolldown moves route chunks into the entry's static `imports` (common in
-  // large projects), every route's transitively-reachable chunk leaks into
-  // root preloads and gets modulepreloaded on every page.
-  //
-  // We collect from the already-built non-root routes' preloads (rather than
-  // `routeChunksByFilePath`) so the filter covers transitively-imported chunks
-  // that Rolldown split out separately but are only reachable via a specific
-  // route (e.g., route-data chunks, shared chunks only used by routes).
-  //
-  // Note: we only filter preloads (which are just browser hints), not CSS
-  // assets — CSS in root may be genuinely needed for SSR-rendered pages even
-  // if it's also transitively reachable from a route.
+  // Exclude chunks already owned by specific routes from root preloads,
+  // so Rolldown's route-chunk hoisting into entry imports doesn't cause
+  // every route to be modulepreloaded on every page.
   const routeOwnedPreloads = new Set<string>()
   for (const [routeId, route] of Object.entries(routes)) {
     if (routeId === rootRouteId) continue

--- a/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
@@ -407,9 +407,7 @@ export function buildRouteManifestRoutes(options: {
         options.assetResolvers.getAssetPath(chunk.fileName),
       )
       for (const cssFile of chunk.css) {
-        routeChunkFileNames.add(
-          options.assetResolvers.getAssetPath(cssFile),
-        )
+        routeChunkFileNames.add(options.assetResolvers.getAssetPath(cssFile))
       }
     }
   }

--- a/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
@@ -395,20 +395,25 @@ export function buildRouteManifestRoutes(options: {
     }
   }
 
-  // Collect filenames of chunks and CSS that belong to specific routes so we
-  // can exclude them from the root route's entry-chunk preloads and assets.
-  // Without this, when Rolldown moves route chunks into the entry's static
-  // `imports` (common in large projects), every route chunk leaks into root
-  // preloads and every route-owned CSS leaks into root assets.
-  const routeChunkFileNames = new Set<string>()
-  for (const chunks of options.routeChunksByFilePath.values()) {
-    for (const chunk of chunks) {
-      routeChunkFileNames.add(
-        options.assetResolvers.getAssetPath(chunk.fileName),
-      )
-      for (const cssFile of chunk.css) {
-        routeChunkFileNames.add(options.assetResolvers.getAssetPath(cssFile))
-      }
+  // Collect all preloads already owned by specific routes so we can exclude
+  // them from the root route's entry-chunk preloads. Without this, when
+  // Rolldown moves route chunks into the entry's static `imports` (common in
+  // large projects), every route's transitively-reachable chunk leaks into
+  // root preloads and gets modulepreloaded on every page.
+  //
+  // We collect from the already-built non-root routes' preloads (rather than
+  // `routeChunksByFilePath`) so the filter covers transitively-imported chunks
+  // that Rolldown split out separately but are only reachable via a specific
+  // route (e.g., route-data chunks, shared chunks only used by routes).
+  //
+  // Note: we only filter preloads (which are just browser hints), not CSS
+  // assets — CSS in root may be genuinely needed for SSR-rendered pages even
+  // if it's also transitively reachable from a route.
+  const routeOwnedPreloads = new Set<string>()
+  for (const [routeId, route] of Object.entries(routes)) {
+    if (routeId === rootRouteId) continue
+    if (route.preloads) {
+      for (const preload of route.preloads) routeOwnedPreloads.add(preload)
     }
   }
 
@@ -416,13 +421,10 @@ export function buildRouteManifestRoutes(options: {
   mergeRouteChunkData({
     route: rootRoute,
     chunk: options.entryChunk,
-    getChunkCssAssets: (chunk) => {
-      const assets = getChunkCssAssets(chunk)
-      return assets.filter((a) => !routeChunkFileNames.has(a.attrs.href))
-    },
+    getChunkCssAssets,
     getChunkPreloads: (chunk) => {
       const preloads = options.assetResolvers.getChunkPreloads(chunk)
-      return preloads.filter((p) => !routeChunkFileNames.has(p))
+      return preloads.filter((p) => !routeOwnedPreloads.has(p))
     },
   })
 

--- a/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
@@ -395,12 +395,29 @@ export function buildRouteManifestRoutes(options: {
     }
   }
 
+  // Collect filenames of chunks that belong to specific routes so we can
+  // exclude them from the root route's entry-chunk preloads. Without this,
+  // when Rolldown moves route chunks into the entry's static `imports`
+  // (common in large projects), every route chunk leaks into root preloads
+  // and gets modulepreloaded on every page.
+  const routeChunkFileNames = new Set<string>()
+  for (const chunks of options.routeChunksByFilePath.values()) {
+    for (const chunk of chunks) {
+      routeChunkFileNames.add(
+        options.assetResolvers.getAssetPath(chunk.fileName),
+      )
+    }
+  }
+
   const rootRoute = (routes[rootRouteId] = routes[rootRouteId] || {})
   mergeRouteChunkData({
     route: rootRoute,
     chunk: options.entryChunk,
     getChunkCssAssets,
-    getChunkPreloads: options.assetResolvers.getChunkPreloads,
+    getChunkPreloads: (chunk) => {
+      const preloads = options.assetResolvers.getChunkPreloads(chunk)
+      return preloads.filter((p) => !routeChunkFileNames.has(p))
+    },
   })
 
   if (options.additionalRouteAssets) {

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -1263,17 +1263,23 @@ describe('root route should not include route-owned preloads or assets', () => {
 
     // Route CSS should be in its own route's assets
     expect(aboutAssets).toContainEqual(
-      expect.objectContaining({ attrs: expect.objectContaining({ href: '/assets/about.css' }) }),
+      expect.objectContaining({
+        attrs: expect.objectContaining({ href: '/assets/about.css' }),
+      }),
     )
 
     // Route CSS should NOT leak into root assets
     expect(rootAssets).not.toContainEqual(
-      expect.objectContaining({ attrs: expect.objectContaining({ href: '/assets/about.css' }) }),
+      expect.objectContaining({
+        attrs: expect.objectContaining({ href: '/assets/about.css' }),
+      }),
     )
 
     // Entry CSS should still be in root assets
     expect(rootAssets).toContainEqual(
-      expect.objectContaining({ attrs: expect.objectContaining({ href: '/assets/entry.css' }) }),
+      expect.objectContaining({
+        attrs: expect.objectContaining({ href: '/assets/entry.css' }),
+      }),
     )
   })
 })

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -1160,23 +1160,24 @@ describe('multi-chunk routes must merge assets and preloads', () => {
 })
 
 describe('root route should not include route-owned preloads', () => {
-  test('entry chunk that statically imports route chunks does not leak them into root preloads', () => {
-    const routeChunk = makeChunk({
-      fileName: 'about-chunk.js',
-      moduleIds: ['/routes/about.tsx?tsr-split=component'],
-    })
-    // Entry chunk statically imports the route chunk (happens in large projects with Rolldown)
-    const entryChunk = makeChunk({
-      fileName: 'entry.js',
-      isEntry: true,
-      imports: ['about-chunk.js'],
-      importedCss: ['entry.css'],
-    })
-
+  test('filters route chunks and their transitive deps, keeps shared vendors', () => {
+    // Simulates Rolldown hoisting route chunks into entry's static imports
+    // in large projects: entry statically imports a shared vendor, a route
+    // chunk, and that route's transitive data chunk.
     const manifest = buildStartManifest({
       clientBuild: normalizeViteClientBuild({
-        'entry.js': entryChunk,
-        'about-chunk.js': routeChunk,
+        'entry.js': makeChunk({
+          fileName: 'entry.js',
+          isEntry: true,
+          imports: ['shared-vendor.js', 'about-chunk.js', 'about-data.js'],
+        }),
+        'shared-vendor.js': makeChunk({ fileName: 'shared-vendor.js' }),
+        'about-chunk.js': makeChunk({
+          fileName: 'about-chunk.js',
+          imports: ['about-data.js'],
+          moduleIds: ['/routes/about.tsx?tsr-split=component'],
+        }),
+        'about-data.js': makeChunk({ fileName: 'about-data.js' }),
       }),
       routeTreeRoutes: {
         __root__: { children: ['/about'] } as any,
@@ -1186,99 +1187,14 @@ describe('root route should not include route-owned preloads', () => {
     })
 
     const rootPreloads = manifest.routes['__root__']!.preloads!
-    const aboutPreloads = manifest.routes['/about']!.preloads!
 
-    // Route chunk should be in its own route's preloads
-    expect(aboutPreloads).toContain('/assets/about-chunk.js')
-
-    // Route chunk should NOT leak into root preloads
-    expect(rootPreloads).not.toContain('/assets/about-chunk.js')
-
-    // Entry chunk itself should still be in root preloads
     expect(rootPreloads).toContain('/assets/entry.js')
-  })
-
-  test('shared dependencies not owned by any route remain in root preloads', () => {
-    const sharedChunk = makeChunk({
-      fileName: 'shared-vendor.js',
-    })
-    const routeChunk = makeChunk({
-      fileName: 'about-chunk.js',
-      moduleIds: ['/routes/about.tsx?tsr-split=component'],
-    })
-    const entryChunk = makeChunk({
-      fileName: 'entry.js',
-      isEntry: true,
-      imports: ['shared-vendor.js', 'about-chunk.js'],
-      importedCss: ['entry.css'],
-    })
-
-    const manifest = buildStartManifest({
-      clientBuild: normalizeViteClientBuild({
-        'entry.js': entryChunk,
-        'shared-vendor.js': sharedChunk,
-        'about-chunk.js': routeChunk,
-      }),
-      routeTreeRoutes: {
-        __root__: { children: ['/about'] } as any,
-        '/about': { filePath: '/routes/about.tsx' },
-      },
-      basePath: '/assets',
-    })
-
-    const rootPreloads = manifest.routes['__root__']!.preloads!
-
-    // Shared vendor chunk should remain in root preloads (not owned by any route)
     expect(rootPreloads).toContain('/assets/shared-vendor.js')
-
-    // Route chunk should be filtered out from root preloads
     expect(rootPreloads).not.toContain('/assets/about-chunk.js')
-  })
-
-  test('transitively-reachable route-owned chunks (e.g. route data chunks) do not leak into root preloads', () => {
-    // In large projects Rolldown often splits route-transitive deps (like
-    // route data modules) into separate chunks. Those chunks end up in entry's
-    // static imports even though they're only reachable via a specific route.
-    const routeDataChunk = makeChunk({
-      fileName: 'about-data.js',
-    })
-    const routeChunk = makeChunk({
-      fileName: 'about-chunk.js',
-      imports: ['about-data.js'],
-      moduleIds: ['/routes/about.tsx?tsr-split=component'],
-    })
-    // Entry statically imports BOTH the route chunk and its data chunk
-    // (simulating Rolldown's chunk hoisting behavior in large projects).
-    const entryChunk = makeChunk({
-      fileName: 'entry.js',
-      isEntry: true,
-      imports: ['about-chunk.js', 'about-data.js'],
-      importedCss: ['entry.css'],
-    })
-
-    const manifest = buildStartManifest({
-      clientBuild: normalizeViteClientBuild({
-        'entry.js': entryChunk,
-        'about-chunk.js': routeChunk,
-        'about-data.js': routeDataChunk,
-      }),
-      routeTreeRoutes: {
-        __root__: { children: ['/about'] } as any,
-        '/about': { filePath: '/routes/about.tsx' },
-      },
-      basePath: '/assets',
-    })
-
-    const rootPreloads = manifest.routes['__root__']!.preloads!
-
-    // The data chunk, though reachable only via /about, shows up in entry's
-    // static imports. It should be filtered out of root preloads because it's
-    // already covered by /about's preloads.
     expect(rootPreloads).not.toContain('/assets/about-data.js')
-    expect(rootPreloads).not.toContain('/assets/about-chunk.js')
-
-    // Entry chunk itself remains
-    expect(rootPreloads).toContain('/assets/entry.js')
+    expect(manifest.routes['/about']!.preloads).toContain(
+      '/assets/about-chunk.js',
+    )
   })
 })
 

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -1156,7 +1156,7 @@ describe('multi-chunk routes must merge assets and preloads', () => {
   })
 })
 
-describe('root route should not include route-owned preloads', () => {
+describe('root route should not include route-owned preloads or assets', () => {
   test('entry chunk that statically imports route chunks does not leak them into root preloads', () => {
     const routeChunk = makeChunk({
       fileName: 'about-chunk.js',
@@ -1230,6 +1230,51 @@ describe('root route should not include route-owned preloads', () => {
 
     // Route chunk should be filtered out from root preloads
     expect(rootPreloads).not.toContain('/assets/about-chunk.js')
+  })
+
+  test('route-owned CSS does not leak into root assets', () => {
+    const routeChunk = makeChunk({
+      fileName: 'about-chunk.js',
+      moduleIds: ['/routes/about.tsx?tsr-split=component'],
+      importedCss: ['about.css'],
+    })
+    // Entry chunk statically imports the route chunk (happens in large projects with Rolldown)
+    const entryChunk = makeChunk({
+      fileName: 'entry.js',
+      isEntry: true,
+      imports: ['about-chunk.js'],
+      importedCss: ['entry.css'],
+    })
+
+    const manifest = buildStartManifest({
+      clientBuild: normalizeViteClientBuild({
+        'entry.js': entryChunk,
+        'about-chunk.js': routeChunk,
+      }),
+      routeTreeRoutes: {
+        __root__: { children: ['/about'] } as any,
+        '/about': { filePath: '/routes/about.tsx' },
+      },
+      basePath: '/assets',
+    })
+
+    const rootAssets = manifest.routes['__root__']?.assets ?? []
+    const aboutAssets = manifest.routes['/about']?.assets ?? []
+
+    // Route CSS should be in its own route's assets
+    expect(aboutAssets).toContainEqual(
+      expect.objectContaining({ attrs: expect.objectContaining({ href: '/assets/about.css' }) }),
+    )
+
+    // Route CSS should NOT leak into root assets
+    expect(rootAssets).not.toContainEqual(
+      expect.objectContaining({ attrs: expect.objectContaining({ href: '/assets/about.css' }) }),
+    )
+
+    // Entry CSS should still be in root assets
+    expect(rootAssets).toContainEqual(
+      expect.objectContaining({ attrs: expect.objectContaining({ href: '/assets/entry.css' }) }),
+    )
   })
 })
 

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -738,10 +738,10 @@ describe('route tree dedupe in buildStartManifest', () => {
         },
       },
     ])
-    expect(manifest.routes.__root__!.preloads).toEqual([
-      '/assets/entry.js',
-      '/assets/root-shared.js',
-    ])
+    // root-shared.js is used by non-root routes, so it's considered route-owned
+    // and filtered out of root preloads. Each route still preloads it via its
+    // own entry.
+    expect(manifest.routes.__root__!.preloads).toEqual(['/assets/entry.js'])
     expect(manifest.routes['/parent']!.assets).toEqual([
       {
         tag: 'link',
@@ -754,6 +754,7 @@ describe('route tree dedupe in buildStartManifest', () => {
     ])
     expect(manifest.routes['/parent']!.preloads).toEqual([
       '/assets/parent.js',
+      '/assets/root-shared.js',
       '/assets/parent-only.js',
     ])
     expect(manifest.routes['/child']!.assets).toEqual([
@@ -782,6 +783,7 @@ describe('route tree dedupe in buildStartManifest', () => {
     ])
     expect(manifest.routes['/sibling']!.preloads).toEqual([
       '/assets/sibling.js',
+      '/assets/root-shared.js',
       '/assets/sibling-only.js',
     ])
   })
@@ -965,10 +967,10 @@ describe('route tree dedupe in buildStartManifest', () => {
         },
       },
     ])
-    expect(manifest.routes.__root__!.preloads).toEqual([
-      '/assets/entry.js',
-      '/assets/shared-root.js',
-    ])
+    // shared-root.js is used by non-root routes, so it's considered route-owned
+    // and filtered out of root preloads. Each route still preloads it via its
+    // own entry.
+    expect(manifest.routes.__root__!.preloads).toEqual(['/assets/entry.js'])
     expect(manifest.routes['/level-one']!.assets).toEqual([
       {
         tag: 'link',
@@ -981,6 +983,7 @@ describe('route tree dedupe in buildStartManifest', () => {
     ])
     expect(manifest.routes['/level-one']!.preloads).toEqual([
       '/assets/level-one.js',
+      '/assets/shared-root.js',
       '/assets/level-one-only.js',
     ])
     expect(manifest.routes['/level-two']!.assets).toEqual([
@@ -1156,7 +1159,7 @@ describe('multi-chunk routes must merge assets and preloads', () => {
   })
 })
 
-describe('root route should not include route-owned preloads or assets', () => {
+describe('root route should not include route-owned preloads', () => {
   test('entry chunk that statically imports route chunks does not leak them into root preloads', () => {
     const routeChunk = makeChunk({
       fileName: 'about-chunk.js',
@@ -1232,17 +1235,24 @@ describe('root route should not include route-owned preloads or assets', () => {
     expect(rootPreloads).not.toContain('/assets/about-chunk.js')
   })
 
-  test('route-owned CSS does not leak into root assets', () => {
+  test('transitively-reachable route-owned chunks (e.g. route data chunks) do not leak into root preloads', () => {
+    // In large projects Rolldown often splits route-transitive deps (like
+    // route data modules) into separate chunks. Those chunks end up in entry's
+    // static imports even though they're only reachable via a specific route.
+    const routeDataChunk = makeChunk({
+      fileName: 'about-data.js',
+    })
     const routeChunk = makeChunk({
       fileName: 'about-chunk.js',
+      imports: ['about-data.js'],
       moduleIds: ['/routes/about.tsx?tsr-split=component'],
-      importedCss: ['about.css'],
     })
-    // Entry chunk statically imports the route chunk (happens in large projects with Rolldown)
+    // Entry statically imports BOTH the route chunk and its data chunk
+    // (simulating Rolldown's chunk hoisting behavior in large projects).
     const entryChunk = makeChunk({
       fileName: 'entry.js',
       isEntry: true,
-      imports: ['about-chunk.js'],
+      imports: ['about-chunk.js', 'about-data.js'],
       importedCss: ['entry.css'],
     })
 
@@ -1250,6 +1260,7 @@ describe('root route should not include route-owned preloads or assets', () => {
       clientBuild: normalizeViteClientBuild({
         'entry.js': entryChunk,
         'about-chunk.js': routeChunk,
+        'about-data.js': routeDataChunk,
       }),
       routeTreeRoutes: {
         __root__: { children: ['/about'] } as any,
@@ -1258,29 +1269,16 @@ describe('root route should not include route-owned preloads or assets', () => {
       basePath: '/assets',
     })
 
-    const rootAssets = manifest.routes['__root__']?.assets ?? []
-    const aboutAssets = manifest.routes['/about']?.assets ?? []
+    const rootPreloads = manifest.routes['__root__']!.preloads!
 
-    // Route CSS should be in its own route's assets
-    expect(aboutAssets).toContainEqual(
-      expect.objectContaining({
-        attrs: expect.objectContaining({ href: '/assets/about.css' }),
-      }),
-    )
+    // The data chunk, though reachable only via /about, shows up in entry's
+    // static imports. It should be filtered out of root preloads because it's
+    // already covered by /about's preloads.
+    expect(rootPreloads).not.toContain('/assets/about-data.js')
+    expect(rootPreloads).not.toContain('/assets/about-chunk.js')
 
-    // Route CSS should NOT leak into root assets
-    expect(rootAssets).not.toContainEqual(
-      expect.objectContaining({
-        attrs: expect.objectContaining({ href: '/assets/about.css' }),
-      }),
-    )
-
-    // Entry CSS should still be in root assets
-    expect(rootAssets).toContainEqual(
-      expect.objectContaining({
-        attrs: expect.objectContaining({ href: '/assets/entry.css' }),
-      }),
-    )
+    // Entry chunk itself remains
+    expect(rootPreloads).toContain('/assets/entry.js')
   })
 })
 

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -1156,6 +1156,83 @@ describe('multi-chunk routes must merge assets and preloads', () => {
   })
 })
 
+describe('root route should not include route-owned preloads', () => {
+  test('entry chunk that statically imports route chunks does not leak them into root preloads', () => {
+    const routeChunk = makeChunk({
+      fileName: 'about-chunk.js',
+      moduleIds: ['/routes/about.tsx?tsr-split=component'],
+    })
+    // Entry chunk statically imports the route chunk (happens in large projects with Rolldown)
+    const entryChunk = makeChunk({
+      fileName: 'entry.js',
+      isEntry: true,
+      imports: ['about-chunk.js'],
+      importedCss: ['entry.css'],
+    })
+
+    const manifest = buildStartManifest({
+      clientBuild: normalizeViteClientBuild({
+        'entry.js': entryChunk,
+        'about-chunk.js': routeChunk,
+      }),
+      routeTreeRoutes: {
+        __root__: { children: ['/about'] } as any,
+        '/about': { filePath: '/routes/about.tsx' },
+      },
+      basePath: '/assets',
+    })
+
+    const rootPreloads = manifest.routes['__root__']!.preloads!
+    const aboutPreloads = manifest.routes['/about']!.preloads!
+
+    // Route chunk should be in its own route's preloads
+    expect(aboutPreloads).toContain('/assets/about-chunk.js')
+
+    // Route chunk should NOT leak into root preloads
+    expect(rootPreloads).not.toContain('/assets/about-chunk.js')
+
+    // Entry chunk itself should still be in root preloads
+    expect(rootPreloads).toContain('/assets/entry.js')
+  })
+
+  test('shared dependencies not owned by any route remain in root preloads', () => {
+    const sharedChunk = makeChunk({
+      fileName: 'shared-vendor.js',
+    })
+    const routeChunk = makeChunk({
+      fileName: 'about-chunk.js',
+      moduleIds: ['/routes/about.tsx?tsr-split=component'],
+    })
+    const entryChunk = makeChunk({
+      fileName: 'entry.js',
+      isEntry: true,
+      imports: ['shared-vendor.js', 'about-chunk.js'],
+      importedCss: ['entry.css'],
+    })
+
+    const manifest = buildStartManifest({
+      clientBuild: normalizeViteClientBuild({
+        'entry.js': entryChunk,
+        'shared-vendor.js': sharedChunk,
+        'about-chunk.js': routeChunk,
+      }),
+      routeTreeRoutes: {
+        __root__: { children: ['/about'] } as any,
+        '/about': { filePath: '/routes/about.tsx' },
+      },
+      basePath: '/assets',
+    })
+
+    const rootPreloads = manifest.routes['__root__']!.preloads!
+
+    // Shared vendor chunk should remain in root preloads (not owned by any route)
+    expect(rootPreloads).toContain('/assets/shared-vendor.js')
+
+    // Route chunk should be filtered out from root preloads
+    expect(rootPreloads).not.toContain('/assets/about-chunk.js')
+  })
+})
+
 describe('buildStartManifest route pruning', () => {
   test('routes with no assets or preloads are pruned from returned manifest', () => {
     const entryChunk = makeChunk({


### PR DESCRIPTION
## Summary

- In large projects (150+ routes, heavy provider chain in `__root__`), Rolldown hoists route chunks (and their transitive deps like route-data chunks) into the entry chunk's static `imports`. `buildRouteManifestRoutes()` then adds every one of them to the root route's `modulepreload` list, which is inherited by every page — defeating code splitting.
- This PR collects all preloads already owned by non-root routes, then filters them out of the root route's entry-chunk preloads. Because we collect from the already-built `routes[].preloads` (not `routeChunksByFilePath`), the filter covers transitively-reachable chunks (route data, shared chunks only used by routes) that Rolldown splits out separately.
- Only preloads are filtered. CSS assets are intentionally left untouched — genuinely shared CSS reached via entry's static imports needs to stay in root for SSR to avoid FOUC on pages that don't activate the sharing route. `dedupeNestedRouteManifestEntries` continues to handle CSS dedup.

## Test plan

- [x] Added test: filters route chunks + their transitive data chunks from root, while keeping shared vendors
- [x] Updated 2 existing tests where the new semantics move a shared chunk (`root-shared.js`) from root preloads to the routes that use it
- [x] All 32 manifestBuilder tests pass

## Verification

Verified on a production app (152 routes) and the minimal repro:

| Project | Without fix | With fix |
|---|---|---|
| Production app (152 routes) | 82 root preloads | 12 root preloads |
| Minimal repro (214 routes) | 156 root preloads | 2 root preloads |

Closes https://github.com/TanStack/router/issues/7197

Repro (natural trigger, no simulation plugin): https://github.com/ZacharyL2/tsr-modulepreload-repro
