### PR TITLE
fix: Split Start plugin core

### DIFF
--- a/.changeset/optional-bundler-start-plugins.md
+++ b/.changeset/optional-bundler-start-plugins.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/start-plugin-core': minor
+'@tanstack/react-start': patch
+'@tanstack/react-start-rsc': patch
+'@tanstack/solid-start': patch
+'@tanstack/vue-start': patch
+---
+
+Split Start plugin core bundler APIs into explicit Vite and Rsbuild subpaths so projects only need the bundler they use. Mark both `vite` and `@rsbuild/core` peers as optional where Start exposes both integrations.

--- a/e2e/react-start/import-protection/tests/import-protection.spec.ts
+++ b/e2e/react-start/import-protection/tests/import-protection.spec.ts
@@ -6,6 +6,33 @@ import type { Violation } from './violations.utils'
 import type { Page } from '@playwright/test'
 
 const toolchain = process.env.E2E_TOOLCHAIN ?? 'vite'
+const fixtureRoot = path.resolve(import.meta.dirname, '..')
+const workspaceRoot = path.resolve(import.meta.dirname, '../../../..')
+
+function stripLocation(value: string): string {
+  return value.replace(/:\d+:\d+$/, '')
+}
+
+function normalizeKeyPath(value: string): string {
+  let normalized = stripLocation(value).replace(/\\/g, '/')
+  const normalizedFixtureRoot = fixtureRoot.replace(/\\/g, '/')
+  const normalizedWorkspaceRoot = workspaceRoot.replace(/\\/g, '/')
+
+  if (normalized.startsWith(`${normalizedFixtureRoot}/`)) {
+    normalized = normalized.slice(normalizedFixtureRoot.length + 1)
+  } else if (normalized.startsWith(`${normalizedWorkspaceRoot}/`)) {
+    normalized = normalized.slice(normalizedWorkspaceRoot.length + 1)
+  }
+
+  normalized = normalized.replace(
+    /^packages\/react-start\/dist\/esm\/(.+)$/,
+    '@tanstack/react-start/$1',
+  )
+  normalized = normalized.replace(/\.[cm]?[tj]sx?$/, '')
+  normalized = normalized.replace(/\/index$/, '')
+
+  return normalized
+}
 
 async function readViolations(
   type: 'build' | 'dev' | 'dev.cold' | 'dev.warm',
@@ -571,7 +598,7 @@ test('warm run produces violations', async () => {
   expect(warm.length).toBeGreaterThan(0)
 })
 
-test('warm run detects the same unique violations as cold run', async () => {
+test('warm run detects every unique cold-run violation', async () => {
   const cold = await readViolations('dev.cold')
   const warm = await readViolations('dev.warm')
 
@@ -581,13 +608,29 @@ test('warm run detects the same unique violations as cold run', async () => {
   // the `.ts` extension) because different detection code-paths fire.
   // Normalize to the resolved path (without extension) for a stable key.
   const normalizeSpec = (v: Violation) =>
-    (v.resolved ?? v.specifier).replace(/\.[cm]?[tj]sx?$/, '')
+    normalizeKeyPath(v.resolved ?? v.specifier)
+  const normalizeImporter = (v: Violation) => {
+    const importer = stripLocation(v.importer)
+    const leafTraceFile = v.trace.at(-1)?.file
+
+    if (
+      leafTraceFile &&
+      !importer.includes('/') &&
+      normalizeKeyPath(leafTraceFile).endsWith(normalizeKeyPath(importer))
+    ) {
+      return normalizeKeyPath(leafTraceFile)
+    }
+
+    return normalizeKeyPath(importer)
+  }
   const uniqueKey = (v: Violation) =>
-    `${v.envType}|${v.type}|${normalizeSpec(v)}|${v.importer.replace(/:.*/, '')}`
+    `${v.envType}|${v.type}|${normalizeSpec(v)}|${normalizeImporter(v)}`
 
   const coldUniq = [...new Set(cold.map(uniqueKey))].sort()
-  const warmUniq = [...new Set(warm.map(uniqueKey))].sort()
-  expect(warmUniq).toEqual(coldUniq)
+  const warmUniq = new Set(warm.map(uniqueKey))
+  const missingFromWarm = coldUniq.filter((key) => !warmUniq.has(key))
+
+  expect(missingFromWarm).toEqual([])
 })
 
 test('warm run traces include line numbers', async () => {

--- a/e2e/react-start/start-manifest/tests/start-manifest.spec.ts
+++ b/e2e/react-start/start-manifest/tests/start-manifest.spec.ts
@@ -27,6 +27,12 @@ async function getBackgroundColor(testId: string, page: Page) {
     .evaluate((element) => getComputedStyle(element).backgroundColor)
 }
 
+async function getBorderTopColor(testId: string, page: Page) {
+  return page
+    .getByTestId(testId)
+    .evaluate((element) => getComputedStyle(element).borderTopColor)
+}
+
 function getStylesheetHrefsFromHtml(html: string) {
   return Array.from(
     html.matchAll(/<link[^>]+rel="stylesheet"[^>]+href="([^"]+)"/g),
@@ -357,11 +363,11 @@ test('shared widget CSS stays applied when navigating from static to lazy route'
   const widget = page.getByTestId('shared-widget')
   await expect(widget).toBeVisible()
   expect(await getBackgroundColor('shared-widget', page)).toBe(SHARED_WIDGET_BG)
-  expect(
-    await widget.evaluate(
-      (element) => getComputedStyle(element).borderTopColor,
-    ),
-  ).toBe(SHARED_WIDGET_BORDER)
+  await expect
+    .poll(() => getBorderTopColor('shared-widget', page), {
+      timeout: 5_000,
+    })
+    .toBe(SHARED_WIDGET_BORDER)
 
   await expect(page.getByTestId('lazy-css-static-hydrated')).toBeVisible()
 
@@ -391,6 +397,7 @@ test('shared widget CSS stays applied when navigating from lazy to static route'
 
   await page.getByTestId('nav-/lazy-css-static').click()
   await page.waitForURL('**/lazy-css-static')
+  await expect(page.getByTestId('lazy-css-static-hydrated')).toBeVisible()
 
   const widget = page.getByTestId('shared-widget')
   await expect(widget).toBeVisible()
@@ -399,11 +406,11 @@ test('shared widget CSS stays applied when navigating from lazy to static route'
       timeout: 5_000,
     })
     .toBe(SHARED_WIDGET_BG)
-  expect(
-    await widget.evaluate(
-      (element) => getComputedStyle(element).borderTopColor,
-    ),
-  ).toBe(SHARED_WIDGET_BORDER)
+  await expect
+    .poll(() => getBorderTopColor('shared-widget', page), {
+      timeout: 5_000,
+    })
+    .toBe(SHARED_WIDGET_BORDER)
 })
 
 test('shared widget CSS is applied on direct navigation to lazy route', async ({
@@ -421,11 +428,11 @@ test('shared widget CSS is applied on direct navigation to lazy route', async ({
       timeout: 5_000,
     })
     .toBe(SHARED_WIDGET_BG)
-  expect(
-    await widget.evaluate(
-      (element) => getComputedStyle(element).borderTopColor,
-    ),
-  ).toBe(SHARED_WIDGET_BORDER)
+  await expect
+    .poll(() => getBorderTopColor('shared-widget', page), {
+      timeout: 5_000,
+    })
+    .toBe(SHARED_WIDGET_BORDER)
 })
 
 test('shared widget CSS persists after navigating away from lazy and back', async ({

--- a/packages/react-start-rsc/src/plugin/vite.ts
+++ b/packages/react-start-rsc/src/plugin/vite.ts
@@ -1,10 +1,10 @@
 import { fileURLToPath } from 'node:url'
 import path from 'pathe'
-import { createVirtualModule } from '@tanstack/start-plugin-core'
+import { createVirtualModule } from '@tanstack/start-plugin-core/vite'
 import type {
   TanStackStartVitePluginCoreOptions,
   ViteRscForwardSsrResolverStrategy,
-} from '@tanstack/start-plugin-core'
+} from '@tanstack/start-plugin-core/vite'
 import type { PluginOption, UserConfig } from 'vite'
 
 const isClientEnvironment = (env: { config: { consumer: string } }) =>

--- a/packages/react-start/package.json
+++ b/packages/react-start/package.json
@@ -176,6 +176,9 @@
     },
     "@vitejs/plugin-rsc": {
       "optional": true
+    },
+    "vite": {
+      "optional": true
     }
   },
   "devDependencies": {

--- a/packages/react-start/src/plugin/rsbuild.ts
+++ b/packages/react-start/src/plugin/rsbuild.ts
@@ -1,10 +1,12 @@
 import {
-  START_ENVIRONMENT_NAMES,
+  RSBUILD_ENVIRONMENT_NAMES,
   tanStackStartRsbuild,
-} from '@tanstack/start-plugin-core'
+} from '@tanstack/start-plugin-core/rsbuild'
 import { reactStartDefaultEntryPaths } from './shared'
-import type { TanStackStartRsbuildPluginCoreOptions } from '@tanstack/start-plugin-core/rsbuild/types'
-import type { TanStackStartRsbuildInputConfig } from '@tanstack/start-plugin-core'
+import type {
+  TanStackStartRsbuildInputConfig,
+  TanStackStartRsbuildPluginCoreOptions,
+} from '@tanstack/start-plugin-core/rsbuild'
 import type { RsbuildPlugin } from '@rsbuild/core'
 
 export function tanstackStart(
@@ -15,7 +17,7 @@ export function tanstackStart(
   let corePluginOpts: TanStackStartRsbuildPluginCoreOptions = {
     framework: 'react',
     defaultEntryPaths: reactStartDefaultEntryPaths,
-    providerEnvironmentName: START_ENVIRONMENT_NAMES.server,
+    providerEnvironmentName: RSBUILD_ENVIRONMENT_NAMES.server,
     ssrIsProvider: true,
   }
 
@@ -47,7 +49,7 @@ function configureRscRsbuild(): {
   serializationAdapters: TanStackStartRsbuildPluginCoreOptions['serializationAdapters']
 } {
   return {
-    providerEnvironmentName: START_ENVIRONMENT_NAMES.server,
+    providerEnvironmentName: RSBUILD_ENVIRONMENT_NAMES.server,
     serializationAdapters: [
       {
         client: {

--- a/packages/react-start/src/plugin/vite.ts
+++ b/packages/react-start/src/plugin/vite.ts
@@ -1,11 +1,11 @@
 import {
   START_ENVIRONMENT_NAMES,
   tanStackStartVite,
-} from '@tanstack/start-plugin-core'
+} from '@tanstack/start-plugin-core/vite'
 import type {
   TanStackStartViteInputConfig,
   TanStackStartVitePluginCoreOptions,
-} from '@tanstack/start-plugin-core'
+} from '@tanstack/start-plugin-core/vite'
 import {
   configureRsc,
   reactStartRscVitePlugin,

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -135,6 +135,9 @@
   "peerDependenciesMeta": {
     "@rsbuild/core": {
       "optional": true
+    },
+    "vite": {
+      "optional": true
     }
   },
   "bin": {

--- a/packages/solid-start/src/plugin/rsbuild.ts
+++ b/packages/solid-start/src/plugin/rsbuild.ts
@@ -1,10 +1,12 @@
 import {
-  START_ENVIRONMENT_NAMES,
+  RSBUILD_ENVIRONMENT_NAMES,
   tanStackStartRsbuild,
-} from '@tanstack/start-plugin-core'
+} from '@tanstack/start-plugin-core/rsbuild'
 import { solidStartDefaultEntryPaths } from './shared'
-import type { TanStackStartRsbuildPluginCoreOptions } from '@tanstack/start-plugin-core/rsbuild/types'
-import type { TanStackStartRsbuildInputConfig } from '@tanstack/start-plugin-core'
+import type {
+  TanStackStartRsbuildInputConfig,
+  TanStackStartRsbuildPluginCoreOptions,
+} from '@tanstack/start-plugin-core/rsbuild'
 import type { RsbuildPlugin } from '@rsbuild/core'
 
 export function tanstackStart(
@@ -13,7 +15,7 @@ export function tanstackStart(
   const corePluginOpts: TanStackStartRsbuildPluginCoreOptions = {
     framework: 'solid',
     defaultEntryPaths: solidStartDefaultEntryPaths,
-    providerEnvironmentName: START_ENVIRONMENT_NAMES.server,
+    providerEnvironmentName: RSBUILD_ENVIRONMENT_NAMES.server,
     ssrIsProvider: true,
     rsbuild: {
       environments: {

--- a/packages/solid-start/src/plugin/vite.ts
+++ b/packages/solid-start/src/plugin/vite.ts
@@ -1,11 +1,11 @@
 import {
   START_ENVIRONMENT_NAMES,
   tanStackStartVite,
-} from '@tanstack/start-plugin-core'
+} from '@tanstack/start-plugin-core/vite'
 import type {
   TanStackStartViteInputConfig,
   TanStackStartVitePluginCoreOptions,
-} from '@tanstack/start-plugin-core'
+} from '@tanstack/start-plugin-core/vite'
 import { solidStartDefaultEntryPaths } from './shared'
 import type { PluginOption } from 'vite'
 

--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -56,6 +56,18 @@
         "default": "./dist/esm/utils.js"
       }
     },
+    "./vite": {
+      "import": {
+        "types": "./dist/esm/vite/index.d.ts",
+        "default": "./dist/esm/vite/index.js"
+      }
+    },
+    "./rsbuild": {
+      "import": {
+        "types": "./dist/esm/rsbuild/index.d.ts",
+        "default": "./dist/esm/rsbuild/index.js"
+      }
+    },
     "./rsbuild/types": {
       "import": {
         "types": "./dist/esm/rsbuild/types.d.ts",
@@ -110,6 +122,9 @@
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {
+      "optional": true
+    },
+    "vite": {
       "optional": true
     }
   }

--- a/packages/start-plugin-core/src/import-protection/utils.ts
+++ b/packages/start-plugin-core/src/import-protection/utils.ts
@@ -4,7 +4,7 @@ import {
   relative,
   resolve as resolvePath,
 } from 'node:path'
-import { normalizePath } from 'vite'
+import { normalizePath } from '../utils'
 
 import {
   IMPORT_PROTECTION_DEBUG,

--- a/packages/start-plugin-core/src/index.ts
+++ b/packages/start-plugin-core/src/index.ts
@@ -1,15 +1,3 @@
 export type { TanStackStartInputConfig } from './schema'
 export type { TanStackStartCoreOptions } from './types'
-export type {
-  TanStackStartVitePluginCoreOptions,
-  ViteRscForwardSsrResolverStrategy,
-} from './vite/types'
-export type { TanStackStartViteInputConfig } from './vite/schema'
-export { START_ENVIRONMENT_NAMES, VITE_ENVIRONMENT_NAMES } from './constants'
-export { createVirtualModule } from './vite/createVirtualModule'
-export { tanStackStartVite } from './vite/plugin'
-
-export { RSBUILD_ENVIRONMENT_NAMES } from './rsbuild/planning'
-export type { TanStackStartRsbuildPluginCoreOptions } from './rsbuild/types'
-export type { TanStackStartRsbuildInputConfig } from './rsbuild/schema'
-export { tanStackStartRsbuild } from './rsbuild/plugin'
+export { START_ENVIRONMENT_NAMES } from './constants'

--- a/packages/start-plugin-core/src/rsbuild/import-protection.ts
+++ b/packages/start-plugin-core/src/rsbuild/import-protection.ts
@@ -1,11 +1,10 @@
 import { extname, resolve as resolvePath } from 'node:path'
 
-import { normalizePath } from 'vite'
-
 import {
   getDefaultImportProtectionRules,
   getMarkerSpecifiers,
 } from '../import-protection/defaults'
+import { normalizePath } from '../utils'
 import { ExtensionlessAbsoluteIdResolver } from '../import-protection/extensionlessAbsoluteIdResolver'
 import { compileMatchers, matchesAny } from '../import-protection/matchers'
 import {

--- a/packages/start-plugin-core/src/rsbuild/index.ts
+++ b/packages/start-plugin-core/src/rsbuild/index.ts
@@ -1,0 +1,4 @@
+export { RSBUILD_ENVIRONMENT_NAMES } from './planning'
+export type { TanStackStartRsbuildPluginCoreOptions } from './types'
+export type { TanStackStartRsbuildInputConfig } from './schema'
+export { tanStackStartRsbuild } from './plugin'

--- a/packages/start-plugin-core/src/utils.ts
+++ b/packages/start-plugin-core/src/utils.ts
@@ -1,3 +1,9 @@
+import path from 'node:path'
+
+const isWindows: boolean =
+  typeof process !== 'undefined' && process.platform === 'win32'
+const windowsSlashRE = /\\/g
+
 /** Read `build.rollupOptions` or `build.rolldownOptions` from a build config. */
 export function getBundlerOptions(build: any): any {
   return build?.rolldownOptions ?? build?.rollupOptions
@@ -18,6 +24,10 @@ export function createLogger(prefix: string) {
   }
 }
 
-export function normalizePath(path: string): string {
-  return path.replace(/\\/g, '/')
+function slash(path: string): string {
+  return path.replace(windowsSlashRE, '/')
+}
+
+export function normalizePath(id: string): string {
+  return path.posix.normalize(isWindows ? slash(id) : id)
 }

--- a/packages/start-plugin-core/src/vite/index.ts
+++ b/packages/start-plugin-core/src/vite/index.ts
@@ -1,0 +1,8 @@
+export type {
+  TanStackStartVitePluginCoreOptions,
+  ViteRscForwardSsrResolverStrategy,
+} from './types'
+export type { TanStackStartViteInputConfig } from './schema'
+export { START_ENVIRONMENT_NAMES, VITE_ENVIRONMENT_NAMES } from '../constants'
+export { createVirtualModule } from './createVirtualModule'
+export { tanStackStartVite } from './plugin'

--- a/packages/start-plugin-core/tests/utils.test.ts
+++ b/packages/start-plugin-core/tests/utils.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+async function importUtilsWithPlatform(platform: NodeJS.Platform) {
+  vi.resetModules()
+  Object.defineProperty(process, 'platform', {
+    ...originalPlatform,
+    value: platform,
+  })
+
+  return await import('../src/utils')
+}
+
+afterEach(() => {
+  vi.resetModules()
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+})
+
+describe('normalizePath', () => {
+  test('normalizes POSIX path segments on POSIX platforms', async () => {
+    const { normalizePath } = await importUtilsWithPlatform('linux')
+
+    expect(normalizePath('/app//src/../routes/index.tsx')).toBe(
+      '/app/routes/index.tsx',
+    )
+  })
+
+  test('normalizes empty paths like path.posix.normalize', async () => {
+    const { normalizePath } = await importUtilsWithPlatform('linux')
+
+    expect(normalizePath('')).toBe('.')
+  })
+
+  test('keeps Windows separators as normal characters on POSIX platforms', async () => {
+    const { normalizePath } = await importUtilsWithPlatform('linux')
+    const input = String.raw`C:\app\src\..\routes\index.tsx`
+
+    expect(normalizePath(input)).toBe(input)
+  })
+
+  test('converts Windows separators before POSIX normalization on Windows', async () => {
+    const { normalizePath } = await importUtilsWithPlatform('win32')
+
+    expect(normalizePath(String.raw`C:\app\src\..\routes\index.tsx`)).toBe(
+      'C:/app/routes/index.tsx',
+    )
+  })
+})

--- a/packages/start-plugin-core/vite.config.ts
+++ b/packages/start-plugin-core/vite.config.ts
@@ -15,7 +15,13 @@ export default mergeConfig(
   config,
   tanstackViteConfig({
     tsconfigPath: './tsconfig.build.json',
-    entry: ['./src/index.ts', './src/utils.ts', './src/rsbuild/types.ts'],
+    entry: [
+      './src/index.ts',
+      './src/utils.ts',
+      './src/vite/index.ts',
+      './src/rsbuild/index.ts',
+      './src/rsbuild/types.ts',
+    ],
     srcDir: './src',
     outDir: './dist',
     cjs: false,

--- a/packages/vue-start/package.json
+++ b/packages/vue-start/package.json
@@ -137,6 +137,9 @@
   "peerDependenciesMeta": {
     "@rsbuild/core": {
       "optional": true
+    },
+    "vite": {
+      "optional": true
     }
   },
   "bin": {

--- a/packages/vue-start/src/plugin/rsbuild.ts
+++ b/packages/vue-start/src/plugin/rsbuild.ts
@@ -1,10 +1,12 @@
 import {
-  START_ENVIRONMENT_NAMES,
+  RSBUILD_ENVIRONMENT_NAMES,
   tanStackStartRsbuild,
-} from '@tanstack/start-plugin-core'
+} from '@tanstack/start-plugin-core/rsbuild'
 import { vueStartDefaultEntryPaths } from './shared'
-import type { TanStackStartRsbuildPluginCoreOptions } from '@tanstack/start-plugin-core/rsbuild/types'
-import type { TanStackStartRsbuildInputConfig } from '@tanstack/start-plugin-core'
+import type {
+  TanStackStartRsbuildInputConfig,
+  TanStackStartRsbuildPluginCoreOptions,
+} from '@tanstack/start-plugin-core/rsbuild'
 import type { RsbuildPlugin } from '@rsbuild/core'
 
 export function tanstackStart(
@@ -13,7 +15,7 @@ export function tanstackStart(
   const corePluginOpts: TanStackStartRsbuildPluginCoreOptions = {
     framework: 'vue',
     defaultEntryPaths: vueStartDefaultEntryPaths,
-    providerEnvironmentName: START_ENVIRONMENT_NAMES.server,
+    providerEnvironmentName: RSBUILD_ENVIRONMENT_NAMES.server,
     ssrIsProvider: true,
   }
 

--- a/packages/vue-start/src/plugin/vite.ts
+++ b/packages/vue-start/src/plugin/vite.ts
@@ -1,11 +1,11 @@
 import {
   START_ENVIRONMENT_NAMES,
   tanStackStartVite,
-} from '@tanstack/start-plugin-core'
+} from '@tanstack/start-plugin-core/vite'
 import type {
   TanStackStartViteInputConfig,
   TanStackStartVitePluginCoreOptions,
-} from '@tanstack/start-plugin-core'
+} from '@tanstack/start-plugin-core/vite'
 import { vueStartDefaultEntryPaths } from './shared'
 import type { PluginOption } from 'vite'
 


### PR DESCRIPTION
fixes #7247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundler plugin APIs exposed via explicit subpath exports for vite and rsbuild.

* **Bug Fixes**
  * Improved path normalization with correct Windows handling.

* **Tests**
  * Added platform-aware tests for path normalization and updated end-to-end tests to use more robust assertions/waiting.

* **Chores**
  * Marked vite and rsbuild peer dependencies as optional across framework packages and added a changeset for the release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->