### PR TITLE
feat(nx): support rsbuild in Playwright inference

### DIFF
--- a/scripts/nx/playwright-plugin.ts
+++ b/scripts/nx/playwright-plugin.ts
@@ -96,11 +96,16 @@ const BUILD_INPUTS: TargetConfiguration['inputs'] = [
   '^production',
 ]
 
-const PLAYWRIGHT_TOOLCHAINS = ['vite'] as const
+const PLAYWRIGHT_TOOLCHAINS = ['vite', 'rsbuild'] as const
 const PLAYWRIGHT_MODES = ['ssr', 'spa', 'prerender', 'preview'] as const
 
 type PlaywrightToolchain = (typeof PLAYWRIGHT_TOOLCHAINS)[number]
 type PlaywrightMode = (typeof PLAYWRIGHT_MODES)[number]
+
+const PLAYWRIGHT_BUILD_COMMANDS: Record<PlaywrightToolchain, string> = {
+  vite: 'vite build && tsc --noEmit',
+  rsbuild: 'rsbuild build && tsc --noEmit',
+}
 
 type PlaywrightModeMetadata = {
   toolchain: PlaywrightToolchain
@@ -199,7 +204,7 @@ function buildModeTargets(
     targets[buildTargetName] = {
       executor: 'nx:run-commands',
       options: {
-        command: 'vite build && tsc --noEmit',
+        command: PLAYWRIGHT_BUILD_COMMANDS[modeMetadata.toolchain],
         cwd: projectRoot,
         env: modeEnv,
       },


### PR DESCRIPTION
## Summary
- add `rsbuild` as a supported Playwright inference toolchain in the Nx Playwright plugin
- choose the e2e build command per toolchain (`vite` or `rsbuild`) when generating inferred build targets
- keep existing Vite behavior unchanged while enabling rsbuild-mode project inference

## How to use rsbuild with Playwright inference
Add `playwrightModes` metadata to your package `package.json` and set `toolchain` to `rsbuild`:

```json
{
  "nx": {
    "metadata": {
      "playwrightModes": [
        { "toolchain": "rsbuild", "mode": "spa" },
        { "toolchain": "rsbuild", "mode": "ssr", "shards": 3 }
      ]
    }
  }
}
```

When inferred targets are generated for an `rsbuild` mode, the build step uses:

- `rsbuild build && tsc --noEmit`

Supported modes remain:

- `ssr`
- `spa`
- `prerender`
- `preview`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the Playwright testing plugin to support `rsbuild` as a build toolchain alongside `vite`. The plugin now automatically selects and executes the appropriate build command based on the configured toolchain, enabling projects to run end-to-end tests with their preferred build system without manual configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->