### PR TITLE
bench(client-nav): shorter timeout duration in JSDom requestAnimationFrame mock

### DIFF
--- a/benchmarks/client-nav/jsdom.ts
+++ b/benchmarks/client-nav/jsdom.ts
@@ -35,7 +35,7 @@ setGlobal(
   'requestAnimationFrame',
   window.requestAnimationFrame?.bind(window) ??
     ((callback: (time: number) => void) =>
-      setTimeout(() => callback(performance.now()), 16)),
+      setTimeout(() => callback(performance.now()), 0)),
 )
 
 setGlobal(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal benchmark testing configuration with minor polyfill timing adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->