### PR TITLE
fix: Fix route matching specificity

### DIFF
--- a/.changeset/early-static-route-matches.md
+++ b/.changeset/early-static-route-matches.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Fix route matching specificity so routes with the same number of static segments prefer the match whose static segment occurs earlier, including when competing with wildcard routes.

--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -1010,6 +1010,10 @@ function buildBranch<T extends RouteLike>(node: AnySegmentNode<T>) {
   return list
 }
 
+function appendStaticMask(staticMask: number, index: number) {
+  return (staticMask | (1 << index)) >>> 0
+}
+
 type MatchStackFrame<T extends RouteLike> = {
   node: AnySegmentNode<T>
   /** index of the segment of path */
@@ -1024,6 +1028,8 @@ type MatchStackFrame<T extends RouteLike> = {
    */
   skipped: number
   statics: number
+  /** Bitmask of static match path indexes, used to prefer earlier static segments. Limited to 32 segments by JS bitwise ops. */
+  staticMask: number
   dynamics: number
   optionals: number
   /** intermediary state for param extraction */
@@ -1067,6 +1073,7 @@ function getNodeMatch<T extends RouteLike>(
       skipped: 0,
       depth: 1,
       statics: 1,
+      staticMask: 0,
       dynamics: 0,
       optionals: 0,
     },
@@ -1078,7 +1085,16 @@ function getNodeMatch<T extends RouteLike>(
 
   while (stack.length) {
     const frame = stack.pop()!
-    const { node, index, skipped, depth, statics, dynamics, optionals } = frame
+    const {
+      node,
+      index,
+      skipped,
+      depth,
+      statics,
+      staticMask,
+      dynamics,
+      optionals,
+    } = frame
     let { extract, rawParams, parsedParams } = frame
 
     if (node.skipOnParamError) {
@@ -1120,6 +1136,7 @@ function getNodeMatch<T extends RouteLike>(
         skipped,
         depth: depth + 1,
         statics,
+        staticMask,
         dynamics,
         optionals,
         extract,
@@ -1169,6 +1186,7 @@ function getNodeMatch<T extends RouteLike>(
           skipped,
           depth,
           statics,
+          staticMask,
           dynamics,
           optionals,
           extract,
@@ -1197,6 +1215,7 @@ function getNodeMatch<T extends RouteLike>(
           skipped: nextSkipped,
           depth: nextDepth,
           statics,
+          staticMask,
           dynamics,
           optionals,
           extract,
@@ -1221,6 +1240,7 @@ function getNodeMatch<T extends RouteLike>(
             skipped,
             depth: nextDepth,
             statics,
+            staticMask,
             dynamics,
             optionals: optionals + 1,
             extract,
@@ -1249,6 +1269,7 @@ function getNodeMatch<T extends RouteLike>(
           skipped,
           depth: depth + 1,
           statics,
+          staticMask,
           dynamics: dynamics + 1,
           optionals,
           extract,
@@ -1270,6 +1291,7 @@ function getNodeMatch<T extends RouteLike>(
           skipped,
           depth: depth + 1,
           statics: statics + 1,
+          staticMask: appendStaticMask(staticMask, index),
           dynamics,
           optionals,
           extract,
@@ -1289,6 +1311,7 @@ function getNodeMatch<T extends RouteLike>(
           skipped,
           depth: depth + 1,
           statics: statics + 1,
+          staticMask: appendStaticMask(staticMask, index),
           dynamics,
           optionals,
           extract,
@@ -1309,6 +1332,7 @@ function getNodeMatch<T extends RouteLike>(
           skipped,
           depth: nextDepth,
           statics,
+          staticMask,
           dynamics,
           optionals,
           extract,
@@ -1371,17 +1395,21 @@ function isFrameMoreSpecific(
   next: MatchStackFrame<any>,
 ): boolean {
   if (!prev) return true
+  if (next.statics !== prev.statics) return next.statics > prev.statics
+  if (next.staticMask !== prev.staticMask) {
+    const diff = (next.staticMask ^ prev.staticMask) >>> 0
+    const firstDifferentPosition = diff & -diff
+    return (next.staticMask & firstDifferentPosition) !== 0
+  }
   return (
-    next.statics > prev.statics ||
-    (next.statics === prev.statics &&
-      (next.dynamics > prev.dynamics ||
-        (next.dynamics === prev.dynamics &&
-          (next.optionals > prev.optionals ||
-            (next.optionals === prev.optionals &&
-              ((next.node.kind === SEGMENT_TYPE_INDEX) >
-                (prev.node.kind === SEGMENT_TYPE_INDEX) ||
-                ((next.node.kind === SEGMENT_TYPE_INDEX) ===
-                  (prev.node.kind === SEGMENT_TYPE_INDEX) &&
-                  next.depth > prev.depth)))))))
+    next.dynamics > prev.dynamics ||
+    (next.dynamics === prev.dynamics &&
+      (next.optionals > prev.optionals ||
+        (next.optionals === prev.optionals &&
+          ((next.node.kind === SEGMENT_TYPE_INDEX) >
+            (prev.node.kind === SEGMENT_TYPE_INDEX) ||
+            ((next.node.kind === SEGMENT_TYPE_INDEX) ===
+              (prev.node.kind === SEGMENT_TYPE_INDEX) &&
+              next.depth > prev.depth)))))
   )
 }

--- a/packages/router-core/tests/new-process-route-tree.bench.ts
+++ b/packages/router-core/tests/new-process-route-tree.bench.ts
@@ -1,0 +1,151 @@
+import { bench, describe } from 'vitest'
+import {
+  findRouteMatch,
+  processRouteTree,
+} from '../src/new-process-route-tree'
+
+type BenchRoute = {
+  id: string
+  isRoot?: boolean
+  fullPath: string
+  path: string
+  children?: Array<BenchRoute>
+}
+
+const BENCH_OPTIONS = {
+  warmupIterations: 100,
+  warmupTime: 1_500,
+  time: 3_000,
+}
+
+let benchmarkSink = 0
+
+function makeRouteTree(routes: Array<string>): BenchRoute {
+  return {
+    id: '__root__',
+    isRoot: true,
+    fullPath: '/',
+    path: '/',
+    children: routes.map((route) => ({
+      id: route,
+      fullPath: route,
+      path: route,
+    })),
+  }
+}
+
+const unitDerivedPatterns = [
+  // Derived from the priority and edge-case tests in new-process-route-tree.test.ts.
+  '/{-$a}/b',
+  '/a/$',
+  '/a/{-$b}',
+  '/{-$a}/{-$b}/{-$c}/d/e',
+  '/{-$a}/{-$b}/c/d/{-$e}',
+  '/$a/$b/$c/d/e',
+  '/$a/$b/c/d/$e',
+  '/users/{-$org}/settings',
+  '/users/$id',
+  '/{-$other}/posts/new',
+  '/posts/$id',
+  '/a/{-$b}/',
+  '/a/{-$b}/$c',
+  '/foo/{-$p}.tsx',
+  '/foo/{-$p}/{-$x}.tsx',
+  '/file{$}',
+  '/{$}/c/file',
+]
+
+const unitDerivedMatchPaths = [
+  '/a/b',
+  '/a/c',
+  '/a/b/c',
+  '/a/b/c/d/e',
+  '/users/settings',
+  '/posts/new',
+  '/foo/bar.tsx',
+  '/file/a/b/c',
+  '/x/y/c/file',
+]
+
+function prefixed(pattern: string, index: number) {
+  return `/g${index}${pattern}`
+}
+
+function makeBigRoutes(groupCount: number) {
+  const routes: Array<string> = []
+  for (let i = 0; i < groupCount; i++) {
+    for (const pattern of unitDerivedPatterns) {
+      routes.push(prefixed(pattern, i))
+    }
+  }
+  return routes
+}
+
+function makeBigMatchPaths(groupCount: number) {
+  const paths: Array<string> = []
+  for (let i = 0; i < groupCount; i++) {
+    for (const path of unitDerivedMatchPaths) {
+      paths.push(`/g${i}${path}`)
+    }
+  }
+  return paths
+}
+
+const routeSuites = [
+  {
+    name: 'small route tree',
+    routes: unitDerivedPatterns,
+    matchPaths: unitDerivedMatchPaths,
+    buildIterations: 3_000,
+    matchIterations: 3_000,
+  },
+  {
+    name: 'big route tree',
+    routes: makeBigRoutes(128),
+    matchPaths: makeBigMatchPaths(128),
+    buildIterations: 20,
+    matchIterations: 20,
+  },
+]
+
+describe.each(routeSuites)(
+  'new process route tree - $name',
+  ({ routes, matchPaths, buildIterations, matchIterations }) => {
+    const routeTree = makeRouteTree(routes)
+    const processedTree = processRouteTree(routeTree).processedTree
+
+    bench(
+      `build ${routes.length} routes x ${buildIterations}`,
+      () => {
+        for (let i = 0; i < buildIterations; i++) {
+          const result = processRouteTree(routeTree)
+          benchmarkSink ^= result.routesById[routes[0]!] ? 1 : 0
+        }
+      },
+      BENCH_OPTIONS,
+    )
+
+    bench(
+      `match ${matchPaths.length} paths x ${matchIterations} (uncached)`,
+      () => {
+        let matches = 0
+
+        for (let i = 0; i < matchIterations; i++) {
+          processedTree.matchCache.clear()
+
+          for (const path of matchPaths) {
+            if (findRouteMatch(path, processedTree)) matches++
+          }
+        }
+
+        const expectedMatches = matchPaths.length * matchIterations
+        if (matches !== expectedMatches) {
+          throw new Error(`Expected ${expectedMatches} matches, got ${matches}`)
+        }
+
+        benchmarkSink ^= matches
+      },
+      BENCH_OPTIONS,
+    )
+  },
+)

--- a/packages/router-core/tests/new-process-route-tree.bench.ts
+++ b/packages/router-core/tests/new-process-route-tree.bench.ts
@@ -1,8 +1,5 @@
 import { bench, describe } from 'vitest'
-import {
-  findRouteMatch,
-  processRouteTree,
-} from '../src/new-process-route-tree'
+import { findRouteMatch, processRouteTree } from '../src/new-process-route-tree'
 
 type BenchRoute = {
   id: string

--- a/packages/router-core/tests/new-process-route-tree.test.ts
+++ b/packages/router-core/tests/new-process-route-tree.test.ts
@@ -233,6 +233,18 @@ describe('findRouteMatch', () => {
         const treeWithIndex = makeTree(['/a/', '/a/{-$b}'])
         expect(findRouteMatch('/a', treeWithIndex)?.route.id).toBe('/a/')
       })
+      it('optional+static vs static+wildcard', () => {
+        const tree = makeTree(['/{-$a}/b', '/a/$'])
+        expect(findRouteMatch('/a/b', tree)?.route.id).toBe('/a/$')
+      })
+      it('dynamic+static vs static+wildcard', () => {
+        const tree = makeTree(['/$a/b', '/a/$'])
+        expect(findRouteMatch('/a/b', tree)?.route.id).toBe('/a/$')
+      })
+      it('optional+static vs static+optional', () => {
+        const tree = makeTree(['/{-$a}/b', '/a/{-$b}'])
+        expect(findRouteMatch('/a/b', tree)?.route.id).toBe('/a/{-$b}')
+      })
     })
   })
 


### PR DESCRIPTION
Fix route matching specificity so routes with the same number of static segments prefer the match whose static segment occurs earlier, including when competing with wildcard routes.

Added new benchmarks to compare against previous implementation:

before:

```
 ✓  @tanstack/router-core  tests/new-process-route-tree.bench.ts > new process route tree - 'small route tree' 10481ms
     name                                  hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · build 17 routes x 3000           57.8219  12.7992  23.5867  17.2945  18.2649  23.0473  23.5867  23.5867  ±1.87%      174
   · match 9 paths x 3000 (uncached)  42.7092  20.3247  42.8783  23.4142  23.8470  36.9805  42.8783  42.8783  ±2.58%      129

 ✓  @tanstack/router-core  tests/new-process-route-tree.bench.ts > new process route tree - 'big route tree' 10835ms
     name                                   hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · build 2176 routes x 20            47.5093  14.6573  60.2042  21.0485  22.2884  53.1247  60.2042  60.2042  ±4.34%      143
   · match 1152 paths x 20 (uncached)  37.3156  24.3373  38.1453  26.7984  27.5687  37.8580  38.1453  38.1453  ±1.53%      112
```

with this PR:

```
 ✓  @tanstack/router-core  tests/new-process-route-tree.bench.ts > new process route tree - 'small route tree' 10634ms
     name                                  hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · build 17 routes x 3000           54.2451  12.6828  56.2507  18.4348  18.4970  48.9038  56.2507  56.2507  ±4.51%      163
   · match 9 paths x 3000 (uncached)  41.9683  20.9160  35.5695  23.8275  24.6797  33.5493  35.5695  35.5695  ±2.00%      126

 ✓  @tanstack/router-core  tests/new-process-route-tree.bench.ts > new process route tree - 'big route tree' 11235ms
     name                                   hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · build 2176 routes x 20            46.1237  14.6381  33.0708  21.6808  23.2042  31.7142  33.0708  33.0708  ±2.67%      139
   · match 1152 paths x 20 (uncached)  34.5584  24.8772  50.7804  28.9365  29.8665  42.5485  50.7804  50.7804  ±2.57%      104
```

| Case | Before | With PR | Change |
|---|---:|---:|---:|
| small build | 57.8219 hz | 54.2451 hz | -6.2% |
| small match | 42.7092 hz | 41.9683 hz | -1.7% |
| big build | 47.5093 hz | 46.1237 hz | -2.9% |
| big match | 37.3156 hz | 34.5584 hz | -7.4% |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated route matching to prefer the route whose earlier static segment appears first when competing routes have equal specificity (includes wildcard conflicts).

* **Tests**
  * Added unit tests covering route-selection priority and benchmarks exercising matching performance at small and large scales.

* **Chores**
  * Created a changeset entry for a patch-level release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->