### PR TITLE
fix: use loader data goes undefined

### DIFF
--- a/.changeset/nine-years-grab.md
+++ b/.changeset/nine-years-grab.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-router': patch
+---
+
+Fix for useLoaderData sometimes going undefined

--- a/packages/solid-router/src/useMatch.tsx
+++ b/packages/solid-router/src/useMatch.tsx
@@ -114,7 +114,10 @@ export function useMatch<
         ? Boolean(router.stores.pendingRouteIds.get()[opts.from!])
         : (nearestMatch?.hasPending() ?? false)
 
-      if (prev !== undefined && (hasPendingMatch || router.stores.isTransitioning.get())) {
+      if (
+        prev !== undefined &&
+        (hasPendingMatch || router.stores.isTransitioning.get())
+      ) {
         return prev
       }
 

--- a/packages/solid-router/src/useMatch.tsx
+++ b/packages/solid-router/src/useMatch.tsx
@@ -109,7 +109,18 @@ export function useMatch<
   return Solid.createMemo((prev: TSelected | undefined) => {
     const selectedMatch = match()
 
-    if (selectedMatch === undefined) return undefined
+    if (selectedMatch === undefined) {
+      const hasPendingMatch = opts.from
+        ? Boolean(router.stores.pendingRouteIds.get()[opts.from!])
+        : (nearestMatch?.hasPending() ?? false)
+
+      if (prev !== undefined && (hasPendingMatch || router.stores.isTransitioning.get())) {
+        return prev
+      }
+
+      return undefined
+    }
+
     const res = opts.select ? opts.select(selectedMatch as any) : selectedMatch
     if (prev === undefined) return res as TSelected
     return replaceEqualDeep(prev, res) as TSelected

--- a/packages/solid-router/tests/loaders.test.tsx
+++ b/packages/solid-router/tests/loaders.test.tsx
@@ -11,6 +11,7 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
+  useLoaderData,
   useRouter,
 } from '../src'
 
@@ -739,6 +740,49 @@ test('clears pendingTimeout when match resolves', async () => {
   expect(defaultPendingComponentOnMountMock).not.toHaveBeenCalled()
   expect(nestedPendingComponentOnMountMock).not.toHaveBeenCalled()
   expect(fooPendingComponentOnMountMock).not.toHaveBeenCalled()
+})
+
+test('useLoaderData retains previous data while route match is pending', async () => {
+  const history = createMemoryHistory({ initialEntries: ['/app'] })
+  const rootRoute = createRootRoute({
+    component: () => {
+      const loaderData = useLoaderData({ from: '/app' })
+
+      return (
+        <>
+          <div data-testid="combined">{`${loaderData().length}:0`}</div>
+          <Outlet />
+        </>
+      )
+    },
+  })
+  const appRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/app',
+    loader: () => 'loaded',
+    component: () => <div>App route</div>,
+  })
+  const routeTree = rootRoute.addChildren([appRoute])
+  const router = createRouter({ routeTree, history })
+
+  render(() => <RouterProvider router={router} />)
+
+  expect(await screen.findByTestId('combined')).toHaveTextContent('6:0')
+
+  const appMatch = router.state.matches.find((match) => match.routeId === '/app')
+
+  expect(appMatch).toBeDefined()
+
+  if (!appMatch) {
+    throw new Error('Expected /app match to be active')
+  }
+
+  router.stores.setPending([{ ...appMatch, id: `${appMatch.id}__pending` }])
+  router.stores.setMatches(
+    router.state.matches.filter((match) => match.routeId !== '/app'),
+  )
+
+  expect(screen.getByTestId('combined')).toHaveTextContent('6:0')
 })
 
 test('cancelMatches after pending timeout', async () => {

--- a/packages/solid-router/tests/loaders.test.tsx
+++ b/packages/solid-router/tests/loaders.test.tsx
@@ -769,7 +769,9 @@ test('useLoaderData retains previous data while route match is pending', async (
 
   expect(await screen.findByTestId('combined')).toHaveTextContent('6:0')
 
-  const appMatch = router.state.matches.find((match) => match.routeId === '/app')
+  const appMatch = router.state.matches.find(
+    (match) => match.routeId === '/app',
+  )
 
   expect(appMatch).toBeDefined()
 


### PR DESCRIPTION
Closes #6777 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented previously loaded route data from becoming undefined during transitions; users will no longer see intermittent data loss while navigating.
* **Tests**
  * Added verification to ensure loader-provided content remains visible when a route enters a pending state, improving reliability of navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->