### PR TITLE
docs(start): document Register module augmentation in build-from-scratch

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -165,6 +165,19 @@ export function getRouter() {
 }
 ```
 
+Then register the router's type by augmenting the `Register` interface from `@tanstack/react-router`. This makes `<Link>`, `useNavigate`, and the [route hooks](/router/latest/docs/framework/react/guide/type-safety) aware of your routes, params, and search schemas:
+
+```tsx
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: ReturnType<typeof getRouter>
+  }
+}
+```
+
+> [!NOTE]
+> `Register` is a TypeScript-only construct. Skipping this declaration doesn't break the build, but `<Link to="...">` will accept any string and route data hooks will lose their inferred types.
+
 ## The Root of Your Application
 
 Finally, we need to create the root of our application. This is the entry point for all other routes. The code in this file will wrap all other routes in the application.

--- a/docs/start/framework/solid/build-from-scratch.md
+++ b/docs/start/framework/solid/build-from-scratch.md
@@ -150,6 +150,19 @@ export function getRouter() {
 }
 ```
 
+Then register the router's type by augmenting the `Register` interface from `@tanstack/solid-router`. This makes `<Link>`, `useNavigate`, and the [route hooks](/router/latest/docs/framework/solid/guide/type-safety) aware of your routes, params, and search schemas:
+
+```tsx
+declare module '@tanstack/solid-router' {
+  interface Register {
+    router: ReturnType<typeof getRouter>
+  }
+}
+```
+
+> [!NOTE]
+> `Register` is a TypeScript-only construct. Skipping this declaration doesn't break the build, but `<Link to="...">` will accept any string and route data hooks will lose their inferred types.
+
 ## The Root of Your Application
 
 Finally, we need to create the root of our application. This is the entry point for all other routes. The code in this file will wrap all other routes in the application.


### PR DESCRIPTION
Hi there. When I started setting up TanStack start, I noticed that it's missing an important part. Here's the fix.

## Summary

- Adds the missing `declare module '@tanstack/react-router'` / `@tanstack/solid-router` `Register` interface augmentation step to the React and Solid **Build from Scratch** Start guides.
- Without this step, `<Link>` accepts any string and route data hooks lose inferred types, which is easy to miss when following the guide top-to-bottom.
- Includes a short note clarifying that `Register` is a TypeScript-only construct, so skipping it does not break the build (it only silently drops type-safety).

## Test plan

- [x] Docs-only change — no code paths affected
- [x] Verified the snippet matches the existing `Register` pattern used elsewhere in the docs
- [x] Both React and Solid guides updated for parity