### PR TITLE
docs(start): fix authenticated routes doc URL

### DIFF
--- a/docs/start/framework/react/guide/authentication-overview.md
+++ b/docs/start/framework/react/guide/authentication-overview.md
@@ -227,7 +227,7 @@ Build your own authentication system using TanStack Start's server functions and
 **Implementation Guides:**
 
 - [Authentication Patterns](./authentication.md)
-- [Router Authentication Guide](/router/latest/docs/framework/react/guide/authenticated-routes.md)
+- [Router Authentication Guide](/router/latest/docs/framework/react/guide/authenticated-routes)
 
 **Foundation Concepts:**
 


### PR DESCRIPTION
Fixes one docs link in authentication-overview.md by removing the .md suffix from the authenticated-routes URL so it resolves correctly on the TanStack docs site (no more 404)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed authentication guide documentation reference link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->