### PR TITLE
fix(react-start-rsc): re-export renderable types from public entries

### DIFF
--- a/.changeset/eight-dingos-occur.md
+++ b/.changeset/eight-dingos-occur.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-start-rsc': patch
+---
+
+Re-export `RenderableServerComponent`, `RenderableServerComponentAttributes`, `RenderableServerComponentBuilder`, and `AnyRenderableServerComponent` from the package's public entries. Without these, consumers with `declaration: true` hit TS2742 on `renderServerComponent` calls and are forced to annotate handlers as `Promise<any>`.

--- a/packages/react-start-rsc/src/index.rsc.ts
+++ b/packages/react-start-rsc/src/index.rsc.ts
@@ -2,7 +2,13 @@
 // This file is used when importing from RSC (React Server Components) context
 
 // Types are always available
-export type { AnyCompositeComponent } from './ServerComponentTypes'
+export type {
+  AnyCompositeComponent,
+  AnyRenderableServerComponent,
+  RenderableServerComponent,
+  RenderableServerComponentAttributes,
+  RenderableServerComponentBuilder,
+} from './ServerComponentTypes'
 
 // New API: renderServerComponent - renders element to renderable proxy
 export { renderServerComponent } from './renderServerComponent.js'

--- a/packages/react-start-rsc/src/index.ts
+++ b/packages/react-start-rsc/src/index.ts
@@ -2,7 +2,13 @@
 // This file is used when importing outside of RSC (React Server Components) context
 
 // Types are always available
-export type { AnyCompositeComponent } from './ServerComponentTypes'
+export type {
+  AnyCompositeComponent,
+  AnyRenderableServerComponent,
+  RenderableServerComponent,
+  RenderableServerComponentAttributes,
+  RenderableServerComponentBuilder,
+} from './ServerComponentTypes'
 
 // CSS hrefs symbol for type-safe access
 export { SERVER_COMPONENT_CSS_HREFS } from './ServerComponentTypes'


### PR DESCRIPTION
## Issue  
`renderServerComponent` returns `Promise<RenderableServerComponentBuilder<TNode>>`,
  but `RenderableServerComponentBuilder` isn't re-exported from the public entries.

  Using `declaration: true` hits TS2742:
```
  > The inferred type of 'getChatHistory' cannot be named without a reference
  > to '.../ServerComponentTypes'. This is likely not portable.
```

## Fix
Re-export `RendaleServerComponent` types.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Type System Improvements**
  * Expanded exported server-component type definitions across package entry points, making richer TypeScript declarations available. This improves editor tooling and type-checking and reduces the need for ad-hoc type workarounds when using server-component APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->