### PR TITLE
fix: fix exports for react-start so useServerFn is available with RSC

### DIFF
--- a/.changeset/angry-flies-taste.md
+++ b/.changeset/angry-flies-taste.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-start': patch
+---
+
+fix exports for react-start so useServerFn is available with RSC

--- a/e2e/react-start/rsc/src/routeTree.gen.ts
+++ b/e2e/react-start/rsc/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as RscUseServerFnRouteImport } from './routes/rsc-use-server-fn'
 import { Route as RscTreeRouteImport } from './routes/rsc-tree'
 import { Route as RscSuspenseRouteImport } from './routes/rsc-suspense'
 import { Route as RscStreamingRouteImport } from './routes/rsc-streaming'
@@ -55,6 +56,11 @@ import { Route as RscParamIdRouteImport } from './routes/rsc-param/$id'
 import { Route as RscCssConditionalBranchRouteImport } from './routes/rsc-css-conditional.$branch'
 import { Route as ApiRscFlightRouteImport } from './routes/api.rsc-flight'
 
+const RscUseServerFnRoute = RscUseServerFnRouteImport.update({
+  id: '/rsc-use-server-fn',
+  path: '/rsc-use-server-fn',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RscTreeRoute = RscTreeRouteImport.update({
   id: '/rsc-tree',
   path: '/rsc-tree',
@@ -322,6 +328,7 @@ export interface FileRoutesByFullPath {
   '/rsc-streaming': typeof RscStreamingRoute
   '/rsc-suspense': typeof RscSuspenseRoute
   '/rsc-tree': typeof RscTreeRoute
+  '/rsc-use-server-fn': typeof RscUseServerFnRoute
   '/api/rsc-flight': typeof ApiRscFlightRoute
   '/rsc-css-conditional/$branch': typeof RscCssConditionalBranchRoute
   '/rsc-param/$id': typeof RscParamIdRoute
@@ -369,6 +376,7 @@ export interface FileRoutesByTo {
   '/rsc-streaming': typeof RscStreamingRoute
   '/rsc-suspense': typeof RscSuspenseRoute
   '/rsc-tree': typeof RscTreeRoute
+  '/rsc-use-server-fn': typeof RscUseServerFnRoute
   '/api/rsc-flight': typeof ApiRscFlightRoute
   '/rsc-css-conditional/$branch': typeof RscCssConditionalBranchRoute
   '/rsc-param/$id': typeof RscParamIdRoute
@@ -417,6 +425,7 @@ export interface FileRoutesById {
   '/rsc-streaming': typeof RscStreamingRoute
   '/rsc-suspense': typeof RscSuspenseRoute
   '/rsc-tree': typeof RscTreeRoute
+  '/rsc-use-server-fn': typeof RscUseServerFnRoute
   '/api/rsc-flight': typeof ApiRscFlightRoute
   '/rsc-css-conditional/$branch': typeof RscCssConditionalBranchRoute
   '/rsc-param/$id': typeof RscParamIdRoute
@@ -466,6 +475,7 @@ export interface FileRouteTypes {
     | '/rsc-streaming'
     | '/rsc-suspense'
     | '/rsc-tree'
+    | '/rsc-use-server-fn'
     | '/api/rsc-flight'
     | '/rsc-css-conditional/$branch'
     | '/rsc-param/$id'
@@ -513,6 +523,7 @@ export interface FileRouteTypes {
     | '/rsc-streaming'
     | '/rsc-suspense'
     | '/rsc-tree'
+    | '/rsc-use-server-fn'
     | '/api/rsc-flight'
     | '/rsc-css-conditional/$branch'
     | '/rsc-param/$id'
@@ -560,6 +571,7 @@ export interface FileRouteTypes {
     | '/rsc-streaming'
     | '/rsc-suspense'
     | '/rsc-tree'
+    | '/rsc-use-server-fn'
     | '/api/rsc-flight'
     | '/rsc-css-conditional/$branch'
     | '/rsc-param/$id'
@@ -608,6 +620,7 @@ export interface RootRouteChildren {
   RscStreamingRoute: typeof RscStreamingRoute
   RscSuspenseRoute: typeof RscSuspenseRoute
   RscTreeRoute: typeof RscTreeRoute
+  RscUseServerFnRoute: typeof RscUseServerFnRoute
   ApiRscFlightRoute: typeof ApiRscFlightRoute
   RscCssConditionalBranchRoute: typeof RscCssConditionalBranchRoute
   RscParamIdRoute: typeof RscParamIdRoute
@@ -617,6 +630,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/rsc-use-server-fn': {
+      id: '/rsc-use-server-fn'
+      path: '/rsc-use-server-fn'
+      fullPath: '/rsc-use-server-fn'
+      preLoaderRoute: typeof RscUseServerFnRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/rsc-tree': {
       id: '/rsc-tree'
       path: '/rsc-tree'
@@ -976,6 +996,7 @@ const rootRouteChildren: RootRouteChildren = {
   RscStreamingRoute: RscStreamingRoute,
   RscSuspenseRoute: RscSuspenseRoute,
   RscTreeRoute: RscTreeRoute,
+  RscUseServerFnRoute: RscUseServerFnRoute,
   ApiRscFlightRoute: ApiRscFlightRoute,
   RscCssConditionalBranchRoute: RscCssConditionalBranchRoute,
   RscParamIdRoute: RscParamIdRoute,

--- a/e2e/react-start/rsc/src/routes/rsc-use-server-fn.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-use-server-fn.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn, useServerFn } from '@tanstack/react-start'
+import { pageStyles } from '~/utils/styles'
+
+const getMessage = createServerFn({ method: 'GET' }).handler(async () => {
+  return 'useServerFn works with RSC builds'
+})
+
+export const Route = createFileRoute('/rsc-use-server-fn')({
+  component: RscUseServerFnComponent,
+})
+
+function RscUseServerFnComponent() {
+  const getMessageFn = useServerFn(getMessage)
+  const [message, setMessage] = React.useState('')
+
+  return (
+    <div style={pageStyles.container}>
+      <h1 data-testid="rsc-use-server-fn-title" style={pageStyles.title}>
+        useServerFn with RSC
+      </h1>
+      <button
+        type="button"
+        data-testid="rsc-use-server-fn-button"
+        onClick={async () => {
+          setMessage(await getMessageFn())
+        }}
+      >
+        Call server function
+      </button>
+      <p data-testid="rsc-use-server-fn-message">
+        {message || 'No message yet'}
+      </p>
+    </div>
+  )
+}

--- a/e2e/react-start/rsc/tests/rsc-use-server-fn.spec.ts
+++ b/e2e/react-start/rsc/tests/rsc-use-server-fn.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from '@playwright/test'
+import { test } from '@tanstack/router-e2e-utils'
+import { waitForHydration } from './hydration'
+
+test.describe('RSC useServerFn Tests', () => {
+  test('useServerFn can be imported and called in an RSC app', async ({
+    page,
+  }) => {
+    await page.goto('/rsc-use-server-fn')
+    await page.waitForURL('/rsc-use-server-fn')
+    await waitForHydration(page)
+
+    await expect(page.getByTestId('rsc-use-server-fn-title')).toHaveText(
+      'useServerFn with RSC',
+    )
+
+    await page.getByTestId('rsc-use-server-fn-button').click()
+    await expect(page.getByTestId('rsc-use-server-fn-message')).toHaveText(
+      'useServerFn works with RSC builds',
+    )
+  })
+})

--- a/packages/react-start/package.json
+++ b/packages/react-start/package.json
@@ -34,8 +34,8 @@
   "exports": {
     ".": {
       "react-server": {
-        "types": "./dist/esm/index.rsc.d.ts",
-        "default": "./dist/esm/index.rsc.js"
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
       },
       "import": {
         "types": "./dist/esm/index.d.ts",

--- a/packages/react-start/src/index.rsc.ts
+++ b/packages/react-start/src/index.rsc.ts
@@ -1,1 +1,0 @@
-export * from '@tanstack/start-client-core'

--- a/packages/react-start/vite.config.ts
+++ b/packages/react-start/vite.config.ts
@@ -26,7 +26,6 @@ export default mergeConfig(
     exclude: ['./src/default-entry'],
     entry: [
       './src/index.ts',
-      './src/index.rsc.ts',
       './src/client.tsx',
       './src/client-rpc.ts',
       './src/server.tsx',


### PR DESCRIPTION
fixes #7276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `useServerFn` export to ensure it is properly available for use in React Server Components (RSC) contexts.

* **Tests**
  * Added E2E test coverage for `useServerFn` functionality within RSC environments to validate proper integration and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->