### PR TITLE
docs: Improve key differences b/w Start Server Functions and Next.js Server Actions

### DIFF
--- a/docs/start/framework/react/comparison.md
+++ b/docs/start/framework/react/comparison.md
@@ -217,6 +217,7 @@ Key differences:
 - Start's server functions support both client and server middleware
 - Start has built-in input validation
 - Start's approach is more explicit about the client/server boundary
+- Start's server functions support both GET and POST methods (configurable via the `method` option, defaults to GET), while Next.js Server Actions only support POST.
 - Next.js Server Actions integrate more seamlessly with forms
 
 ### Middleware Architecture


### PR DESCRIPTION
Improve key differences b/w Start Server Functions and Next.js Server Actions to show that TanStack Start server functions support both GET and POST methods, while Next.js Server Actions only support POST.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification about server function configuration options, comparing supported HTTP methods between frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->