### PR TITLE
fix: parse params union inference

### DIFF
--- a/.changeset/fix-parse-params-union.md
+++ b/.changeset/fix-parse-params-union.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Fix params.parse inference for discriminated union path params while preserving path key validation.

--- a/packages/react-router/tests/fileRoute.test-d.tsx
+++ b/packages/react-router/tests/fileRoute.test-d.tsx
@@ -17,6 +17,31 @@ const postRoute = createFileRoute('/_postLayout/posts/$postId_')()
 
 const protectedRoute = createFileRoute('/(auth)/protected')()
 
+const attachmentRoute = createFileRoute(
+  '/projects/$observationDocId/attachments/$driveId/$type/$variant/$name',
+)({
+  params: {
+    parse: ({ driveId, type, variant, name, ...rest }) => {
+      const blobId =
+        type === 'audio'
+          ? {
+              type: 'audio' as const,
+              variant: 'original' as const,
+              driveId,
+              name,
+            }
+          : {
+              type: 'photo' as const,
+              variant: variant as 'original' | 'preview' | 'thumbnail',
+              driveId,
+              name,
+            }
+
+      return { ...rest, ...blobId }
+    },
+  },
+})
+
 declare module '@tanstack/router-core' {
   interface FileRoutesByPath {
     '/': {
@@ -68,6 +93,13 @@ declare module '@tanstack/router-core' {
       fullPath: '/posts/$postId'
       path: '/$postId_'
     }
+    '/projects/$observationDocId/attachments/$driveId/$type/$variant/$name': {
+      preLoaderRoute: typeof attachmentRoute
+      parentRoute: typeof rootRoute
+      id: '/projects/$observationDocId/attachments/$driveId/$type/$variant/$name'
+      fullPath: '/projects/$observationDocId/attachments/$driveId/$type/$variant/$name'
+      path: '/projects/$observationDocId/attachments/$driveId/$type/$variant/$name'
+    }
   }
 }
 
@@ -99,4 +131,32 @@ test('when creating a folder group', () => {
   expectTypeOf<'/protected'>(protectedRoute.fullPath)
   expectTypeOf<'(auth)/protected'>(protectedRoute.path)
   expectTypeOf<'/protected'>(protectedRoute.id)
+})
+
+test('when file route params.parse returns a discriminated union', () => {
+  expectTypeOf(attachmentRoute.types.params).toEqualTypeOf<
+    | {
+        observationDocId: string
+        driveId: string
+        type: 'audio'
+        variant: 'original'
+        name: string
+      }
+    | {
+        observationDocId: string
+        driveId: string
+        type: 'photo'
+        variant: 'original' | 'preview' | 'thumbnail'
+        name: string
+      }
+  >()
+})
+
+test('when file route params.parse drops a path param', () => {
+  createFileRoute('/invoices/$invoiceId')({
+    params: {
+      // @ts-expect-error parsed params must keep path param keys
+      parse: () => ({}),
+    },
+  })
 })

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -173,11 +173,13 @@ export type ResolveParams<
 
 export type ParseParamsFn<in out TPath extends string, in out TParams> = (
   rawParams: Expand<ResolveParams<TPath>>,
-) =>
-  | (TParams extends ResolveParams<TPath, any>
-      ? TParams
-      : ResolveParams<TPath, any>)
-  | false
+) => TParams | false
+
+type ValidateParsedParams<TPath extends string, TParams> = [TParams] extends [
+  ResolveParams<TPath, any>,
+]
+  ? unknown
+  : never
 
 export type StringifyParamsFn<in out TPath extends string, in out TParams> = (
   params: TParams,
@@ -185,14 +187,15 @@ export type StringifyParamsFn<in out TPath extends string, in out TParams> = (
 
 export type ParamsOptions<in out TPath extends string, in out TParams> = {
   params?: {
-    parse?: ParseParamsFn<TPath, TParams>
+    parse?: ParseParamsFn<TPath, TParams> & ValidateParsedParams<TPath, TParams>
     stringify?: StringifyParamsFn<TPath, TParams>
   }
 
   /** 
   @deprecated Use params.parse instead
   */
-  parseParams?: ParseParamsFn<TPath, TParams>
+  parseParams?: ParseParamsFn<TPath, TParams> &
+    ValidateParsedParams<TPath, TParams>
 
   /** 
   @deprecated Use params.stringify instead


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type inference for `params.parse` with discriminated-union path parameters to properly resolve the expected type shape.
  * Enhanced type validation to catch errors when required path parameters are missing from parsing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->