### PR TITLE
docs: fix FileRouteLoader deprecation guidance

### DIFF
--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -183,7 +183,7 @@ export function FileRouteLoader<
 ) => TLoaderFn {
   if (process.env.NODE_ENV !== 'production') {
     console.warn(
-      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options`,
+      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options.`,
     )
   }
   return (loaderFn) => loaderFn as any

--- a/packages/solid-router/src/fileRoute.ts
+++ b/packages/solid-router/src/fileRoute.ts
@@ -146,10 +146,10 @@ export class FileRoute<
   }
 }
 
-/** 
+/**
   @deprecated It's recommended not to split loaders into separate files.
-  Instead, place the loader function in the the main route file, inside the
-  `createFileRoute('/path/to/file)(options)` options.
+  Instead, place the loader function in the main route file, inside the
+  `createFileRoute('/path/to/file')(options)` options.
 */
 export function FileRouteLoader<
   TFilePath extends keyof FileRoutesByPath,
@@ -173,7 +173,7 @@ export function FileRouteLoader<
 ) => TLoaderFn {
   if (process.env.NODE_ENV !== 'production') {
     console.warn(
-      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options`,
+      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options.`,
     )
   }
   return (loaderFn) => loaderFn as any

--- a/packages/vue-router/src/fileRoute.ts
+++ b/packages/vue-router/src/fileRoute.ts
@@ -148,8 +148,8 @@ export class FileRoute<
 
 /**
   @deprecated It's recommended not to split loaders into separate files.
-  Instead, place the loader function in the the main route file, inside the
-  `createFileRoute('/path/to/file)(options)` options.
+  Instead, place the loader function in the main route file, inside the
+  `createFileRoute('/path/to/file')(options)` options.
 */
 export function FileRouteLoader<
   TFilePath extends keyof FileRoutesByPath,
@@ -173,7 +173,7 @@ export function FileRouteLoader<
 ) => TLoaderFn {
   if (process.env.NODE_ENV !== 'production') {
     console.warn(
-      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options`,
+      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options.`,
     )
   }
   return (loaderFn) => loaderFn as any


### PR DESCRIPTION

**Repo:** TanStack/router (⭐ 10000)
**Type:** docs
**Files changed:** 3
**Lines:** +8/-8

## What
This change fixes the deprecated `FileRouteLoader` guidance in the React, Solid, and Vue router packages. It removes duplicated wording from the runtime warning text and corrects the `createFileRoute('/path/to/file')(options)` example in the Solid and Vue JSDoc blocks so all three frameworks now present the same valid usage.

## Why
The previous deprecation copy was inconsistent across packages and, in two frameworks, showed a malformed `createFileRoute` example. That makes generated API docs and runtime guidance less reliable right when users are being told how to migrate away from a deprecated API. This patch keeps the migration message accurate and consistent without changing behavior.

## Testing
Verified with `git diff --check` to ensure the patch is clean and inspected the final diff/stat output to confirm the corrected example and warning text in all three files. No package tests were run because the change only affects comments and user-facing warning strings.

## Risk
Low / text-only change to deprecation guidance with no runtime logic changes.
