### PR TITLE
fix(start-server-core): enforce payload size limit on POST server function requests

### DIFF
--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -150,7 +150,11 @@ export const handleServerAction = async ({
 
         let jsonPayload
         if (contentType?.includes('application/json')) {
-          jsonPayload = await request.json()
+          const text = await request.text()
+          if (text.length > MAX_PAYLOAD_SIZE) {
+            throw new Error('Payload too large')
+          }
+          jsonPayload = JSON.parse(text)
         }
 
         const payload = jsonPayload ? parsePayload(jsonPayload) : {}


### PR DESCRIPTION
GET requests to server function endpoints already enforce a `MAX_PAYLOAD_SIZE` (1MB) check on the query string payload, but POST requests with `application/json` bodies go straight to `request.json()` with no size validation.

The GET path has this guard:

```ts
// Maximum payload size for GET requests (1MB)
const MAX_PAYLOAD_SIZE = 1_000_000

// ...

if (payloadParam && payloadParam.length > MAX_PAYLOAD_SIZE) {
  throw new Error('Payload too large')
}
```

But the POST path skips any size check:

```ts
let jsonPayload
if (contentType?.includes('application/json')) {
  jsonPayload = await request.json()
}
```

On self-hosted Node.js deployments without a reverse proxy (nginx, Cloudflare, etc.), there's nothing stopping an attacker from sending a multi-gigabyte POST body to any `/_serverFn` endpoint, which will get fully buffered into memory.

Managed platforms like Vercel, Cloudflare Workers, and AWS Lambda already have their own request body limits so they're not affected — but the gap between GET and POST seems like an oversight regardless.

This change reads the body as text first, checks its length against the same `MAX_PAYLOAD_SIZE` constant, then parses. Nothing fancy, just making the two paths consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added payload size validation to server functions to prevent processing of excessively large requests, improving stability and resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->