### PR TITLE
fix(react-start-rsc): bump @vitejs/plugin-rsc to ^0.5.23 (GHSA-v457-wxvj-p9w9)

### DIFF
--- a/e2e/react-start/rsc-query/package.json
+++ b/e2e/react-start/rsc-query/package.json
@@ -28,7 +28,7 @@
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "@vitejs/plugin-rsc": "^0.5.20",
+    "@vitejs/plugin-rsc": "^0.5.23",
     "srvx": "^0.10.0",
     "typescript": "^5.7.2",
     "vite": "^8.0.0"

--- a/e2e/react-start/rsc/package.json
+++ b/e2e/react-start/rsc/package.json
@@ -44,7 +44,7 @@
     "@types/react-dom": "^19.0.3",
     "@typescript-eslint/parser": "^8.23.0",
     "@vitejs/plugin-react": "^6.0.1",
-    "@vitejs/plugin-rsc": "^0.5.20",
+    "@vitejs/plugin-rsc": "^0.5.23",
     "eslint": "^9.22.0",
     "srvx": "^0.10.0",
     "typescript": "^5.7.2",

--- a/examples/react/start-rscs/package.json
+++ b/examples/react/start-rscs/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "^6.0.1",
-    "@vitejs/plugin-rsc": "^0.5.20",
+    "@vitejs/plugin-rsc": "^0.5.23",
     "nitro": "npm:nitro-nightly@latest",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.7.2",

--- a/packages/react-start-rsc/package.json
+++ b/packages/react-start-rsc/package.json
@@ -106,12 +106,12 @@
     "@rspack/core": "2.0.0",
     "@testing-library/react": "^16.2.0",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitejs/plugin-rsc": "^0.5.20",
+    "@vitejs/plugin-rsc": "^0.5.23",
     "react-server-dom-rspack": "^0.0.2"
   },
   "peerDependencies": {
     "@rspack/core": ">=2.0.0-0",
-    "@vitejs/plugin-rsc": ">=0.5.20",
+    "@vitejs/plugin-rsc": ">=0.5.23",
     "react": ">=18.0.0 || >=19.0.0",
     "react-dom": ">=18.0.0 || >=19.0.0",
     "react-server-dom-rspack": ">=0.0.2"


### PR DESCRIPTION
## Summary

- Bumps `@vitejs/plugin-rsc` from `^0.5.20` to `^0.5.23` across `packages/react-start-rsc`, `examples/react/start-rscs`, `e2e/react-start/rsc`, and `e2e/react-start/rsc-query`.
- Also bumps the `peerDependencies` floor in `packages/react-start-rsc` from `>=0.5.20` to `>=0.5.23`.
- Versions `<= 0.5.22` vendor a vulnerable copy of `react-server-dom-webpack` (DoS) — see [GHSA-v457-wxvj-p9w9](https://osv.dev/vulnerability/GHSA-v457-wxvj-p9w9). The upstream advisory recommends upgrading to `0.5.23+`.

## Note on the lockfile

I was not able to regenerate `pnpm-lock.yaml` in my local environment (registry mirror does not have several already-pinned versions, and the public registry was unreachable). The lockfile will need to be regenerated by a maintainer with `pnpm install` before this can land. Happy to push the regenerated lockfile if useful — let me know.
