### PR TITLE
fix: disabled topLevelVar

### DIFF
--- a/.changeset/slow-seahorses-grab.md
+++ b/.changeset/slow-seahorses-grab.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+prevent isServer exports from being transformed to top-level vars so rspack can dead-code eliminate them

--- a/packages/router-core/vite.config.ts
+++ b/packages/router-core/vite.config.ts
@@ -10,9 +10,9 @@ const config = defineConfig({
   build: {
     rolldownOptions: {
       output: {
-        topLevelVar: false
-      }
-    }
+        topLevelVar: false,
+      },
+    },
   },
   test: {
     name: packageJson.name,

--- a/packages/router-core/vite.config.ts
+++ b/packages/router-core/vite.config.ts
@@ -7,6 +7,13 @@ import type { ViteUserConfig } from 'vitest/config'
 
 const config = defineConfig({
   plugins: [minifyScriptPlugin()] as ViteUserConfig['plugins'],
+  build: {
+    rolldownOptions: {
+      output: {
+        topLevelVar: false
+      }
+    }
+  },
   test: {
     name: packageJson.name,
     dir: './tests',


### PR DESCRIPTION
this will cause isServer not to be transpiled to `var` and thus rspack can properly DCE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build output configuration to properly preserve critical exports during dead-code elimination, ensuring correct behavior with rspack bundler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->