### PR TITLE
simplify type

### DIFF
--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -175,27 +175,26 @@ export type ParseParamsFn<in out TPath extends string, in out TParams> = (
   rawParams: Expand<ResolveParams<TPath>>,
 ) => TParams | false
 
-type ValidateParsedParams<TPath extends string, TParams> = [TParams] extends [
-  ResolveParams<TPath, any>,
-]
-  ? unknown
-  : never
-
 export type StringifyParamsFn<in out TPath extends string, in out TParams> = (
   params: TParams,
 ) => ResolveParams<TPath>
 
 export type ParamsOptions<in out TPath extends string, in out TParams> = {
   params?: {
-    parse?: ParseParamsFn<TPath, TParams> & ValidateParsedParams<TPath, TParams>
+    parse?: Constrain<
+      ParseParamsFn<TPath, TParams>,
+      (rawParams: Expand<ResolveParams<TPath>>) => ResolveParams<TPath, any> | false
+    >
     stringify?: StringifyParamsFn<TPath, TParams>
   }
 
   /** 
   @deprecated Use params.parse instead
   */
-  parseParams?: ParseParamsFn<TPath, TParams> &
-    ValidateParsedParams<TPath, TParams>
+  parseParams?: Constrain<
+    ParseParamsFn<TPath, TParams>,
+    (rawParams: Expand<ResolveParams<TPath>>) => ResolveParams<TPath, any> | false
+  >
 
   /** 
   @deprecated Use params.stringify instead

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -183,7 +183,9 @@ export type ParamsOptions<in out TPath extends string, in out TParams> = {
   params?: {
     parse?: Constrain<
       ParseParamsFn<TPath, TParams>,
-      (rawParams: Expand<ResolveParams<TPath>>) => ResolveParams<TPath, any> | false
+      (
+        rawParams: Expand<ResolveParams<TPath>>,
+      ) => ResolveParams<TPath, any> | false
     >
     stringify?: StringifyParamsFn<TPath, TParams>
   }
@@ -193,7 +195,9 @@ export type ParamsOptions<in out TPath extends string, in out TParams> = {
   */
   parseParams?: Constrain<
     ParseParamsFn<TPath, TParams>,
-    (rawParams: Expand<ResolveParams<TPath>>) => ResolveParams<TPath, any> | false
+    (
+      rawParams: Expand<ResolveParams<TPath>>,
+    ) => ResolveParams<TPath, any> | false
   >
 
   /** 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed an exported type used by downstream code—update any direct references.
  * Route parameter parsing options now enforce stricter type constraints; adjust custom parsing handlers to match the tighter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->