### PR TITLE
docs: Fix server function middleware prop

### DIFF
--- a/docs/start/framework/react/guide/middleware.md
+++ b/docs/start/framework/react/guide/middleware.md
@@ -225,7 +225,7 @@ The `.client` method is used to define client-side logic that the middleware wil
 import { createMiddleware } from '@tanstack/react-start'
 
 const loggingMiddleware = createMiddleware({ type: 'function' }).client(
-  async ({ next, context, request }) => {
+  async ({ next, context }) => {
     const result = await next() // <-- This will execute the next middleware in the chain and eventually, the RPC to the server
     return result
   },


### PR DESCRIPTION
Server function middleware's `.client()` and `.server()` methods do not expose `request` argument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined the middleware creation example in the React framework guide to clarify the parameters available in the async callback function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->