### PR TITLE
test(start-plugin-core): cover whitespace-tolerant server fn filter

### DIFF
--- a/packages/start-plugin-core/tests/vite-start-compiler-plugin.test.ts
+++ b/packages/start-plugin-core/tests/vite-start-compiler-plugin.test.ts
@@ -18,6 +18,25 @@ import { mergeHotUpdateModules } from '../src/vite/start-compiler-plugin/hot-upd
 import type { Plugin } from 'vite'
 import type { EnvironmentModuleNode } from 'vite'
 
+function getPerEnvironmentServerFnPlugin(type: 'client' | 'server') {
+  const name = type === 'client' ? 'client' : 'ssr'
+  const plugins = startCompilerPlugin({
+    framework: 'react',
+    providerEnvName: 'ssr',
+    environments: [{ name, type }],
+  }) as Array<Plugin>
+
+  return plugins.find(
+    (candidate) => candidate.name === `tanstack-start-core::server-fn:${name}`,
+  )!
+}
+
+function matchesTransformCodeFilter(plugin: Plugin, code: string) {
+  const include = (plugin.transform as any).filter.code.include as Array<RegExp>
+
+  return include.some((pattern) => pattern.test(code))
+}
+
 describe('Vite dev server module specifiers', () => {
   test('encodes app files as root-relative dev server paths', () => {
     const encode = createViteDevServerFnModuleSpecifierEncoder('/repo/app')
@@ -79,6 +98,31 @@ describe('mergeHotUpdateModules', () => {
       route,
       provider,
     ])
+  })
+})
+
+describe('startCompilerPlugin Vite transform filter', () => {
+  test('matches server function handlers split by AST round-tripping', () => {
+    // Omit the literal `createServerFn` identifier so this exercises the
+    // whitespace-tolerant `.handler(` filter itself.
+    const code = `
+      export const ping = create({ method: 'GET' }).
+      inputValidator((d: { x?: string } = {}) => d).
+      handler(async () => 'ok')
+    `
+
+    expect(
+      matchesTransformCodeFilter(
+        getPerEnvironmentServerFnPlugin('client'),
+        code,
+      ),
+    ).toBe(true)
+    expect(
+      matchesTransformCodeFilter(
+        getPerEnvironmentServerFnPlugin('server'),
+        code,
+      ),
+    ).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

- add regression coverage for the Start Vite server-fn transform code filter
- verify the filter still matches AST-roundtripped chains where `.` and `handler` are split across lines
- intentionally avoid matching the literal `createServerFn` identifier in the fixture so the `.handler` regex path is exercised

Fixes #7280

## Test plan

- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/start-plugin-core:test:unit --outputStyle=stream --skipRemoteCache -- tests/vite-start-compiler-plugin.test.ts`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/start-plugin-core:test:unit --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/start-plugin-core:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/start-plugin-core:test:eslint --outputStyle=stream --skipRemoteCache`
- `pnpm prettier --check packages/start-plugin-core/tests/vite-start-compiler-plugin.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test utilities for plugin instantiation across different environments (client and server-side rendering).
  * Added test case verifying plugin correctly identifies and transforms server function code in various formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->