### PR TITLE
test(e2e-rsc): migrate to playwrightModes and dynamic inferred dist

### DIFF
--- a/e2e/react-start/rsc/.gitignore
+++ b/e2e/react-start/rsc/.gitignore
@@ -13,6 +13,8 @@ yarn.lock
 /server/build
 /public/build
 /dist/
+/dist-vite-*/
+/dist-rsbuild-*/
 /test-results/
 /playwright-report/
 /blob-report/

--- a/e2e/react-start/rsc/package.json
+++ b/e2e/react-start/rsc/package.json
@@ -8,12 +8,18 @@
     "dev:e2e": "vite dev --port $PORT",
     "build": "vite build && tsc --noEmit",
     "preview": "vite preview",
-    "start": "pnpx srvx --prod -s ../client dist/server/server.js",
+    "start": "pnpx srvx --prod -s ../client ${E2E_DIST_DIR:-dist}/server/server.js",
     "test:e2e-full": "pnpm build && sh -c 'rm -f \"port-${E2E_PORT_KEY:-$npm_package_name}.txt\" \"port-${E2E_PORT_KEY:-$npm_package_name}-external.txt\"' && playwright test --project=chromium"
   },
   "nx": {
     "metadata": {
-      "playwrightShards": 6
+      "playwrightModes": [
+        {
+          "toolchain": "vite",
+          "mode": "ssr",
+          "shards": 6
+        }
+      ]
     }
   },
   "dependencies": {

--- a/e2e/react-start/rsc/vite.config.ts
+++ b/e2e/react-start/rsc/vite.config.ts
@@ -3,8 +3,13 @@ import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
 import rsc from '@vitejs/plugin-rsc'
 
+const outDir = process.env.E2E_DIST_DIR ?? 'dist'
+
 export default defineConfig({
   resolve: { tsconfigPaths: true },
+  build: {
+    outDir,
+  },
   server: {
     port: 3000,
   },


### PR DESCRIPTION
## Summary
- migrate `e2e/react-start/rsc` from legacy `nx.metadata.playwrightShards` to `nx.metadata.playwrightModes` using `{ toolchain: \"vite\", mode: \"ssr\", shards: 6 }`
- make the RSC e2e build output dynamic via `E2E_DIST_DIR` in Vite config so inferred mode/toolchain targets build into mode-specific folders (for example `dist-vite-ssr`)
- make the RSC start command read server output from `${E2E_DIST_DIR:-dist}` and ignore inferred dist folders in `.gitignore`

## Verification
- ran `CI=1 NX_DAEMON=false pnpm nx run tanstack-react-start-e2e-rsc:test:e2e--vite-ssr--shard-1-of-6 --outputStyle=stream --skipRemoteCache`
- confirmed build artifacts are produced under `dist-vite-ssr/...` and the shard target completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to support environment-based output directory settings
  * Enhanced test infrastructure with improved Playwright testing configuration
  * Refined build artifact exclusion patterns for cleaner build environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->