### PR TITLE
fix(start-plugin-core): move rsbuild exports to dedicated `/rsbuild` subpath

### DIFF
--- a/.changeset/fix-start-plugin-core-rsbuild-subpath.md
+++ b/.changeset/fix-start-plugin-core-rsbuild-subpath.md
@@ -1,0 +1,29 @@
+---
+'@tanstack/start-plugin-core': patch
+'@tanstack/react-start': patch
+'@tanstack/solid-start': patch
+'@tanstack/vue-start': patch
+---
+
+fix(start-plugin-core): move rsbuild exports to dedicated `/rsbuild` subpath
+
+Because `./rsbuild/planning` (and transitively `./rsbuild/plugin`) statically
+imports `mergeRsbuildConfig` from `@rsbuild/core`, re-exporting them from the
+package root entry caused Vite-only consumers (who reach the root entry via
+`@tanstack/*-start/plugin/vite`) to fail at load time with
+`ERR_MODULE_NOT_FOUND: Cannot find package '@rsbuild/core'` — even though
+`@rsbuild/core` is an optional peer.
+
+The root entry is now Vite-only. All rsbuild-specific value and type exports
+(`tanStackStartRsbuild`, `RSBUILD_ENVIRONMENT_NAMES`,
+`TanStackStartRsbuildInputConfig`, `TanStackStartRsbuildPluginCoreOptions`) are
+available from the new `@tanstack/start-plugin-core/rsbuild` subpath, matching
+the existing convention used by `@tanstack/router-plugin`
+(`./vite`, `./rspack`, `./webpack`, `./esbuild`) and the pre-existing
+`@tanstack/start-plugin-core/rsbuild/types` subpath.
+
+`@tanstack/{react,solid,vue}-start/plugin/rsbuild` are updated internally to
+import from the new subpath. No changes are required for end users who consume
+these framework-specific rsbuild entries.
+
+Closes #7247

--- a/packages/react-start/src/plugin/rsbuild.ts
+++ b/packages/react-start/src/plugin/rsbuild.ts
@@ -1,10 +1,8 @@
-import {
-  START_ENVIRONMENT_NAMES,
-  tanStackStartRsbuild,
-} from '@tanstack/start-plugin-core'
+import { START_ENVIRONMENT_NAMES } from '@tanstack/start-plugin-core'
+import { tanStackStartRsbuild } from '@tanstack/start-plugin-core/rsbuild'
 import { reactStartDefaultEntryPaths } from './shared'
 import type { TanStackStartRsbuildPluginCoreOptions } from '@tanstack/start-plugin-core/rsbuild/types'
-import type { TanStackStartRsbuildInputConfig } from '@tanstack/start-plugin-core'
+import type { TanStackStartRsbuildInputConfig } from '@tanstack/start-plugin-core/rsbuild'
 import type { RsbuildPlugin } from '@rsbuild/core'
 
 export function tanstackStart(

--- a/packages/solid-start/src/plugin/rsbuild.ts
+++ b/packages/solid-start/src/plugin/rsbuild.ts
@@ -1,10 +1,8 @@
-import {
-  START_ENVIRONMENT_NAMES,
-  tanStackStartRsbuild,
-} from '@tanstack/start-plugin-core'
+import { START_ENVIRONMENT_NAMES } from '@tanstack/start-plugin-core'
+import { tanStackStartRsbuild } from '@tanstack/start-plugin-core/rsbuild'
 import { solidStartDefaultEntryPaths } from './shared'
 import type { TanStackStartRsbuildPluginCoreOptions } from '@tanstack/start-plugin-core/rsbuild/types'
-import type { TanStackStartRsbuildInputConfig } from '@tanstack/start-plugin-core'
+import type { TanStackStartRsbuildInputConfig } from '@tanstack/start-plugin-core/rsbuild'
 import type { RsbuildPlugin } from '@rsbuild/core'
 
 export function tanstackStart(

--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -56,6 +56,12 @@
         "default": "./dist/esm/utils.js"
       }
     },
+    "./rsbuild": {
+      "import": {
+        "types": "./dist/esm/rsbuild/index.d.ts",
+        "default": "./dist/esm/rsbuild/index.js"
+      }
+    },
     "./rsbuild/types": {
       "import": {
         "types": "./dist/esm/rsbuild/types.d.ts",

--- a/packages/start-plugin-core/src/index.ts
+++ b/packages/start-plugin-core/src/index.ts
@@ -8,8 +8,3 @@ export type { TanStackStartViteInputConfig } from './vite/schema'
 export { START_ENVIRONMENT_NAMES, VITE_ENVIRONMENT_NAMES } from './constants'
 export { createVirtualModule } from './vite/createVirtualModule'
 export { tanStackStartVite } from './vite/plugin'
-
-export { RSBUILD_ENVIRONMENT_NAMES } from './rsbuild/planning'
-export type { TanStackStartRsbuildPluginCoreOptions } from './rsbuild/types'
-export type { TanStackStartRsbuildInputConfig } from './rsbuild/schema'
-export { tanStackStartRsbuild } from './rsbuild/plugin'

--- a/packages/start-plugin-core/src/rsbuild/index.ts
+++ b/packages/start-plugin-core/src/rsbuild/index.ts
@@ -1,0 +1,4 @@
+export { RSBUILD_ENVIRONMENT_NAMES } from './planning'
+export type { TanStackStartRsbuildPluginCoreOptions } from './types'
+export type { TanStackStartRsbuildInputConfig } from './schema'
+export { tanStackStartRsbuild } from './plugin'

--- a/packages/start-plugin-core/vite.config.ts
+++ b/packages/start-plugin-core/vite.config.ts
@@ -15,7 +15,12 @@ export default mergeConfig(
   config,
   tanstackViteConfig({
     tsconfigPath: './tsconfig.build.json',
-    entry: ['./src/index.ts', './src/utils.ts', './src/rsbuild/types.ts'],
+    entry: [
+      './src/index.ts',
+      './src/utils.ts',
+      './src/rsbuild/index.ts',
+      './src/rsbuild/types.ts',
+    ],
     srcDir: './src',
     outDir: './dist',
     cjs: false,

--- a/packages/vue-start/src/plugin/rsbuild.ts
+++ b/packages/vue-start/src/plugin/rsbuild.ts
@@ -1,10 +1,8 @@
-import {
-  START_ENVIRONMENT_NAMES,
-  tanStackStartRsbuild,
-} from '@tanstack/start-plugin-core'
+import { START_ENVIRONMENT_NAMES } from '@tanstack/start-plugin-core'
+import { tanStackStartRsbuild } from '@tanstack/start-plugin-core/rsbuild'
 import { vueStartDefaultEntryPaths } from './shared'
 import type { TanStackStartRsbuildPluginCoreOptions } from '@tanstack/start-plugin-core/rsbuild/types'
-import type { TanStackStartRsbuildInputConfig } from '@tanstack/start-plugin-core'
+import type { TanStackStartRsbuildInputConfig } from '@tanstack/start-plugin-core/rsbuild'
 import type { RsbuildPlugin } from '@rsbuild/core'
 
 export function tanstackStart(


### PR DESCRIPTION
## Summary

`@tanstack/start-plugin-core@1.168.0` re-exports `tanStackStartRsbuild` and `RSBUILD_ENVIRONMENT_NAMES` from the package root. Their transitive dependency chain reaches `./rsbuild/planning.ts`, which statically imports `mergeRsbuildConfig` from `@rsbuild/core`:

```ts
// src/rsbuild/planning.ts
import { mergeRsbuildConfig } from '@rsbuild/core'
```

Vite-only consumers end up in this graph through `@tanstack/*-start/plugin/vite` and crash at config load:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@rsbuild/core'
  imported from .../@tanstack/start-plugin-core/dist/esm/rsbuild/planning.js
```

`@rsbuild/core` is declared as an optional peer, so this is unexpected.

## Fix

Move the rsbuild exports out of the root entry into a dedicated `./rsbuild` subpath, matching the existing convention used by `@tanstack/router-plugin` (`./vite`, `./rspack`, `./webpack`, `./esbuild`) and the pre-existing `@tanstack/start-plugin-core/rsbuild/types` subpath.

- New file `packages/start-plugin-core/src/rsbuild/index.ts` re-exports `tanStackStartRsbuild`, `RSBUILD_ENVIRONMENT_NAMES`, `TanStackStartRsbuildInputConfig`, `TanStackStartRsbuildPluginCoreOptions`
- `packages/start-plugin-core/package.json` adds the `./rsbuild` export next to `./rsbuild/types`
- `packages/start-plugin-core/src/index.ts` is now Vite-only
- `packages/{react,solid,vue}-start/src/plugin/rsbuild.ts` import from the new subpath

After the change, `dist/esm/index.js` no longer has `@rsbuild/core` in its module graph. The only `@rsbuild/core` reference remaining in the built artefacts is inside `dist/esm/rsbuild/planning.js`, which is only reachable if you explicitly import from `@tanstack/start-plugin-core/rsbuild` (where `@rsbuild/core` is installed by definition).

End users who consume `@tanstack/{react,solid,vue}-start/plugin/rsbuild` need no changes.

## Testing

- `pnpm nx run @tanstack/start-plugin-core:test:eslint|test:types|test:unit|test:build` — pass
- `pnpm nx run-many --target=test:types,test:build --projects=@tanstack/react-start,@tanstack/solid-start,@tanstack/vue-start` — pass
- `pnpm nx run tanstack-start-example-basic:build` — vite example builds without `@rsbuild/core`
- `pnpm nx run tanstack-react-start-e2e-custom-server-rsbuild:build` — rsbuild path still works

Closes #7247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved module-resolution failures for Vite-only consumers by reorganizing framework-specific rsbuild exports into a dedicated subpath, preventing unnecessary optional peer dependency errors.

* **New Features**
  * Added new `@tanstack/start-plugin-core/rsbuild` subpath export for more granular rsbuild configuration imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->