### PR TITLE
fix(start-plugin-core): sort server fn manifest entries for deterministic build output

### DIFF
--- a/.changeset/silver-lions-sort.md
+++ b/.changeset/silver-lions-sort.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+Sort server function manifest entries by ID before emitting the resolver module. The `serverFnsById` map is populated in source-file scan order, which varies across machines and incremental builds, producing non-deterministic key ordering in the emitted `__tanstack-start-server-fn-resolver-*.mjs` artifact. Stable alphabetic sorting ensures reproducible builds, consistent content hashes, and clean `git diff` on committed artifacts.

--- a/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
+++ b/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
@@ -16,17 +16,19 @@ interface GenerateServerFnResolverModuleOptions {
 function getResolverManifestEntries(
   serverFnsById: Record<string, ServerFn>,
 ): Array<ResolverManifestEntry> {
-  return Object.entries(serverFnsById)
-    // Sort entries by ID so that the generated manifest has a stable, deterministic order. 
-    // Non-deterministic ordering causes the compiled hash of the same source file to change 
-    // between builds, breaking content-addressed caching and reproducible deployments.
-    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-    .map(([id, fn]) => ({
-      id,
-      functionName: fn.functionName,
-      extractedFilename: fn.extractedFilename,
-      isClientReferenced: fn.isClientReferenced ?? true,
-    }))
+  return (
+    Object.entries(serverFnsById)
+      // Sort entries by ID so that the generated manifest has a stable, deterministic order.
+      // Non-deterministic ordering causes the compiled hash of the same source file to change
+      // between builds, breaking content-addressed caching and reproducible deployments.
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([id, fn]) => ({
+        id,
+        functionName: fn.functionName,
+        extractedFilename: fn.extractedFilename,
+        isClientReferenced: fn.isClientReferenced ?? true,
+      }))
+  )
 }
 
 function getClientReferencedCheck(

--- a/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
+++ b/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
@@ -16,7 +16,7 @@ interface GenerateServerFnResolverModuleOptions {
 function getResolverManifestEntries(
   serverFnsById: Record<string, ServerFn>,
 ): Array<ResolverManifestEntry> {
-  return Object.entries(serverFnsById).map(([id, fn]) => ({
+  return Object.entries(serverFnsById).sort(([a], [b]) => a.localeCompare(b)).map(([id, fn]) => ({
     id,
     functionName: fn.functionName,
     extractedFilename: fn.extractedFilename,

--- a/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
+++ b/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
@@ -16,7 +16,7 @@ interface GenerateServerFnResolverModuleOptions {
 function getResolverManifestEntries(
   serverFnsById: Record<string, ServerFn>,
 ): Array<ResolverManifestEntry> {
-  return Object.entries(serverFnsById).sort(([a], [b]) => a.localeCompare(b)).map(([id, fn]) => ({
+  return Object.entries(serverFnsById).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0).map(([id, fn]) => ({
     id,
     functionName: fn.functionName,
     extractedFilename: fn.extractedFilename,

--- a/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
+++ b/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
@@ -17,6 +17,9 @@ function getResolverManifestEntries(
   serverFnsById: Record<string, ServerFn>,
 ): Array<ResolverManifestEntry> {
   return Object.entries(serverFnsById)
+    // Sort entries by ID so that the generated manifest has a stable, deterministic order. 
+    // Non-deterministic ordering causes the compiled hash of the same source file to change 
+    // between builds, breaking content-addressed caching and reproducible deployments.
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     .map(([id, fn]) => ({
       id,

--- a/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
+++ b/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
@@ -16,12 +16,14 @@ interface GenerateServerFnResolverModuleOptions {
 function getResolverManifestEntries(
   serverFnsById: Record<string, ServerFn>,
 ): Array<ResolverManifestEntry> {
-  return Object.entries(serverFnsById).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0).map(([id, fn]) => ({
-    id,
-    functionName: fn.functionName,
-    extractedFilename: fn.extractedFilename,
-    isClientReferenced: fn.isClientReferenced ?? true,
-  }))
+  return Object.entries(serverFnsById)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([id, fn]) => ({
+      id,
+      functionName: fn.functionName,
+      extractedFilename: fn.extractedFilename,
+      isClientReferenced: fn.isClientReferenced ?? true,
+    }))
 }
 
 function getClientReferencedCheck(


### PR DESCRIPTION
Fixes #6762.

## Problem

`getResolverManifestEntries` calls `Object.entries(serverFnsById)` and maps over the result without sorting. The `serverFnsById` dictionary is built by processing source files in build-system order, which is non-deterministic across machines and runs. Because JS object key iteration follows insertion order, the generated `manifest` object in the emitted `__tanstack-start-server-fn-resolver-*.mjs` artifact ends up with keys in a different order on each build — changing the file hash even when no functions have changed.

This breaks:
- Content-addressed caching (CDN, build caches)
- Reproducible builds / lockfile verification
- `git diff` noise on committed build artifacts

## Fix

Sort the entries by ID (stable alphabetic order) before mapping. One-line change in `getResolverManifestEntries` — no behavioural difference at runtime since `getServerFnById` looks up by key, not by position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolver manifest entries are now emitted in deterministic lexicographic ID order.
  * Result: more reproducible manifests and consistent module indexing across builds and environments, reducing unexpected diffs and build variability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->