### PR TITLE
docs(start): add missing space after comma in 'Handling requests with a body'

### DIFF
--- a/docs/start/framework/react/guide/server-routes.md
+++ b/docs/start/framework/react/guide/server-routes.md
@@ -314,7 +314,7 @@ export const Route = createFileRoute('/file/$')({
 
 ## Handling requests with a body
 
-To handle POST requests,you can add a `POST` handler to the route object. The handler will receive the request object as the first argument, and you can access the request body using the `request.json()` method.
+To handle POST requests, you can add a `POST` handler to the route object. The handler will receive the request object as the first argument, and you can access the request body using the `request.json()` method.
 
 ```ts
 // routes/hello.ts

--- a/docs/start/framework/solid/guide/server-routes.md
+++ b/docs/start/framework/solid/guide/server-routes.md
@@ -314,7 +314,7 @@ export const Route = createFileRoute('/file/$')({
 
 ## Handling requests with a body
 
-To handle POST requests,you can add a `POST` handler to the route object. The handler will receive the request object as the first argument, and you can access the request body using the `request.json()` method.
+To handle POST requests, you can add a `POST` handler to the route object. The handler will receive the request object as the first argument, and you can access the request body using the `request.json()` method.
 
 ```ts
 // routes/hello.ts


### PR DESCRIPTION
## Summary

The *Handling requests with a body* section of the TanStack Start server-routes guide is missing a space after a comma:

Before:
```
To handle POST requests,you can add a \`POST\` handler to the route object.
```

After:
```
To handle POST requests, you can add a \`POST\` handler to the route object.
```

Fixed in both the React and Solid versions of the same guide, since they share the same prose:
- \`docs/start/framework/react/guide/server-routes.md\`
- \`docs/start/framework/solid/guide/server-routes.md\`

Refs TanStack/tanstack.com#838

## Testing

Docs-only change; one character per file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Fixed minor formatting issues in server-routes guide documentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->