### PR TITLE
fix: server middleware type in solid-router

### DIFF
--- a/.changeset/curvy-chairs-study.md
+++ b/.changeset/curvy-chairs-study.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-router': patch
+---
+
+fix server middleware type in solid-router

--- a/packages/solid-router/src/fileRoute.ts
+++ b/packages/solid-router/src/fileRoute.ts
@@ -81,7 +81,7 @@ export class FileRoute<
     TLoaderFn = undefined,
     TChildren = unknown,
     TSSR = unknown,
-    TMiddlewares = unknown,
+    const TMiddlewares = unknown,
     THandlers = undefined,
   >(
     options?: FileBaseRouteOptions<

--- a/packages/solid-router/tests/fileRoute.test-d.tsx
+++ b/packages/solid-router/tests/fileRoute.test-d.tsx
@@ -104,9 +104,11 @@ test('when creating a folder group', () => {
 })
 
 test('when creating a file route with server middleware', () => {
-  const middleware = createMiddleware({ type: 'request' }).server(({ next }) => {
-    return next({ context: { supportsGzip: true } })
-  })
+  const middleware = createMiddleware({ type: 'request' }).server(
+    ({ next }) => {
+      return next({ context: { supportsGzip: true } })
+    },
+  )
 
   createFileRoute('/invoices')({
     server: {

--- a/packages/solid-router/tests/fileRoute.test-d.tsx
+++ b/packages/solid-router/tests/fileRoute.test-d.tsx
@@ -149,18 +149,9 @@ test('when creating a folder group', () => {
   expectTypeOf<'/protected'>(protectedRoute.id)
 })
 
-<<<<<<< Updated upstream
-test('when creating a file route with server middleware', () => {
-  const middleware = createMiddleware({ type: 'request' }).server(
-    ({ next }) => {
-      return next({ context: { supportsGzip: true } })
-    },
-  )
-=======
 test('when creating a file route with middleware options', () => {
   type Middleware = { readonly middleware: 'middleware' }
   const middleware = { middleware: 'middleware' } as const
->>>>>>> Stashed changes
 
   const route = createFileRoute('/invoices')({
     server: {

--- a/packages/solid-router/tests/fileRoute.test-d.tsx
+++ b/packages/solid-router/tests/fileRoute.test-d.tsx
@@ -1,7 +1,53 @@
 import { expectTypeOf, test } from 'vitest'
-import '../../start-client-core/src/serverRoute'
 import { createFileRoute, createRootRoute } from '../src'
-import { createMiddleware } from '../../start-client-core/src/createMiddleware'
+import type { Route } from '@tanstack/router-core'
+
+declare module '@tanstack/router-core' {
+  interface FilebaseRouteOptionsInterface<
+    TRegister,
+    TParentRoute,
+    TId,
+    TPath,
+    TSearchValidator,
+    TParams,
+    TLoaderDeps,
+    TLoaderFn,
+    TRouterContext,
+    TRouteContextFn,
+    TBeforeLoadFn,
+    TRemountDepsFn,
+    TSSR,
+    TServerMiddlewares,
+    THandlers,
+  > {
+    server?: {
+      middleware?: TServerMiddlewares
+    }
+  }
+
+  interface RouteTypes<
+    TRegister,
+    TParentRoute,
+    TPath,
+    TFullPath,
+    TCustomId,
+    TId,
+    TSearchValidator,
+    TParams,
+    TRouterContext,
+    TRouteContextFn,
+    TBeforeLoadFn,
+    TLoaderDeps,
+    TLoaderFn,
+    TChildren,
+    TFileRouteTypes,
+    TSSR,
+    TServerMiddlewares,
+    THandlers,
+  > {
+    middleware: TServerMiddlewares
+  }
+}
 
 const rootRoute = createRootRoute()
 
@@ -103,23 +149,49 @@ test('when creating a folder group', () => {
   expectTypeOf<'/protected'>(protectedRoute.id)
 })
 
+<<<<<<< Updated upstream
 test('when creating a file route with server middleware', () => {
   const middleware = createMiddleware({ type: 'request' }).server(
     ({ next }) => {
       return next({ context: { supportsGzip: true } })
     },
   )
+=======
+test('when creating a file route with middleware options', () => {
+  type Middleware = { readonly middleware: 'middleware' }
+  const middleware = { middleware: 'middleware' } as const
+>>>>>>> Stashed changes
 
-  createFileRoute('/invoices')({
+  const route = createFileRoute('/invoices')({
     server: {
       middleware: [middleware],
-      handlers: {
-        GET: ({ context }) => {
-          expectTypeOf(context).toEqualTypeOf<{ supportsGzip: boolean }>()
-
-          return Response.json(context)
-        },
-      },
     },
   })
+
+  type ExtractMiddlewares<TRoute> = TRoute extends Route<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    infer TMiddlewares,
+    any
+  >
+    ? TMiddlewares
+    : never
+
+  expectTypeOf<ExtractMiddlewares<typeof route>>().toEqualTypeOf<
+    readonly [Middleware]
+  >()
 })

--- a/packages/solid-router/tests/fileRoute.test-d.tsx
+++ b/packages/solid-router/tests/fileRoute.test-d.tsx
@@ -159,28 +159,29 @@ test('when creating a file route with middleware options', () => {
     },
   })
 
-  type ExtractMiddlewares<TRoute> = TRoute extends Route<
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    infer TMiddlewares,
-    any
-  >
-    ? TMiddlewares
-    : never
+  type ExtractMiddlewares<TRoute> =
+    TRoute extends Route<
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      infer TMiddlewares,
+      any
+    >
+      ? TMiddlewares
+      : never
 
   expectTypeOf<ExtractMiddlewares<typeof route>>().toEqualTypeOf<
     readonly [Middleware]

--- a/packages/solid-router/tests/fileRoute.test-d.tsx
+++ b/packages/solid-router/tests/fileRoute.test-d.tsx
@@ -1,5 +1,7 @@
 import { expectTypeOf, test } from 'vitest'
+import '../../start-client-core/src/serverRoute'
 import { createFileRoute, createRootRoute } from '../src'
+import { createMiddleware } from '../../start-client-core/src/createMiddleware'
 
 const rootRoute = createRootRoute()
 
@@ -99,4 +101,23 @@ test('when creating a folder group', () => {
   expectTypeOf<'/protected'>(protectedRoute.fullPath)
   expectTypeOf<'(auth)/protected'>(protectedRoute.path)
   expectTypeOf<'/protected'>(protectedRoute.id)
+})
+
+test('when creating a file route with server middleware', () => {
+  const middleware = createMiddleware({ type: 'request' }).server(({ next }) => {
+    return next({ context: { supportsGzip: true } })
+  })
+
+  createFileRoute('/invoices')({
+    server: {
+      middleware: [middleware],
+      handlers: {
+        GET: ({ context }) => {
+          expectTypeOf(context).toEqualTypeOf<{ supportsGzip: boolean }>()
+
+          return Response.json(context)
+        },
+      },
+    },
+  })
 })


### PR DESCRIPTION
Closes #7092 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server middleware type handling for file-based routes so middleware configuration is recognized and inferred correctly.

* **Tests**
  * Added type-level tests to validate middleware configuration and inference for file routes.

* **Chores**
  * Added changeset metadata to document the fix and mark a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->