### PR TITLE
fix(nx): align playwright mode build target naming

### DIFF
--- a/scripts/nx/playwright-plugin.ts
+++ b/scripts/nx/playwright-plugin.ts
@@ -187,7 +187,7 @@ function buildModeTargets(
   for (const [index, rawModeMetadata] of modes.entries()) {
     const modeMetadata = validateModeMetadata(rawModeMetadata, index)
     const modeTargetName = `${CI_TARGET_NAME}--${modeMetadata.toolchain}-${modeMetadata.mode}`
-    const buildTargetName = `build:e2e--${modeMetadata.toolchain}-${modeMetadata.mode}`
+    const buildTargetName = `build:${modeMetadata.toolchain}:${modeMetadata.mode}`
     const shardCount = modeMetadata.shards ?? 1
     const distDir = `dist-${modeMetadata.toolchain}-${modeMetadata.mode}`
     const modeEnv = {


### PR DESCRIPTION
## Summary
- rename inferred Playwright mode build targets to the `build:<toolchain>:<mode>` format
- keep mode and shard test targets depending on the renamed build target so execution flow stays unchanged
- align generated Nx target names with the expected mode-specific build naming convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated build target naming convention to improve consistency in the build process configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->