### PR TITLE
fix(router-plugin): isolate route metadata per plugin instance

### DIFF
--- a/.changeset/clean-router-plugin-context.md
+++ b/.changeset/clean-router-plugin-context.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/router-plugin': patch
+'@tanstack/start-plugin-core': patch
+---
+
+Replace global route metadata with explicit router plugin contexts so multiple router plugin instances cannot cross-transform route files.

--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -63,6 +63,16 @@
         "default": "./dist/cjs/vite.cjs"
       }
     },
+    "./context": {
+      "import": {
+        "types": "./dist/esm/context.d.ts",
+        "default": "./dist/esm/context.js"
+      },
+      "require": {
+        "types": "./dist/cjs/context.d.cts",
+        "default": "./dist/cjs/context.cjs"
+      }
+    },
     "./rspack": {
       "import": {
         "types": "./dist/esm/rspack.d.ts",

--- a/packages/router-plugin/src/context.ts
+++ b/packages/router-plugin/src/context.ts
@@ -1,0 +1,2 @@
+export { createRouterPluginContext } from './core/router-plugin-context'
+export type { RouterPluginContext } from './core/router-plugin-context'

--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -22,7 +22,7 @@ import {
 } from './constants'
 import { decodeIdentifier } from './code-splitter/path-ids'
 import { debug, normalizePath } from './utils'
-import { defaultRouterPluginContext } from './router-plugin-context'
+import { createRouterPluginContext } from './router-plugin-context'
 import type { CodeSplitGroupings, SplitRouteIdentNodes } from './constants'
 import type { GetRoutesByFileMapResultValue } from '@tanstack/router-generator'
 import type { Config } from './config'
@@ -409,5 +409,5 @@ export function createRouterCodeSplitterPlugin(
 export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
   Partial<Config | (() => Config)> | undefined
 > = (options = {}) => {
-  return createRouterCodeSplitterPlugin(options, defaultRouterPluginContext)
+  return createRouterCodeSplitterPlugin(options, createRouterPluginContext())
 }

--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -22,9 +22,11 @@ import {
 } from './constants'
 import { decodeIdentifier } from './code-splitter/path-ids'
 import { debug, normalizePath } from './utils'
+import { defaultRouterPluginContext } from './router-plugin-context'
 import type { CodeSplitGroupings, SplitRouteIdentNodes } from './constants'
 import type { GetRoutesByFileMapResultValue } from '@tanstack/router-generator'
 import type { Config } from './config'
+import type { RouterPluginContext } from './router-plugin-context'
 import type {
   UnpluginFactory,
   TransformResult as UnpluginTransformResult,
@@ -76,9 +78,10 @@ const TRANSFORMATION_PLUGINS_BY_FRAMEWORK: Record<
   ],
 }
 
-export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
-  Partial<Config | (() => Config)> | undefined
-> = (options = {}, { framework: _framework }) => {
+export function createRouterCodeSplitterPlugin(
+  options: Partial<Config | (() => Config)> | undefined = {},
+  routerPluginContext: RouterPluginContext,
+): ReturnType<UnpluginFactory<Partial<Config | (() => Config)> | undefined>> {
   let ROOT: string = process.cwd()
   let userConfig: Config
 
@@ -259,7 +262,7 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
         handler(code, id) {
           const normalizedId = normalizePath(id)
           const generatorFileInfo =
-            globalThis.TSR_ROUTES_BY_ID_MAP?.get(normalizedId)
+            routerPluginContext.routesByFile.get(normalizedId)
           if (
             generatorFileInfo &&
             includedCode.some((included) => code.includes(included))
@@ -401,4 +404,10 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
       },
     },
   ]
+}
+
+export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
+  Partial<Config | (() => Config)> | undefined
+> = (options = {}) => {
+  return createRouterCodeSplitterPlugin(options, defaultRouterPluginContext)
 }

--- a/packages/router-plugin/src/core/router-composed-plugin.ts
+++ b/packages/router-plugin/src/core/router-composed-plugin.ts
@@ -1,7 +1,8 @@
 import { getConfig } from '@tanstack/router-generator'
-import { unpluginRouterGeneratorFactory } from './router-generator-plugin'
-import { unpluginRouterCodeSplitterFactory } from './router-code-splitter-plugin'
-import { unpluginRouterHmrFactory } from './router-hmr-plugin'
+import { createRouterGeneratorPlugin } from './router-generator-plugin'
+import { createRouterCodeSplitterPlugin } from './router-code-splitter-plugin'
+import { createRouterHmrPlugin } from './router-hmr-plugin'
+import { createRouterPluginContext } from './router-plugin-context'
 import type { Config } from './config'
 import type {
   RspackCompiler,
@@ -29,25 +30,27 @@ function applyRspackInlineCssDefaultDefinePlugin(compiler: RspackCompiler) {
 
 export const unpluginRouterComposedFactory: UnpluginFactory<
   Partial<Config | (() => Config)> | undefined
-> = (options = {}, meta) => {
+> = (options = {}, _meta) => {
   const ROOT: string = process.cwd()
   const userConfig = getConfig(
     (typeof options === 'function' ? options() : options) as Partial<Config>,
     ROOT,
   )
+  const routerPluginContext = createRouterPluginContext()
 
-  const getPlugin = (
-    pluginFactory: UnpluginFactory<Partial<Config | (() => Config)>>,
-  ) => {
-    const plugin = pluginFactory(options, meta)
+  const getPlugin = (plugin: ReturnType<UnpluginFactory<any>>) => {
     if (!Array.isArray(plugin)) {
       return [plugin]
     }
     return plugin
   }
 
-  const routerGenerator = getPlugin(unpluginRouterGeneratorFactory)
-  const routerCodeSplitter = getPlugin(unpluginRouterCodeSplitterFactory)
+  const routerGenerator = getPlugin(
+    createRouterGeneratorPlugin(options, routerPluginContext),
+  )
+  const routerCodeSplitter = getPlugin(
+    createRouterCodeSplitterPlugin(options, routerPluginContext),
+  )
 
   const result = [
     {
@@ -85,7 +88,9 @@ export const unpluginRouterComposedFactory: UnpluginFactory<
   const isProduction = process.env.NODE_ENV === 'production'
 
   if (!isProduction && !userConfig.autoCodeSplitting) {
-    const routerHmr = getPlugin(unpluginRouterHmrFactory)
+    const routerHmr = getPlugin(
+      createRouterHmrPlugin(options, routerPluginContext),
+    )
     result.push(...routerHmr)
   }
   return result

--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -1,17 +1,20 @@
 import { isAbsolute, join, normalize } from 'node:path'
 import { Generator, resolveConfigPath } from '@tanstack/router-generator'
 import { getConfig } from './config'
+import { defaultRouterPluginContext } from './router-plugin-context'
 
 import type { GeneratorEvent } from '@tanstack/router-generator'
 import type { FSWatcher } from 'chokidar'
 import type { UnpluginFactory } from 'unplugin'
 import type { Config } from './config'
+import type { RouterPluginContext } from './router-plugin-context'
 
 const PLUGIN_NAME = 'unplugin:router-generator'
 
-export const unpluginRouterGeneratorFactory: UnpluginFactory<
-  Partial<Config | (() => Config)> | undefined
-> = (options = {}) => {
+export function createRouterGeneratorPlugin(
+  options: Partial<Config | (() => Config)> | undefined = {},
+  routerPluginContext: RouterPluginContext,
+): ReturnType<UnpluginFactory<Partial<Config | (() => Config)> | undefined>> {
   let ROOT: string = process.cwd()
   let userConfig: Config
   let generator: Generator
@@ -58,7 +61,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
 
     try {
       await generator.run(generatorEvent)
-      globalThis.TSR_ROUTES_BY_ID_MAP = generator.getRoutesByFileMap()
+      routerPluginContext.routesByFile = generator.getRoutesByFileMap()
     } catch (e) {
       console.error(e)
     }
@@ -145,4 +148,10 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
       },
     },
   }
+}
+
+export const unpluginRouterGeneratorFactory: UnpluginFactory<
+  Partial<Config | (() => Config)> | undefined
+> = (options = {}) => {
+  return createRouterGeneratorPlugin(options, defaultRouterPluginContext)
 }

--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, join, normalize } from 'node:path'
 import { Generator, resolveConfigPath } from '@tanstack/router-generator'
 import { getConfig } from './config'
-import { defaultRouterPluginContext } from './router-plugin-context'
+import { createRouterPluginContext } from './router-plugin-context'
 
 import type { GeneratorEvent } from '@tanstack/router-generator'
 import type { FSWatcher } from 'chokidar'
@@ -153,5 +153,5 @@ export function createRouterGeneratorPlugin(
 export const unpluginRouterGeneratorFactory: UnpluginFactory<
   Partial<Config | (() => Config)> | undefined
 > = (options = {}) => {
-  return createRouterGeneratorPlugin(options, defaultRouterPluginContext)
+  return createRouterGeneratorPlugin(options, createRouterPluginContext())
 }

--- a/packages/router-plugin/src/core/router-hmr-plugin.ts
+++ b/packages/router-plugin/src/core/router-hmr-plugin.ts
@@ -4,8 +4,10 @@ import { getReferenceRouteCompilerPlugins } from './code-splitter/plugins/framew
 import { createRouteHmrStatement } from './hmr'
 import { debug, normalizePath } from './utils'
 import { getConfig } from './config'
+import { defaultRouterPluginContext } from './router-plugin-context'
 import type { UnpluginFactory } from 'unplugin'
 import type { Config } from './config'
+import type { RouterPluginContext } from './router-plugin-context'
 
 /**
  * This plugin adds HMR support for file routes.
@@ -18,11 +20,15 @@ const includeCode = [
   'createRootRoute(',
   'createRootRouteWithContext(',
 ]
-export const unpluginRouterHmrFactory: UnpluginFactory<
-  Partial<Config> | undefined
-> = (options = {}) => {
+
+export function createRouterHmrPlugin(
+  options: Partial<Config | (() => Config)> | undefined = {},
+  routerPluginContext: RouterPluginContext,
+): ReturnType<UnpluginFactory<Partial<Config> | undefined>> {
   let ROOT: string = process.cwd()
-  let userConfig = options as Config
+  let userConfig = (
+    typeof options === 'function' ? options() : options
+  ) as Config
 
   return {
     name: 'tanstack-router:hmr',
@@ -37,7 +43,7 @@ export const unpluginRouterHmrFactory: UnpluginFactory<
       },
       handler(code, id) {
         const normalizedId = normalizePath(id)
-        const routeEntry = globalThis.TSR_ROUTES_BY_ID_MAP?.get(normalizedId)
+        const routeEntry = routerPluginContext.routesByFile.get(normalizedId)
         if (!routeEntry) {
           return null
         }
@@ -97,7 +103,10 @@ export const unpluginRouterHmrFactory: UnpluginFactory<
     vite: {
       configResolved(config) {
         ROOT = config.root
-        userConfig = getConfig(options, ROOT)
+        userConfig = getConfig(
+          typeof options === 'function' ? options() : options,
+          ROOT,
+        )
       },
       applyToEnvironment(environment) {
         if (userConfig.plugin?.vite?.environmentName) {
@@ -107,4 +116,10 @@ export const unpluginRouterHmrFactory: UnpluginFactory<
       },
     },
   }
+}
+
+export const unpluginRouterHmrFactory: UnpluginFactory<
+  Partial<Config> | undefined
+> = (options = {}) => {
+  return createRouterHmrPlugin(options, defaultRouterPluginContext)
 }

--- a/packages/router-plugin/src/core/router-hmr-plugin.ts
+++ b/packages/router-plugin/src/core/router-hmr-plugin.ts
@@ -4,7 +4,7 @@ import { getReferenceRouteCompilerPlugins } from './code-splitter/plugins/framew
 import { createRouteHmrStatement } from './hmr'
 import { debug, normalizePath } from './utils'
 import { getConfig } from './config'
-import { defaultRouterPluginContext } from './router-plugin-context'
+import { createRouterPluginContext } from './router-plugin-context'
 import type { UnpluginFactory } from 'unplugin'
 import type { Config } from './config'
 import type { RouterPluginContext } from './router-plugin-context'
@@ -26,9 +26,12 @@ export function createRouterHmrPlugin(
   routerPluginContext: RouterPluginContext,
 ): ReturnType<UnpluginFactory<Partial<Config> | undefined>> {
   let ROOT: string = process.cwd()
-  let userConfig = (
-    typeof options === 'function' ? options() : options
-  ) as Config
+
+  const resolveUserConfig = () => {
+    return getConfig(typeof options === 'function' ? options() : options, ROOT)
+  }
+
+  let userConfig = resolveUserConfig()
 
   return {
     name: 'tanstack-router:hmr',
@@ -103,10 +106,7 @@ export function createRouterHmrPlugin(
     vite: {
       configResolved(config) {
         ROOT = config.root
-        userConfig = getConfig(
-          typeof options === 'function' ? options() : options,
-          ROOT,
-        )
+        userConfig = resolveUserConfig()
       },
       applyToEnvironment(environment) {
         if (userConfig.plugin?.vite?.environmentName) {
@@ -121,5 +121,5 @@ export function createRouterHmrPlugin(
 export const unpluginRouterHmrFactory: UnpluginFactory<
   Partial<Config> | undefined
 > = (options = {}) => {
-  return createRouterHmrPlugin(options, defaultRouterPluginContext)
+  return createRouterHmrPlugin(options, createRouterPluginContext())
 }

--- a/packages/router-plugin/src/core/router-plugin-context.ts
+++ b/packages/router-plugin/src/core/router-plugin-context.ts
@@ -9,5 +9,3 @@ export function createRouterPluginContext(): RouterPluginContext {
     routesByFile: new Map(),
   }
 }
-
-export const defaultRouterPluginContext = createRouterPluginContext()

--- a/packages/router-plugin/src/core/router-plugin-context.ts
+++ b/packages/router-plugin/src/core/router-plugin-context.ts
@@ -1,0 +1,13 @@
+import type { GetRoutesByFileMapResult } from '@tanstack/router-generator'
+
+export type RouterPluginContext = {
+  routesByFile: GetRoutesByFileMapResult
+}
+
+export function createRouterPluginContext(): RouterPluginContext {
+  return {
+    routesByFile: new Map(),
+  }
+}
+
+export const defaultRouterPluginContext = createRouterPluginContext()

--- a/packages/router-plugin/src/esbuild.ts
+++ b/packages/router-plugin/src/esbuild.ts
@@ -11,6 +11,8 @@ import type { RouterPluginContext } from './core/router-plugin-context'
 
 type RouterPluginOptions = Partial<Config | (() => Config)> | undefined
 
+const defaultRouterPluginContext = createRouterPluginContext()
+
 /**
  * @example
  * ```ts
@@ -24,7 +26,7 @@ const TanStackRouterGeneratorEsbuild = (
   options?: RouterPluginOptions,
   routerPluginContext?: RouterPluginContext,
 ) => {
-  const pluginContext = routerPluginContext ?? createRouterPluginContext()
+  const pluginContext = routerPluginContext ?? defaultRouterPluginContext
   return createEsbuildPlugin((pluginOptions: RouterPluginOptions) =>
     createRouterGeneratorPlugin(pluginOptions, pluginContext),
   )(options)
@@ -43,7 +45,7 @@ const TanStackRouterCodeSplitterEsbuild = (
   options?: RouterPluginOptions,
   routerPluginContext?: RouterPluginContext,
 ) => {
-  const pluginContext = routerPluginContext ?? createRouterPluginContext()
+  const pluginContext = routerPluginContext ?? defaultRouterPluginContext
   return createEsbuildPlugin((pluginOptions: RouterPluginOptions) =>
     createRouterCodeSplitterPlugin(pluginOptions, pluginContext),
   )(options)

--- a/packages/router-plugin/src/esbuild.ts
+++ b/packages/router-plugin/src/esbuild.ts
@@ -1,11 +1,15 @@
 import { createEsbuildPlugin } from 'unplugin'
 
 import { configSchema } from './core/config'
-import { unpluginRouterCodeSplitterFactory } from './core/router-code-splitter-plugin'
-import { unpluginRouterGeneratorFactory } from './core/router-generator-plugin'
+import { createRouterCodeSplitterPlugin } from './core/router-code-splitter-plugin'
+import { createRouterGeneratorPlugin } from './core/router-generator-plugin'
 import { unpluginRouterComposedFactory } from './core/router-composed-plugin'
+import { defaultRouterPluginContext } from './core/router-plugin-context'
 
 import type { CodeSplittingOptions, Config } from './core/config'
+import type { RouterPluginContext } from './core/router-plugin-context'
+
+type RouterPluginOptions = Partial<Config | (() => Config)> | undefined
 
 /**
  * @example
@@ -16,9 +20,14 @@ import type { CodeSplittingOptions, Config } from './core/config'
  * }
  * ```
  */
-const TanStackRouterGeneratorEsbuild = createEsbuildPlugin(
-  unpluginRouterGeneratorFactory,
-)
+const TanStackRouterGeneratorEsbuild = (
+  options?: RouterPluginOptions,
+  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+) => {
+  return createEsbuildPlugin((pluginOptions: RouterPluginOptions) =>
+    createRouterGeneratorPlugin(pluginOptions, routerPluginContext),
+  )(options)
+}
 
 /**
  * @example
@@ -29,9 +38,14 @@ const TanStackRouterGeneratorEsbuild = createEsbuildPlugin(
  * }
  * ```
  */
-const TanStackRouterCodeSplitterEsbuild = createEsbuildPlugin(
-  unpluginRouterCodeSplitterFactory,
-)
+const TanStackRouterCodeSplitterEsbuild = (
+  options?: RouterPluginOptions,
+  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+) => {
+  return createEsbuildPlugin((pluginOptions: RouterPluginOptions) =>
+    createRouterCodeSplitterPlugin(pluginOptions, routerPluginContext),
+  )(options)
+}
 
 /**
  * @example
@@ -54,4 +68,4 @@ export {
   tanstackRouter,
 }
 
-export type { Config, CodeSplittingOptions }
+export type { Config, CodeSplittingOptions, RouterPluginContext }

--- a/packages/router-plugin/src/esbuild.ts
+++ b/packages/router-plugin/src/esbuild.ts
@@ -4,7 +4,7 @@ import { configSchema } from './core/config'
 import { createRouterCodeSplitterPlugin } from './core/router-code-splitter-plugin'
 import { createRouterGeneratorPlugin } from './core/router-generator-plugin'
 import { unpluginRouterComposedFactory } from './core/router-composed-plugin'
-import { defaultRouterPluginContext } from './core/router-plugin-context'
+import { createRouterPluginContext } from './core/router-plugin-context'
 
 import type { CodeSplittingOptions, Config } from './core/config'
 import type { RouterPluginContext } from './core/router-plugin-context'
@@ -22,10 +22,11 @@ type RouterPluginOptions = Partial<Config | (() => Config)> | undefined
  */
 const TanStackRouterGeneratorEsbuild = (
   options?: RouterPluginOptions,
-  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+  routerPluginContext?: RouterPluginContext,
 ) => {
+  const pluginContext = routerPluginContext ?? createRouterPluginContext()
   return createEsbuildPlugin((pluginOptions: RouterPluginOptions) =>
-    createRouterGeneratorPlugin(pluginOptions, routerPluginContext),
+    createRouterGeneratorPlugin(pluginOptions, pluginContext),
   )(options)
 }
 
@@ -40,10 +41,11 @@ const TanStackRouterGeneratorEsbuild = (
  */
 const TanStackRouterCodeSplitterEsbuild = (
   options?: RouterPluginOptions,
-  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+  routerPluginContext?: RouterPluginContext,
 ) => {
+  const pluginContext = routerPluginContext ?? createRouterPluginContext()
   return createEsbuildPlugin((pluginOptions: RouterPluginOptions) =>
-    createRouterCodeSplitterPlugin(pluginOptions, routerPluginContext),
+    createRouterCodeSplitterPlugin(pluginOptions, pluginContext),
   )(options)
 }
 

--- a/packages/router-plugin/src/global.d.ts
+++ b/packages/router-plugin/src/global.d.ts
@@ -1,7 +1,0 @@
-/* eslint-disable no-var */
-import type { GetRoutesByFileMapResult } from '@tanstack/router-generator'
-
-declare global {
-  var TSR_ROUTES_BY_ID_MAP: GetRoutesByFileMapResult | undefined
-}
-export {}

--- a/packages/router-plugin/src/index.ts
+++ b/packages/router-plugin/src/index.ts
@@ -1,6 +1,7 @@
 export { configSchema, getConfig } from './core/config'
 export { unpluginRouterCodeSplitterFactory } from './core/router-code-splitter-plugin'
 export { unpluginRouterGeneratorFactory } from './core/router-generator-plugin'
+export { createRouterPluginContext } from './core/router-plugin-context'
 export type {
   Config,
   ConfigInput,
@@ -9,6 +10,7 @@ export type {
   DeletableNodes,
   HmrOptions,
 } from './core/config'
+export type { RouterPluginContext } from './core/router-plugin-context'
 export {
   tsrSplit,
   splitRouteIdentNodes,

--- a/packages/router-plugin/src/rspack.ts
+++ b/packages/router-plugin/src/rspack.ts
@@ -10,6 +10,8 @@ import type { RouterPluginContext } from './core/router-plugin-context'
 
 type RspackRouterPluginOptions = Partial<Config> | (() => Partial<Config>)
 
+const defaultRouterPluginContext = createRouterPluginContext()
+
 /**
  * Rspack uses webpack-compatible `module.hot` / `import.meta.webpackHot` HMR.
  * Force `plugin.hmr.style = 'webpack'` so the router HMR adapter emits
@@ -56,7 +58,7 @@ const TanStackRouterGeneratorRspack = (
   options?: RspackRouterPluginOptions,
   routerPluginContext?: RouterPluginContext,
 ) => {
-  const pluginContext = routerPluginContext ?? createRouterPluginContext()
+  const pluginContext = routerPluginContext ?? defaultRouterPluginContext
   return createRspackPlugin((pluginOptions) =>
     createRouterGeneratorPlugin(
       pluginOptions as Partial<Config | (() => Config)> | undefined,
@@ -82,7 +84,7 @@ const TanStackRouterCodeSplitterRspack = (
   options?: RspackRouterPluginOptions,
   routerPluginContext?: RouterPluginContext,
 ) => {
-  const pluginContext = routerPluginContext ?? createRouterPluginContext()
+  const pluginContext = routerPluginContext ?? defaultRouterPluginContext
   return createRspackPlugin((pluginOptions) =>
     createRouterCodeSplitterPlugin(
       withWebpackHmrStyle(

--- a/packages/router-plugin/src/rspack.ts
+++ b/packages/router-plugin/src/rspack.ts
@@ -1,10 +1,12 @@
 import { createRspackPlugin } from 'unplugin'
 
 import { configSchema } from './core/config'
-import { unpluginRouterCodeSplitterFactory } from './core/router-code-splitter-plugin'
-import { unpluginRouterGeneratorFactory } from './core/router-generator-plugin'
+import { createRouterCodeSplitterPlugin } from './core/router-code-splitter-plugin'
+import { createRouterGeneratorPlugin } from './core/router-generator-plugin'
 import { unpluginRouterComposedFactory } from './core/router-composed-plugin'
+import { defaultRouterPluginContext } from './core/router-plugin-context'
 import type { CodeSplittingOptions, Config } from './core/config'
+import type { RouterPluginContext } from './core/router-plugin-context'
 
 type RspackRouterPluginOptions = Partial<Config> | (() => Partial<Config>)
 
@@ -50,9 +52,17 @@ function withWebpackHmrStyle(
  * })
  * ```
  */
-const TanStackRouterGeneratorRspack = /* #__PURE__ */ createRspackPlugin(
-  unpluginRouterGeneratorFactory,
-)
+const TanStackRouterGeneratorRspack = (
+  options?: RspackRouterPluginOptions,
+  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+) => {
+  return createRspackPlugin((pluginOptions) =>
+    createRouterGeneratorPlugin(
+      pluginOptions as Partial<Config | (() => Config)> | undefined,
+      routerPluginContext,
+    ),
+  )(options)
+}
 
 /**
  * @example
@@ -67,15 +77,19 @@ const TanStackRouterGeneratorRspack = /* #__PURE__ */ createRspackPlugin(
  * })
  * ```
  */
-const TanStackRouterCodeSplitterRspack = /* #__PURE__ */ createRspackPlugin(
-  (options, meta) =>
-    unpluginRouterCodeSplitterFactory(
+const TanStackRouterCodeSplitterRspack = (
+  options?: RspackRouterPluginOptions,
+  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+) => {
+  return createRspackPlugin((pluginOptions) =>
+    createRouterCodeSplitterPlugin(
       withWebpackHmrStyle(
-        options as RspackRouterPluginOptions | undefined,
+        pluginOptions as RspackRouterPluginOptions | undefined,
       ) as Partial<Config | (() => Config)>,
-      meta,
+      routerPluginContext,
     ),
-)
+  )(options)
+}
 
 /**
  * @example
@@ -108,4 +122,4 @@ export {
   TanStackRouterCodeSplitterRspack,
   tanstackRouter,
 }
-export type { Config, CodeSplittingOptions }
+export type { Config, CodeSplittingOptions, RouterPluginContext }

--- a/packages/router-plugin/src/rspack.ts
+++ b/packages/router-plugin/src/rspack.ts
@@ -4,7 +4,7 @@ import { configSchema } from './core/config'
 import { createRouterCodeSplitterPlugin } from './core/router-code-splitter-plugin'
 import { createRouterGeneratorPlugin } from './core/router-generator-plugin'
 import { unpluginRouterComposedFactory } from './core/router-composed-plugin'
-import { defaultRouterPluginContext } from './core/router-plugin-context'
+import { createRouterPluginContext } from './core/router-plugin-context'
 import type { CodeSplittingOptions, Config } from './core/config'
 import type { RouterPluginContext } from './core/router-plugin-context'
 
@@ -54,12 +54,13 @@ function withWebpackHmrStyle(
  */
 const TanStackRouterGeneratorRspack = (
   options?: RspackRouterPluginOptions,
-  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+  routerPluginContext?: RouterPluginContext,
 ) => {
+  const pluginContext = routerPluginContext ?? createRouterPluginContext()
   return createRspackPlugin((pluginOptions) =>
     createRouterGeneratorPlugin(
       pluginOptions as Partial<Config | (() => Config)> | undefined,
-      routerPluginContext,
+      pluginContext,
     ),
   )(options)
 }
@@ -79,14 +80,15 @@ const TanStackRouterGeneratorRspack = (
  */
 const TanStackRouterCodeSplitterRspack = (
   options?: RspackRouterPluginOptions,
-  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+  routerPluginContext?: RouterPluginContext,
 ) => {
+  const pluginContext = routerPluginContext ?? createRouterPluginContext()
   return createRspackPlugin((pluginOptions) =>
     createRouterCodeSplitterPlugin(
       withWebpackHmrStyle(
         pluginOptions as RspackRouterPluginOptions | undefined,
       ) as Partial<Config | (() => Config)>,
-      routerPluginContext,
+      pluginContext,
     ),
   )(options)
 }

--- a/packages/router-plugin/src/vite.ts
+++ b/packages/router-plugin/src/vite.ts
@@ -4,7 +4,7 @@ import { configSchema, getConfig } from './core/config'
 import { createRouterCodeSplitterPlugin } from './core/router-code-splitter-plugin'
 import { createRouterGeneratorPlugin } from './core/router-generator-plugin'
 import { unpluginRouterComposedFactory } from './core/router-composed-plugin'
-import { defaultRouterPluginContext } from './core/router-plugin-context'
+import { createRouterPluginContext } from './core/router-plugin-context'
 import type { CodeSplittingOptions, Config } from './core/config'
 import type { RouterPluginContext } from './core/router-plugin-context'
 
@@ -21,10 +21,11 @@ type RouterPluginOptions = Partial<Config | (() => Config)> | undefined
  */
 const tanstackRouterGenerator = (
   options?: RouterPluginOptions,
-  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+  routerPluginContext?: RouterPluginContext,
 ) => {
+  const pluginContext = routerPluginContext ?? createRouterPluginContext()
   return createVitePlugin((pluginOptions: RouterPluginOptions) =>
-    createRouterGeneratorPlugin(pluginOptions, routerPluginContext),
+    createRouterGeneratorPlugin(pluginOptions, pluginContext),
   )(options)
 }
 
@@ -39,10 +40,11 @@ const tanstackRouterGenerator = (
  */
 const tanStackRouterCodeSplitter = (
   options?: RouterPluginOptions,
-  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+  routerPluginContext?: RouterPluginContext,
 ) => {
+  const pluginContext = routerPluginContext ?? createRouterPluginContext()
   return createVitePlugin((pluginOptions: RouterPluginOptions) =>
-    createRouterCodeSplitterPlugin(pluginOptions, routerPluginContext),
+    createRouterCodeSplitterPlugin(pluginOptions, pluginContext),
   )(options)
 }
 

--- a/packages/router-plugin/src/vite.ts
+++ b/packages/router-plugin/src/vite.ts
@@ -10,6 +10,8 @@ import type { RouterPluginContext } from './core/router-plugin-context'
 
 type RouterPluginOptions = Partial<Config | (() => Config)> | undefined
 
+const defaultRouterPluginContext = createRouterPluginContext()
+
 /**
  * @example
  * ```ts
@@ -23,7 +25,7 @@ const tanstackRouterGenerator = (
   options?: RouterPluginOptions,
   routerPluginContext?: RouterPluginContext,
 ) => {
-  const pluginContext = routerPluginContext ?? createRouterPluginContext()
+  const pluginContext = routerPluginContext ?? defaultRouterPluginContext
   return createVitePlugin((pluginOptions: RouterPluginOptions) =>
     createRouterGeneratorPlugin(pluginOptions, pluginContext),
   )(options)
@@ -42,7 +44,7 @@ const tanStackRouterCodeSplitter = (
   options?: RouterPluginOptions,
   routerPluginContext?: RouterPluginContext,
 ) => {
-  const pluginContext = routerPluginContext ?? createRouterPluginContext()
+  const pluginContext = routerPluginContext ?? defaultRouterPluginContext
   return createVitePlugin((pluginOptions: RouterPluginOptions) =>
     createRouterCodeSplitterPlugin(pluginOptions, pluginContext),
   )(options)

--- a/packages/router-plugin/src/vite.ts
+++ b/packages/router-plugin/src/vite.ts
@@ -1,10 +1,14 @@
 import { createVitePlugin } from 'unplugin'
 
-import { configSchema } from './core/config'
-import { unpluginRouterCodeSplitterFactory } from './core/router-code-splitter-plugin'
-import { unpluginRouterGeneratorFactory } from './core/router-generator-plugin'
+import { configSchema, getConfig } from './core/config'
+import { createRouterCodeSplitterPlugin } from './core/router-code-splitter-plugin'
+import { createRouterGeneratorPlugin } from './core/router-generator-plugin'
 import { unpluginRouterComposedFactory } from './core/router-composed-plugin'
-import type { CodeSplittingOptions, Config, getConfig } from './core/config'
+import { defaultRouterPluginContext } from './core/router-plugin-context'
+import type { CodeSplittingOptions, Config } from './core/config'
+import type { RouterPluginContext } from './core/router-plugin-context'
+
+type RouterPluginOptions = Partial<Config | (() => Config)> | undefined
 
 /**
  * @example
@@ -15,7 +19,14 @@ import type { CodeSplittingOptions, Config, getConfig } from './core/config'
  * })
  * ```
  */
-const tanstackRouterGenerator = createVitePlugin(unpluginRouterGeneratorFactory)
+const tanstackRouterGenerator = (
+  options?: RouterPluginOptions,
+  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+) => {
+  return createVitePlugin((pluginOptions: RouterPluginOptions) =>
+    createRouterGeneratorPlugin(pluginOptions, routerPluginContext),
+  )(options)
+}
 
 /**
  * @example
@@ -26,9 +37,14 @@ const tanstackRouterGenerator = createVitePlugin(unpluginRouterGeneratorFactory)
  * })
  * ```
  */
-const tanStackRouterCodeSplitter = createVitePlugin(
-  unpluginRouterCodeSplitterFactory,
-)
+const tanStackRouterCodeSplitter = (
+  options?: RouterPluginOptions,
+  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+) => {
+  return createVitePlugin((pluginOptions: RouterPluginOptions) =>
+    createRouterCodeSplitterPlugin(pluginOptions, routerPluginContext),
+  )(options)
+}
 
 /**
  * @example
@@ -56,4 +72,4 @@ export {
   tanstackRouter,
 }
 
-export type { Config, CodeSplittingOptions }
+export type { Config, CodeSplittingOptions, RouterPluginContext }

--- a/packages/router-plugin/src/webpack.ts
+++ b/packages/router-plugin/src/webpack.ts
@@ -8,6 +8,8 @@ import { createRouterPluginContext } from './core/router-plugin-context'
 import type { CodeSplittingOptions, Config } from './core/config'
 import type { RouterPluginContext } from './core/router-plugin-context'
 
+const defaultRouterPluginContext = createRouterPluginContext()
+
 /**
  * Webpack uses `module.hot` / `import.meta.webpackHot` HMR. Force
  * `plugin.hmr.style = 'webpack'` so the router HMR adapter emits the correct
@@ -41,7 +43,7 @@ const TanStackRouterGeneratorWebpack = (
   options?: Partial<Config>,
   routerPluginContext?: RouterPluginContext,
 ) => {
-  const pluginContext = routerPluginContext ?? createRouterPluginContext()
+  const pluginContext = routerPluginContext ?? defaultRouterPluginContext
   return createWebpackPlugin((pluginOptions: Partial<Config> | undefined) =>
     createRouterGeneratorPlugin(pluginOptions, pluginContext),
   )(options)
@@ -60,7 +62,7 @@ const TanStackRouterCodeSplitterWebpack = (
   options?: Partial<Config>,
   routerPluginContext?: RouterPluginContext,
 ) => {
-  const pluginContext = routerPluginContext ?? createRouterPluginContext()
+  const pluginContext = routerPluginContext ?? defaultRouterPluginContext
   return createWebpackPlugin((pluginOptions: Partial<Config> | undefined) =>
     createRouterCodeSplitterPlugin(
       withWebpackHmrStyle(pluginOptions),

--- a/packages/router-plugin/src/webpack.ts
+++ b/packages/router-plugin/src/webpack.ts
@@ -1,10 +1,12 @@
 import { createWebpackPlugin } from 'unplugin'
 
 import { configSchema } from './core/config'
-import { unpluginRouterCodeSplitterFactory } from './core/router-code-splitter-plugin'
-import { unpluginRouterGeneratorFactory } from './core/router-generator-plugin'
+import { createRouterCodeSplitterPlugin } from './core/router-code-splitter-plugin'
+import { createRouterGeneratorPlugin } from './core/router-generator-plugin'
 import { unpluginRouterComposedFactory } from './core/router-composed-plugin'
+import { defaultRouterPluginContext } from './core/router-plugin-context'
 import type { CodeSplittingOptions, Config } from './core/config'
+import type { RouterPluginContext } from './core/router-plugin-context'
 
 /**
  * Webpack uses `module.hot` / `import.meta.webpackHot` HMR. Force
@@ -35,9 +37,14 @@ function withWebpackHmrStyle(
  * }
  * ```
  */
-const TanStackRouterGeneratorWebpack = /* #__PURE__ */ createWebpackPlugin(
-  unpluginRouterGeneratorFactory,
-)
+const TanStackRouterGeneratorWebpack = (
+  options?: Partial<Config>,
+  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+) => {
+  return createWebpackPlugin((pluginOptions: Partial<Config> | undefined) =>
+    createRouterGeneratorPlugin(pluginOptions, routerPluginContext),
+  )(options)
+}
 
 /**
  * @example
@@ -48,13 +55,17 @@ const TanStackRouterGeneratorWebpack = /* #__PURE__ */ createWebpackPlugin(
  * }
  * ```
  */
-const TanStackRouterCodeSplitterWebpack = /* #__PURE__ */ createWebpackPlugin(
-  (options, meta) =>
-    unpluginRouterCodeSplitterFactory(
-      withWebpackHmrStyle(options as Partial<Config> | undefined),
-      meta,
+const TanStackRouterCodeSplitterWebpack = (
+  options?: Partial<Config>,
+  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+) => {
+  return createWebpackPlugin((pluginOptions: Partial<Config> | undefined) =>
+    createRouterCodeSplitterPlugin(
+      withWebpackHmrStyle(pluginOptions),
+      routerPluginContext,
     ),
-)
+  )(options)
+}
 
 /**
  * @example
@@ -82,4 +93,4 @@ export {
   TanStackRouterCodeSplitterWebpack,
   tanstackRouter,
 }
-export type { Config, CodeSplittingOptions }
+export type { Config, CodeSplittingOptions, RouterPluginContext }

--- a/packages/router-plugin/src/webpack.ts
+++ b/packages/router-plugin/src/webpack.ts
@@ -4,7 +4,7 @@ import { configSchema } from './core/config'
 import { createRouterCodeSplitterPlugin } from './core/router-code-splitter-plugin'
 import { createRouterGeneratorPlugin } from './core/router-generator-plugin'
 import { unpluginRouterComposedFactory } from './core/router-composed-plugin'
-import { defaultRouterPluginContext } from './core/router-plugin-context'
+import { createRouterPluginContext } from './core/router-plugin-context'
 import type { CodeSplittingOptions, Config } from './core/config'
 import type { RouterPluginContext } from './core/router-plugin-context'
 
@@ -39,10 +39,11 @@ function withWebpackHmrStyle(
  */
 const TanStackRouterGeneratorWebpack = (
   options?: Partial<Config>,
-  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+  routerPluginContext?: RouterPluginContext,
 ) => {
+  const pluginContext = routerPluginContext ?? createRouterPluginContext()
   return createWebpackPlugin((pluginOptions: Partial<Config> | undefined) =>
-    createRouterGeneratorPlugin(pluginOptions, routerPluginContext),
+    createRouterGeneratorPlugin(pluginOptions, pluginContext),
   )(options)
 }
 
@@ -57,12 +58,13 @@ const TanStackRouterGeneratorWebpack = (
  */
 const TanStackRouterCodeSplitterWebpack = (
   options?: Partial<Config>,
-  routerPluginContext: RouterPluginContext = defaultRouterPluginContext,
+  routerPluginContext?: RouterPluginContext,
 ) => {
+  const pluginContext = routerPluginContext ?? createRouterPluginContext()
   return createWebpackPlugin((pluginOptions: Partial<Config> | undefined) =>
     createRouterCodeSplitterPlugin(
       withWebpackHmrStyle(pluginOptions),
-      routerPluginContext,
+      pluginContext,
     ),
   )(options)
 }

--- a/packages/router-plugin/tests/router-plugin-context.test.ts
+++ b/packages/router-plugin/tests/router-plugin-context.test.ts
@@ -1,0 +1,147 @@
+import path from 'node:path'
+import * as t from '@babel/types'
+import { describe, expect, it } from 'vitest'
+import { parseAst } from '@tanstack/router-utils'
+import { createRouterCodeSplitterPlugin } from '../src/core/router-code-splitter-plugin'
+import { createRouterPluginContext } from '../src/core/router-plugin-context'
+import { normalizePath } from '../src/core/utils'
+import type { Config } from '../src/core/config'
+import type { UnpluginOptions, TransformResult } from 'unplugin'
+
+const referencePluginName =
+  'tanstack-router:code-splitter:compile-reference-file'
+
+function getReferencePlugin(
+  plugins: ReturnType<typeof createRouterCodeSplitterPlugin>,
+): UnpluginOptions {
+  const pluginArray = Array.isArray(plugins) ? plugins : [plugins]
+  const plugin = pluginArray.find((item) => item.name === referencePluginName)
+  if (!plugin) {
+    throw new Error('Reference code-splitter plugin not found')
+  }
+  return plugin
+}
+
+async function configurePlugin(plugin: UnpluginOptions) {
+  const hook = plugin.vite?.configResolved
+  if (!hook) {
+    return
+  }
+
+  const config = {
+    root: process.cwd(),
+    plugins: [{ name: referencePluginName }],
+  } as never
+
+  if (typeof hook === 'function') {
+    await hook.call({} as never, config)
+    return
+  }
+
+  await hook.handler.call({} as never, config)
+}
+
+async function transformReferenceRoute(
+  plugin: UnpluginOptions,
+  code: string,
+  id: string,
+): Promise<TransformResult | null | undefined> {
+  const transform = plugin.transform
+  if (!transform || typeof transform === 'function') {
+    throw new Error('Expected object transform')
+  }
+  return transform.handler.call({} as never, code, id)
+}
+
+function getCode(result: TransformResult | null | undefined) {
+  if (!result) {
+    return null
+  }
+  if (typeof result === 'string') {
+    return result
+  }
+  return result.code
+}
+
+function countProgramHotDeclarations(code: string) {
+  const ast = parseAst({ code })
+  return ast.program.body.filter((statement) => {
+    return (
+      t.isVariableDeclaration(statement) &&
+      statement.declarations.some((declaration) => {
+        return t.isIdentifier(declaration.id) && declaration.id.name === 'hot'
+      })
+    )
+  }).length
+}
+
+describe('router plugin context', () => {
+  it('keeps multiple code-splitter instances isolated by explicit context', async () => {
+    const routeFile = normalizePath(
+      path.join(process.cwd(), 'src/routes-a/owned.tsx'),
+    )
+    const otherRouteFile = normalizePath(
+      path.join(process.cwd(), 'src/routes-b/other.tsx'),
+    )
+
+    const routeCode = `
+import { createFileRoute } from '@tanstack/react-router'
+
+function Component() {
+  return <div>Hello</div>
+}
+
+export const Route = createFileRoute('/owned')({
+  component: Component,
+})
+`
+
+    const contextA = createRouterPluginContext()
+    contextA.routesByFile.set(routeFile, { routeId: '/owned' })
+
+    const contextB = createRouterPluginContext()
+    contextB.routesByFile.set(otherRouteFile, { routeId: '/other' })
+
+    const configA = {
+      target: 'react',
+      routesDirectory: './src/routes-a',
+      generatedRouteTree: './src/routeTree-a.gen.ts',
+      autoCodeSplitting: true,
+    } satisfies Partial<Config>
+
+    const configB = {
+      target: 'react',
+      routesDirectory: './src/routes-b',
+      generatedRouteTree: './src/routeTree-b.gen.ts',
+      autoCodeSplitting: true,
+    } satisfies Partial<Config>
+
+    const splitterA = getReferencePlugin(
+      createRouterCodeSplitterPlugin(configA, contextA),
+    )
+    const splitterB = getReferencePlugin(
+      createRouterCodeSplitterPlugin(configB, contextB),
+    )
+
+    await configurePlugin(splitterA)
+    await configurePlugin(splitterB)
+
+    const firstResult = await transformReferenceRoute(
+      splitterA,
+      routeCode,
+      routeFile,
+    )
+    const firstCode = getCode(firstResult)
+
+    expect(firstCode).not.toBeNull()
+    expect(countProgramHotDeclarations(firstCode!)).toBe(1)
+
+    const secondResult = await transformReferenceRoute(
+      splitterB,
+      firstCode!,
+      routeFile,
+    )
+
+    expect(secondResult).toBeNull()
+  })
+})

--- a/packages/router-plugin/tests/router-plugin-context.test.ts
+++ b/packages/router-plugin/tests/router-plugin-context.test.ts
@@ -3,6 +3,7 @@ import * as t from '@babel/types'
 import { describe, expect, it } from 'vitest'
 import { parseAst } from '@tanstack/router-utils'
 import { createRouterCodeSplitterPlugin } from '../src/core/router-code-splitter-plugin'
+import { createRouterHmrPlugin } from '../src/core/router-hmr-plugin'
 import { createRouterPluginContext } from '../src/core/router-plugin-context'
 import { normalizePath } from '../src/core/utils'
 import type { Config } from '../src/core/config'
@@ -143,5 +144,38 @@ export const Route = createFileRoute('/owned')({
     )
 
     expect(secondResult).toBeNull()
+  })
+
+  it('normalizes HMR options before the first transform', async () => {
+    const routeFile = normalizePath(
+      path.join(process.cwd(), 'src/routes/owned.tsx'),
+    )
+
+    const routeCode = `
+import { createFileRoute } from '@tanstack/react-router'
+
+function Component() {
+  return <div>Hello</div>
+}
+
+export const Route = createFileRoute('/owned')({
+  component: Component,
+})
+`
+
+    const context = createRouterPluginContext()
+    context.routesByFile.set(routeFile, { routeId: '/owned' })
+
+    const hmrPlugin = createRouterHmrPlugin({}, context)
+    const hmrResult = await transformReferenceRoute(
+      Array.isArray(hmrPlugin) ? hmrPlugin[0]! : hmrPlugin,
+      routeCode,
+      routeFile,
+    )
+
+    const hmrCode = getCode(hmrResult)
+
+    expect(hmrCode).not.toBeNull()
+    expect(hmrCode).toContain('TSRFastRefreshAnchor')
   })
 })

--- a/packages/router-plugin/vite.config.ts
+++ b/packages/router-plugin/vite.config.ts
@@ -17,6 +17,7 @@ export default mergeConfig(
     tsconfigPath: './tsconfig.build.json',
     entry: [
       './src/index.ts',
+      './src/context.ts',
       './src/vite.ts',
       './src/rspack.ts',
       './src/webpack.ts',

--- a/packages/start-plugin-core/src/rsbuild/start-router-plugin.ts
+++ b/packages/start-plugin-core/src/rsbuild/start-router-plugin.ts
@@ -1,4 +1,9 @@
 import path from 'pathe'
+import { createRouterPluginContext } from '@tanstack/router-plugin/context'
+import {
+  TanStackRouterCodeSplitterRspack,
+  TanStackRouterGeneratorRspack,
+} from '@tanstack/router-plugin/rspack'
 import { routesManifestPlugin } from '../start-router-plugin/generator-plugins/routes-manifest-plugin'
 import { prerenderRoutesPlugin } from '../start-router-plugin/generator-plugins/prerender-routes-plugin'
 import { buildRouteTreeFileFooterFromConfig } from '../start-router-plugin/route-tree-footer'
@@ -14,8 +19,6 @@ import type { TanStackStartRsbuildInputConfig } from './schema'
  * The router-plugin package exports rspack-compatible unplugin wrappers:
  * - TanStackRouterGeneratorRspack: file-based route generation
  * - TanStackRouterCodeSplitterRspack: route code splitting
- *
- * These are dynamically imported to avoid hard dependency on router-plugin/rspack.
  */
 export function registerRouterPlugins(
   api: RsbuildPluginAPI,
@@ -25,17 +28,17 @@ export function registerRouterPlugins(
     startPluginOpts: TanStackStartRsbuildInputConfig
   },
 ): void {
-  api.modifyRspackConfig(async (config, utils) => {
+  const routerPluginContext = createRouterPluginContext()
+
+  api.modifyRspackConfig((config, utils) => {
     const envName = utils.environment.name
     const { startConfig } = opts.getConfig()
     const routerConfig = startConfig.router
 
     // Generator only runs once — register for the client environment
     if (envName === RSBUILD_ENVIRONMENT_NAMES.client) {
-      try {
-        const { TanStackRouterGeneratorRspack } =
-          await import('@tanstack/router-plugin/rspack')
-        const generatorPlugin = TanStackRouterGeneratorRspack({
+      const generatorPlugin = TanStackRouterGeneratorRspack(
+        {
           ...routerConfig,
           target: opts.corePluginOpts.framework,
           routeTreeFileFooter: () => {
@@ -53,11 +56,10 @@ export function registerRouterPlugins(
               ? [prerenderRoutesPlugin()]
               : []),
           ],
-        })
-        utils.appendPlugins(generatorPlugin as any)
-      } catch {
-        // router-plugin/rspack not available — skip
-      }
+        },
+        routerPluginContext,
+      )
+      utils.appendPlugins(generatorPlugin as any)
     }
 
     if (
@@ -65,10 +67,8 @@ export function registerRouterPlugins(
       envName === RSBUILD_ENVIRONMENT_NAMES.server
     ) {
       const isClient = envName === RSBUILD_ENVIRONMENT_NAMES.client
-      try {
-        const { TanStackRouterCodeSplitterRspack } =
-          await import('@tanstack/router-plugin/rspack')
-        const splitterPlugin = TanStackRouterCodeSplitterRspack({
+      const splitterPlugin = TanStackRouterCodeSplitterRspack(
+        {
           ...routerConfig,
           target: opts.corePluginOpts.framework,
           codeSplittingOptions: {
@@ -76,11 +76,10 @@ export function registerRouterPlugins(
             deleteNodes: isClient ? ['ssr', 'server', 'headers'] : undefined,
             addHmr: isClient,
           },
-        })
-        utils.appendPlugins(splitterPlugin as any)
-      } catch {
-        // router-plugin/rspack not available — skip
-      }
+        },
+        routerPluginContext,
+      )
+      utils.appendPlugins(splitterPlugin as any)
     }
   })
 }

--- a/packages/start-plugin-core/src/vite/start-router-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-router-plugin/plugin.ts
@@ -1,3 +1,4 @@
+import { createRouterPluginContext } from '@tanstack/router-plugin/context'
 import {
   tanStackRouterCodeSplitter,
   tanstackRouterGenerator,
@@ -35,6 +36,8 @@ export function tanStackStartRouter(
   getConfig: GetConfigFn,
   corePluginOpts: TanStackStartVitePluginCoreOptions,
 ): Array<PluginOption> {
+  const routerPluginContext = createRouterPluginContext()
+
   const getGeneratedRouteTreePath = () => {
     const { startConfig } = getConfig()
     return path.resolve(startConfig.router.generatedRouteTree)
@@ -153,7 +156,7 @@ export function tanStackStartRouter(
         routeTreeFileFooter: getRouteTreeFileFooter,
         plugins,
       }
-    }),
+    }, routerPluginContext),
     tanStackRouterCodeSplitter(() => {
       const routerConfig = getConfig().startConfig.router
       return {
@@ -167,7 +170,7 @@ export function tanStackStartRouter(
           vite: { environmentName: VITE_ENVIRONMENT_NAMES.client },
         },
       }
-    }),
+    }, routerPluginContext),
     tanStackRouterCodeSplitter(() => {
       const routerConfig = getConfig().startConfig.router
       return {
@@ -180,6 +183,6 @@ export function tanStackStartRouter(
           vite: { environmentName: VITE_ENVIRONMENT_NAMES.server },
         },
       }
-    }),
+    }, routerPluginContext),
   ]
 }


### PR DESCRIPTION
fixes #7174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit Router Plugin Context API (runtime + type) and new public export to access it.
  * Router plugins and platform wrappers can now accept an optional context to scope state per-instance.

* **Bug Fixes**
  * Eliminates cross-instance/global-state interference between router plugin instances.

* **Tests**
  * Added tests validating isolation and correct HMR behavior when using separate plugin contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->