### PR TITLE
docs(skills): address 8 agent failure modes from user feedback

### DIFF
--- a/docs/router/guide/authenticated-routes.md
+++ b/docs/router/guide/authenticated-routes.md
@@ -5,7 +5,7 @@ title: Authenticated Routes
 
 Authentication is an extremely common requirement for web applications. In this guide, we'll walk through how to use TanStack Router to build protected routes, and how to redirect users to login if they try to access them.
 
-> **A route guard does not protect a server function.** This guide shows how to gate a route's UI behind `beforeLoad`. If you also have a `createServerFn` that fetches sensitive data, the route guard does NOT stop a direct request to that RPC — server functions are reachable by POST regardless of which route renders them. Pair routing-side guards with **handler-level enforcement** (auth middleware or in-handler check). See [Authentication Server Primitives](/start/latest/docs/framework/react/guide/authentication-server-primitives) in the Start docs.
+> **A route guard does not protect a server function.** This guide shows how to gate a route's UI behind `beforeLoad`. If you also have a `createServerFn` that fetches sensitive data, the route guard does NOT stop a direct request to that RPC — server functions are reachable by POST regardless of which route renders them. Pair routing-side guards with **handler-level enforcement** (auth middleware or in-handler check). See [Authentication Server Primitives](../../start/framework/react/guide/authentication-server-primitives.md) in the Start docs.
 
 ## The `route.beforeLoad` Option
 

--- a/docs/router/guide/authenticated-routes.md
+++ b/docs/router/guide/authenticated-routes.md
@@ -5,6 +5,8 @@ title: Authenticated Routes
 
 Authentication is an extremely common requirement for web applications. In this guide, we'll walk through how to use TanStack Router to build protected routes, and how to redirect users to login if they try to access them.
 
+> **A route guard does not protect a server function.** This guide shows how to gate a route's UI behind `beforeLoad`. If you also have a `createServerFn` that fetches sensitive data, the route guard does NOT stop a direct request to that RPC — server functions are reachable by POST regardless of which route renders them. Pair routing-side guards with **handler-level enforcement** (auth middleware or in-handler check). See [Authentication Server Primitives](/start/latest/docs/framework/react/guide/authentication-server-primitives) in the Start docs.
+
 ## The `route.beforeLoad` Option
 
 The `route.beforeLoad` option allows you to specify a function that will be called before a route is loaded. It receives all of the same arguments that the `route.loader` function does. This is a great place to check if a user is authenticated, and redirect them to a login page if they are not.

--- a/docs/router/guide/ssr.md
+++ b/docs/router/guide/ssr.md
@@ -8,6 +8,8 @@ title: SSR
 
 Server Side Rendering (SSR) is the process of rendering a component on the server and sending the HTML markup to the client. The client then hydrates the markup into a fully interactive component.
 
+> **TanStack Router is not Next.js, Remix, or React Router DOM.** When generating routes or components, do **not** use `src/pages/`, `app/layout.tsx`, `_app/index.tsx`, `getServerSideProps`, `getStaticProps`, Remix-style `loader`/`action` exports, or imports from `react-router-dom` or `next/`. TanStack uses `src/routes/` with `createFileRoute`, `Link`/`useNavigate`/`redirect` from `@tanstack/react-router`, and (for Start) `createServerFn` from `@tanstack/<framework>-start`. Wrong-framework code typically fails to build or produces conflicting `/` routes at runtime.
+
 There are usually two different flavors of SSR to be considered:
 
 - Non-streaming SSR

--- a/docs/start/framework/react/guide/authentication-overview.md
+++ b/docs/start/framework/react/guide/authentication-overview.md
@@ -109,11 +109,11 @@ title: Authentication
 
 ### 🛠️ DIY Authentication
 
-Build your own authentication system using TanStack Start's server functions and session management:
+Build your own authentication system using TanStack Start's server functions and session management. Start with the [Authentication Server Primitives](./authentication-server-primitives.md) guide — it covers session cookies (`HttpOnly`/`Secure`/`SameSite`/`__Host-`), session lookup as middleware, OAuth `state` + PKCE, password-reset enumeration defense, CSRF, rate limiting, and session rotation, with the WRONG/CORRECT patterns that catch the common mistakes.
 
 - **Full Control**: Complete customization over authentication flow
-- **Server Functions**: Secure authentication logic on the server
-- **Session Management**: Built-in session handling with HTTP-only cookies
+- **Server Primitives**: Sessions, OAuth, CSRF, rate limiting — see [Authentication Server Primitives](./authentication-server-primitives.md)
+- **Session Management**: HTTP-only cookies via `setResponseHeader`, read with `getRequestHeader`
 - **Type Safety**: End-to-end type safety for authentication state
 
 ### 🌐 Other Excellent Options
@@ -226,6 +226,7 @@ Build your own authentication system using TanStack Start's server functions and
 
 **Implementation Guides:**
 
+- [Authentication Server Primitives](./authentication-server-primitives.md) — sessions, cookies, OAuth, CSRF, rate limiting (the server half)
 - [Authentication Patterns](./authentication.md)
 - [Router Authentication Guide](/router/latest/docs/framework/react/guide/authenticated-routes)
 

--- a/docs/start/framework/react/guide/authentication-server-primitives.md
+++ b/docs/start/framework/react/guide/authentication-server-primitives.md
@@ -68,14 +68,14 @@ export function readSessionToken(): string | null {
 }
 ```
 
-| Flag | Why |
-|---|---|
-| `HttpOnly` | JavaScript can't read the cookie. An XSS bug can't exfiltrate the session. |
-| `Secure` | HTTPS only. Required when using the `__Host-` prefix. |
-| `SameSite=Lax` | Sent on top-level navigations; blocks most cross-site CSRF on POST. Use `Strict` for higher-risk apps where loss of cross-site GET navigation is acceptable. |
-| `__Host-` prefix | Binds the cookie to the exact origin. No `Domain` attribute, `Path=/`, `Secure` required. Defeats subdomain-takeover session fixation. |
-| `Path=/` | Required by `__Host-`. |
-| `Max-Age` | Bounded lifetime. Pair with server-side rotation. |
+| Flag             | Why                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `HttpOnly`       | JavaScript can't read the cookie. An XSS bug can't exfiltrate the session.                                                                                   |
+| `Secure`         | HTTPS only. Required when using the `__Host-` prefix.                                                                                                        |
+| `SameSite=Lax`   | Sent on top-level navigations; blocks most cross-site CSRF on POST. Use `Strict` for higher-risk apps where loss of cross-site GET navigation is acceptable. |
+| `__Host-` prefix | Binds the cookie to the exact origin. No `Domain` attribute, `Path=/`, `Secure` required. Defeats subdomain-takeover session fixation.                       |
+| `Path=/`         | Required by `__Host-`.                                                                                                                                       |
+| `Max-Age`        | Bounded lifetime. Pair with server-side rotation.                                                                                                            |
 
 ## Session Lookup as Middleware
 
@@ -273,7 +273,11 @@ A login endpoint without rate limiting is a credential-stuffing target. Limit pe
 import { createMiddleware } from '@tanstack/react-start'
 import { getRequest } from '@tanstack/react-start/server'
 
-function rateLimitMiddleware(opts: { key: string; max: number; windowMs: number }) {
+function rateLimitMiddleware(opts: {
+  key: string
+  max: number
+  windowMs: number
+}) {
   return createMiddleware().server(async ({ next }) => {
     const request = getRequest()
     const ip =
@@ -290,9 +294,10 @@ function rateLimitMiddleware(opts: { key: string; max: number; windowMs: number 
   })
 }
 
-export const login = createServerFn({ method: 'POST' })
-  .middleware([rateLimitMiddleware({ key: 'login', max: 5, windowMs: 60_000 })])
-  // ...
+export const login = createServerFn({ method: 'POST' }).middleware([
+  rateLimitMiddleware({ key: 'login', max: 5, windowMs: 60_000 }),
+])
+// ...
 ```
 
 ## Session Rotation

--- a/docs/start/framework/react/guide/authentication-server-primitives.md
+++ b/docs/start/framework/react/guide/authentication-server-primitives.md
@@ -1,0 +1,342 @@
+---
+id: authentication-server-primitives
+title: Authentication Server Primitives
+---
+
+This guide covers the **server-side primitives** for building authentication in TanStack Start: session cookies, session lookup, OAuth, password-reset hardening, CSRF, and rate limiting. It pairs with the [routing-side guide](../../../router/guide/authenticated-routes.md) (`_authenticated` layout, `beforeLoad`, redirects, RBAC).
+
+If you can use a managed solution like [Clerk](https://go.clerk.com/wOwHtuJ) or [WorkOS](https://workos.com/), prefer that — they handle most of what this guide describes. Read on if you're rolling your own.
+
+## The Two Halves of Auth
+
+Authentication has a routing half and a server half. They both need to be implemented; either one alone is incomplete.
+
+- **Routing half** (`router-core/auth-and-guards`): redirect unauthenticated users away from protected pages, gate UI on roles/permissions, surface a login form.
+- **Server half** (this guide): issue and verify session cookies, exchange OAuth codes, hash and verify passwords, rate-limit credential endpoints, defeat user enumeration.
+
+> **A route guard does NOT protect a `createServerFn` on that route.** Server functions are RPC endpoints — they're reachable via direct POST regardless of which route renders them. Auth must be enforced on the handler (or via middleware), not on the calling route.
+
+## Session Cookies
+
+The default session storage is an HTTP-only cookie. The cookie can hold:
+
+- An **opaque session ID** that the server looks up in a database (recommended — easy to revoke).
+- A **signed/encrypted token** that carries the session payload itself (stateless, but revocation is harder).
+
+Whichever you choose, the cookie flags matter:
+
+```ts
+// src/server/session.ts
+import '@tanstack/react-start/server-only'
+import {
+  getRequestHeader,
+  setResponseHeader,
+} from '@tanstack/react-start/server'
+
+const SESSION_COOKIE = '__Host-session'
+const ONE_DAY = 60 * 60 * 24
+
+export function setSessionCookie(token: string) {
+  setResponseHeader(
+    'Set-Cookie',
+    [
+      `${SESSION_COOKIE}=${token}`,
+      `HttpOnly`,
+      `Secure`,
+      `SameSite=Lax`,
+      `Path=/`,
+      `Max-Age=${ONE_DAY}`,
+    ].join('; '),
+  )
+}
+
+export function clearSessionCookie() {
+  setResponseHeader(
+    'Set-Cookie',
+    `${SESSION_COOKIE}=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0`,
+  )
+}
+
+export function readSessionToken(): string | null {
+  const header = getRequestHeader('cookie')
+  if (!header) return null
+  for (const part of header.split(/;\s*/)) {
+    const [name, value] = part.split('=')
+    if (name === SESSION_COOKIE) return value ?? null
+  }
+  return null
+}
+```
+
+| Flag | Why |
+|---|---|
+| `HttpOnly` | JavaScript can't read the cookie. An XSS bug can't exfiltrate the session. |
+| `Secure` | HTTPS only. Required when using the `__Host-` prefix. |
+| `SameSite=Lax` | Sent on top-level navigations; blocks most cross-site CSRF on POST. Use `Strict` for higher-risk apps where loss of cross-site GET navigation is acceptable. |
+| `__Host-` prefix | Binds the cookie to the exact origin. No `Domain` attribute, `Path=/`, `Secure` required. Defeats subdomain-takeover session fixation. |
+| `Path=/` | Required by `__Host-`. |
+| `Max-Age` | Bounded lifetime. Pair with server-side rotation. |
+
+## Session Lookup as Middleware
+
+Centralize session loading in middleware so every protected handler sees a typed session:
+
+```ts
+// src/server/auth-middleware.ts
+import { createMiddleware } from '@tanstack/react-start'
+import { readSessionToken } from './session'
+
+export const authMiddleware = createMiddleware({ type: 'function' }).server(
+  async ({ next }) => {
+    const token = readSessionToken()
+    const session = token ? await db.sessions.findValid(token) : null
+    if (!session) throw new Error('Unauthorized')
+    return next({ context: { session } })
+  },
+)
+```
+
+Attach to every protected server function:
+
+```ts
+import { createServerFn } from '@tanstack/react-start'
+import { authMiddleware } from '~/server/auth-middleware'
+
+export const getMyOrders = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    return db.orders.findMany({ where: { userId: context.session.userId } })
+  })
+```
+
+## Login
+
+```ts
+// src/server/login.functions.ts
+import { createServerFn } from '@tanstack/react-start'
+import { z } from 'zod'
+import { setSessionCookie } from './session'
+
+export const login = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({ email: z.string().email(), password: z.string() }))
+  .handler(async ({ data }) => {
+    const user = await db.users.findByEmail(data.email)
+    const ok =
+      user != null &&
+      (await verifyPasswordHash(user.passwordHash, data.password))
+    if (!ok) throw new Error('Invalid email or password')
+
+    // Rotate: destroy any existing session, then issue fresh.
+    const token = await db.sessions.create({ userId: user.id })
+    setSessionCookie(token)
+    return { ok: true }
+  })
+```
+
+The `Invalid email or password` message is identical for "user not found" and "wrong password". Don't leak which one it was; the constant-time `verifyPasswordHash` should also keep the timing similar.
+
+## Logout
+
+```ts
+import { createServerFn } from '@tanstack/react-start'
+import { authMiddleware } from '~/server/auth-middleware'
+import { clearSessionCookie } from '~/server/session'
+
+export const logout = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    await db.sessions.revoke(context.session.id)
+    clearSessionCookie()
+    return { ok: true }
+  })
+```
+
+## OAuth: state + PKCE
+
+For OAuth authorization-code flow:
+
+- Generate a one-time random `state` parameter — prevents CSRF on the callback.
+- Generate a PKCE `code_verifier`/`code_challenge` pair — defends against authorization-code interception.
+- Store both in a short-lived signed cookie keyed to this exact attempt.
+
+```ts
+// src/server/oauth.functions.ts
+import { createServerFn } from '@tanstack/react-start'
+import { redirect } from '@tanstack/react-router'
+import { setResponseHeader } from '@tanstack/react-start/server'
+import crypto from 'node:crypto'
+
+const OAUTH_STATE_COOKIE = '__Host-oauth'
+
+function base64url(buf: Buffer) {
+  return buf
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+}
+
+export const startOAuth = createServerFn({ method: 'GET' }).handler(
+  async () => {
+    const state = base64url(crypto.randomBytes(32))
+    const verifier = base64url(crypto.randomBytes(32))
+    const challenge = base64url(
+      crypto.createHash('sha256').update(verifier).digest(),
+    )
+
+    setResponseHeader(
+      'Set-Cookie',
+      `${OAUTH_STATE_COOKIE}=${signed({ state, verifier })}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=600`,
+    )
+
+    throw redirect({
+      href:
+        `https://provider.example/authorize` +
+        `?response_type=code` +
+        `&client_id=${process.env.OAUTH_CLIENT_ID}` +
+        `&redirect_uri=${encodeURIComponent(process.env.OAUTH_REDIRECT_URI!)}` +
+        `&state=${state}` +
+        `&code_challenge=${challenge}` +
+        `&code_challenge_method=S256`,
+    })
+  },
+)
+```
+
+In the callback handler:
+
+1. Read the cookie, verify its signature, and extract `state` + `verifier`.
+2. Compare cookie-state to the `state` query param. If they don't match, abort.
+3. Exchange the authorization code for an access token, sending `code_verifier` along with it.
+4. Fetch the user profile, find/create the local user record, issue a session.
+5. Clear the OAuth cookie.
+
+If any of those checks fail, the request did not originate from your `startOAuth` and must be rejected.
+
+## Password Reset: defeat user enumeration
+
+The reset endpoint must NOT tell the caller whether a given email is registered. Returning 200 vs 404 — or even different copy — leaks user existence to anyone who can hit the endpoint.
+
+```ts
+import { createServerFn } from '@tanstack/react-start'
+import { z } from 'zod'
+
+export const requestPasswordReset = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({ email: z.string().email() }))
+  .handler(async ({ data }) => {
+    const user = await db.users.findByEmail(data.email)
+    if (user) {
+      const token = await db.passwordResets.issue(user.id)
+      await sendResetEmail(user.email, token)
+    }
+    // Same response, same body, regardless of existence.
+    return { ok: true }
+  })
+```
+
+Do NOT:
+
+- Return 200 if exists, 404 if not.
+- Vary the message ("we sent you a link" vs "no account found").
+- Skip the work when the user doesn't exist (timing leak — measurable from the wire).
+
+## CSRF for non-GET RPCs
+
+`SameSite=Lax` on the session cookie blocks most cross-site CSRF for POST/PUT/DELETE. Two cases need explicit defense:
+
+1. **GET-that-mutates** — never. Use POST/PUT/DELETE for any mutation.
+2. **POST from a sibling subdomain** — `SameSite=Lax` does not block this; verify the `Origin` header matches your app.
+
+```ts
+import { createMiddleware } from '@tanstack/react-start'
+import { getRequest } from '@tanstack/react-start/server'
+
+export const csrfMiddleware = createMiddleware().server(async ({ next }) => {
+  const request = getRequest()
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    const origin = request.headers.get('origin')
+    if (!origin || new URL(origin).host !== process.env.APP_HOST) {
+      throw new Error('Origin check failed')
+    }
+  }
+  return next()
+})
+```
+
+Attach this in `src/start.ts` global `requestMiddleware` so it runs on every non-GET request, including server routes and SSR.
+
+## Rate Limiting Auth Endpoints
+
+A login endpoint without rate limiting is a credential-stuffing target. Limit per IP (and per-account if you can identify the user) with a sliding window or token bucket.
+
+```ts
+import { createMiddleware } from '@tanstack/react-start'
+import { getRequest } from '@tanstack/react-start/server'
+
+function rateLimitMiddleware(opts: { key: string; max: number; windowMs: number }) {
+  return createMiddleware().server(async ({ next }) => {
+    const request = getRequest()
+    const ip =
+      request.headers.get('cf-connecting-ip') ??
+      request.headers.get('x-forwarded-for')?.split(',')[0] ??
+      'unknown'
+    const allowed = await rateLimiter.consume(
+      `rl:${opts.key}:${ip}`,
+      opts.max,
+      opts.windowMs,
+    )
+    if (!allowed) throw new Error('Too many requests')
+    return next()
+  })
+}
+
+export const login = createServerFn({ method: 'POST' })
+  .middleware([rateLimitMiddleware({ key: 'login', max: 5, windowMs: 60_000 })])
+  // ...
+```
+
+## Session Rotation
+
+Whenever the user's privileges change — login, logout, password change, role grant — destroy the old session and issue a new one. This neutralizes session-fixation attacks where an attacker plants their own session ID in the victim's browser before the privilege change.
+
+```ts
+// On login: revoke any pre-login session, create fresh.
+const token = await db.sessions.create({ userId: user.id })
+setSessionCookie(token)
+
+// On password change / role grant:
+await db.sessions.revokeAllForUser(user.id)
+const token = await db.sessions.create({ userId: user.id })
+setSessionCookie(token)
+```
+
+## Read Cookies and Env Per Request, Not at Module Scope
+
+Module-scope reads are wrong on two axes:
+
+- **Security:** they can be inlined into the client bundle.
+- **Correctness on edge runtimes:** Cloudflare Workers (and others) inject env at request time. Module-level reads run before any request exists and evaluate to `undefined` even on the server.
+
+```ts
+// ❌ Wrong
+const SESSION_SECRET = process.env.SESSION_SECRET
+export function signSession(payload) {
+  return sign(payload, SESSION_SECRET)
+}
+
+// ✅ Right
+export function signSession(payload) {
+  return sign(payload, process.env.SESSION_SECRET)
+}
+```
+
+See [Execution Model: Module-Level `process.env` Reads](./execution-model.md#module-level-processenv-reads) for the full rule.
+
+## See Also
+
+- [Authentication Overview](./authentication-overview.md) — choosing between partner solutions, OSS libraries, and DIY.
+- [Authenticated Routes (Router)](../../../router/guide/authenticated-routes.md) — the routing-side guide.
+- [Server Functions](./server-functions.md) — the RPC primitive that auth lives inside.
+- [Middleware](./middleware.md) — composing `authMiddleware`.
+- [OWASP Cheat Sheets — Authentication](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html), [Session Management](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html), [CSRF](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).
+- [MDN — Set-Cookie](https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie).

--- a/docs/start/framework/react/guide/authentication-server-primitives.md
+++ b/docs/start/framework/react/guide/authentication-server-primitives.md
@@ -27,7 +27,6 @@ Whichever you choose, the cookie flags matter:
 
 ```ts
 // src/server/session.ts
-import '@tanstack/react-start/server-only'
 import {
   getRequestHeader,
   setResponseHeader,

--- a/docs/start/framework/react/guide/authentication-server-primitives.md
+++ b/docs/start/framework/react/guide/authentication-server-primitives.md
@@ -256,7 +256,9 @@ export const csrfMiddleware = createMiddleware().server(async ({ next }) => {
   const request = getRequest()
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     const origin = request.headers.get('origin')
-    if (!origin || new URL(origin).host !== process.env.APP_HOST) {
+    // Compare the FULL origin (scheme + host + port) — host alone lets
+    // http://example.com pass a check meant for https://example.com.
+    if (!origin || new URL(origin).origin !== process.env.APP_ORIGIN) {
       throw new Error('Origin check failed')
     }
   }

--- a/docs/start/framework/react/guide/authentication-server-primitives.md
+++ b/docs/start/framework/react/guide/authentication-server-primitives.md
@@ -3,7 +3,7 @@ id: authentication-server-primitives
 title: Authentication Server Primitives
 ---
 
-This guide covers the **server-side primitives** for building authentication in TanStack Start: session cookies, session lookup, OAuth, password-reset hardening, CSRF, and rate limiting. It pairs with the [routing-side guide](../../../router/guide/authenticated-routes.md) (`_authenticated` layout, `beforeLoad`, redirects, RBAC).
+This guide covers the **server-side primitives** for building authentication in TanStack Start: session cookies, session lookup, OAuth, password-reset hardening, CSRF, and rate limiting. It pairs with the [routing-side guide](../../../../router/guide/authenticated-routes.md) (`_authenticated` layout, `beforeLoad`, redirects, RBAC).
 
 If you can use a managed solution like [Clerk](https://go.clerk.com/wOwHtuJ) or [WorkOS](https://workos.com/), prefer that — they handle most of what this guide describes. Read on if you're rolling your own.
 
@@ -127,6 +127,7 @@ export const login = createServerFn({ method: 'POST' })
     if (!ok) throw new Error('Invalid email or password')
 
     // Rotate: destroy any existing session, then issue fresh.
+    await db.sessions.revokeAllForUser(user.id)
     const token = await db.sessions.create({ userId: user.id })
     setSessionCookie(token)
     return { ok: true }
@@ -306,6 +307,7 @@ Whenever the user's privileges change — login, logout, password change, role g
 
 ```ts
 // On login: revoke any pre-login session, create fresh.
+await db.sessions.revokeAllForUser(user.id)
 const token = await db.sessions.create({ userId: user.id })
 setSessionCookie(token)
 
@@ -340,7 +342,7 @@ See [Execution Model: Module-Level `process.env` Reads](./execution-model.md#mod
 ## See Also
 
 - [Authentication Overview](./authentication-overview.md) — choosing between partner solutions, OSS libraries, and DIY.
-- [Authenticated Routes (Router)](../../../router/guide/authenticated-routes.md) — the routing-side guide.
+- [Authenticated Routes (Router)](../../../../router/guide/authenticated-routes.md) — the routing-side guide.
 - [Server Functions](./server-functions.md) — the RPC primitive that auth lives inside.
 - [Middleware](./middleware.md) — composing `authMiddleware`.
 - [OWASP Cheat Sheets — Authentication](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html), [Session Management](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html), [CSRF](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).

--- a/docs/start/framework/react/guide/authentication-server-primitives.md
+++ b/docs/start/framework/react/guide/authentication-server-primitives.md
@@ -61,8 +61,10 @@ export function readSessionToken(): string | null {
   const header = getRequestHeader('cookie')
   if (!header) return null
   for (const part of header.split(/;\s*/)) {
-    const [name, value] = part.split('=')
-    if (name === SESSION_COOKIE) return value ?? null
+    // Split only on the FIRST '=' — signed/base64 values often contain '='.
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    if (part.slice(0, eq) === SESSION_COOKIE) return part.slice(eq + 1)
   }
   return null
 }
@@ -121,9 +123,13 @@ export const login = createServerFn({ method: 'POST' })
   .inputValidator(z.object({ email: z.string().email(), password: z.string() }))
   .handler(async ({ data }) => {
     const user = await db.users.findByEmail(data.email)
-    const ok =
-      user != null &&
-      (await verifyPasswordHash(user.passwordHash, data.password))
+    // Always run verifyPasswordHash — even when the user doesn't exist —
+    // so the user-not-found branch takes the same time as wrong-password.
+    // DUMMY_PASSWORD_HASH is a hash of any throwaway password computed once
+    // at startup with the same algorithm/cost as real password hashes.
+    const hashToCheck = user?.passwordHash ?? DUMMY_PASSWORD_HASH
+    const passwordMatches = await verifyPasswordHash(hashToCheck, data.password)
+    const ok = user != null && passwordMatches
     if (!ok) throw new Error('Invalid email or password')
 
     // Rotate: destroy any existing session, then issue fresh.
@@ -134,7 +140,7 @@ export const login = createServerFn({ method: 'POST' })
   })
 ```
 
-The `Invalid email or password` message is identical for "user not found" and "wrong password". Don't leak which one it was; the constant-time `verifyPasswordHash` should also keep the timing similar.
+The `Invalid email or password` message is identical for "user not found" and "wrong password". The dummy-hash technique above also makes the timing identical: without it, the no-user branch returns instantly while the wrong-password branch spends ~100ms on the hash compare, leaking account existence over the wire.
 
 ## Logout
 

--- a/docs/start/framework/react/guide/environment-variables.md
+++ b/docs/start/framework/react/guide/environment-variables.md
@@ -5,6 +5,8 @@ title: Environment Variables
 
 Learn how to securely configure and use environment variables in your TanStack Start application across different contexts (server functions, client code, and build processes).
 
+> **Read env per-request, not at module scope.** On Cloudflare Workers and other edge SSR runtimes, env vars are injected at request time — module-level `process.env.X` reads run before the env exists and evaluate to `undefined` even on the server. Always read `process.env` inside `.handler()`, middleware `.server()`, server-route handlers, or other per-request callbacks. Reading at module scope also risks inlining secrets into the client bundle.
+
 ## Quick Start
 
 TanStack Start automatically loads `.env` files and makes variables available in both server and client contexts with proper security boundaries.
@@ -294,9 +296,17 @@ const clientEnvSchema = z.object({
 })
 
 // Validate server environment
+// NOTE: Module-level parse runs at module load. Fine for Node.js;
+// on Cloudflare Workers (and other edge runtimes) `process.env` is
+// empty at module load, so wrap this in a function and call it
+// inside `.handler()` instead:
+//
+//   export const getServerEnv = () => envSchema.parse(process.env)
+//
+// Then read `getServerEnv()` per-request from server functions/middleware.
 export const serverEnv = envSchema.parse(process.env)
 
-// Validate client environment
+// Validate client environment (build-time, always safe)
 export const clientEnv = clientEnvSchema.parse(import.meta.env)
 ```
 

--- a/docs/start/framework/react/guide/environment-variables.md
+++ b/docs/start/framework/react/guide/environment-variables.md
@@ -5,7 +5,7 @@ title: Environment Variables
 
 Learn how to securely configure and use environment variables in your TanStack Start application across different contexts (server functions, client code, and build processes).
 
-> **Read env per-request, not at module scope.** On Cloudflare Workers and other edge SSR runtimes, env vars are injected at request time — module-level `process.env.X` reads run before the env exists and evaluate to `undefined` even on the server. Always read `process.env` inside `.handler()`, middleware `.server()`, server-route handlers, or other per-request callbacks. Reading at module scope also risks inlining secrets into the client bundle.
+> **Read env per-request, not at module scope.** On Cloudflare Workers and other edge SSR runtimes, env vars are injected at request time — module-level `process.env.X` reads run before the env exists and evaluate to `undefined` even on the server. Always read `process.env` inside `.handler()`, middleware `.server()`, server-route handlers, or other per-request callbacks. Reading at module scope also risks inlining secrets into the client bundle. (On Cloudflare Workers specifically, the canonical way to read env from anywhere — including module scope — is the [`cloudflare:workers` env binding](https://developers.cloudflare.com/workers/configuration/environment-variables/).)
 
 ## Quick Start
 

--- a/docs/start/framework/react/guide/execution-model.md
+++ b/docs/start/framework/react/guide/execution-model.md
@@ -194,14 +194,25 @@ const secret = getSecret() // ❌ Throws error
 
 ## Common Anti-Patterns
 
-### Environment Variable Exposure
+### Module-Level `process.env` Reads
+
+Reading `process.env` at module scope is wrong for **two** reasons, not one:
+
+1. **Security:** the value can be inlined into the client bundle.
+2. **Runtime correctness:** on Cloudflare Workers and other edge SSR runtimes, env is injected per-request. Module-level code runs at module load, before the env exists, so the read evaluates to `undefined` even on the server.
 
 ```tsx
-// ❌ Exposes to client bundle
+// ❌ Leaks to client AND is undefined under Worker SSR
 const apiKey = process.env.SECRET_KEY
 
-// ✅ Server-only access
+// ✅ Wrap in a server-only function — read happens per call, on the server
 const apiKey = createServerOnlyFn(() => process.env.SECRET_KEY)
+
+// ✅ Or read directly inside `.handler()` / middleware `.server()` / server-route handlers
+const fetchData = createServerFn().handler(async () => {
+  const apiKey = process.env.SECRET_KEY
+  // ...
+})
 ```
 
 ### Incorrect Loader Assumptions
@@ -264,6 +275,30 @@ const logMessage = createIsomorphicFn()
   .server((msg) => console.log(`[SERVER]: ${msg}`))
   .client((msg) => console.log(`[CLIENT]: ${msg}`))
 ```
+
+## Marking Whole Files Server- or Client-Only
+
+The `.server.*` and `.client.*` filename suffixes opt a file into Start's import protection automatically. When you can't or don't want to rename the file, achieve the same effect with a side-effect import at the top:
+
+```ts
+// src/lib/secrets.ts (filename can't be *.server.ts)
+import '@tanstack/react-start/server-only'
+
+export function getApiKey() {
+  return process.env.API_KEY
+}
+```
+
+```ts
+// src/lib/storage.ts
+import '@tanstack/react-start/client-only'
+
+export function savePreferences(prefs: Record<string, string>) {
+  localStorage.setItem('prefs', JSON.stringify(prefs))
+}
+```
+
+Use the framework-scoped path that matches your stack: `@tanstack/solid-start/...`, `@tanstack/vue-start/...`. Both markers in the same file is an error. Type-only imports are ignored. See the [Import Protection guide](./import-protection.md) for the full reference, including dev vs build behavior, configuring deny rules, and reading violation traces.
 
 ## Architecture Decision Framework
 

--- a/docs/start/framework/react/guide/execution-model.md
+++ b/docs/start/framework/react/guide/execution-model.md
@@ -298,7 +298,7 @@ export function savePreferences(prefs: Record<string, string>) {
 }
 ```
 
-Use the framework-scoped path that matches your stack: `@tanstack/solid-start/...`, `@tanstack/vue-start/...`. Both markers in the same file is an error. Type-only imports are ignored. See the [Import Protection guide](./import-protection.md) for the full reference, including dev vs build behavior, configuring deny rules, and reading violation traces.
+Both markers in the same file is an error. Type-only imports are ignored. See the [Import Protection guide](./import-protection.md) for the full reference, including dev vs build behavior, configuring deny rules, and reading violation traces.
 
 ## Architecture Decision Framework
 

--- a/docs/start/framework/react/guide/hosting.md
+++ b/docs/start/framework/react/guide/hosting.md
@@ -114,26 +114,6 @@ Deploy your application to Cloudflare Workers using their one-click deployment p
 
 A full TanStack Start example for Cloudflare Workers is available [here](https://github.com/TanStack/router/tree/main/examples/react/start-basic-cloudflare).
 
-#### Reading environment variables on Workers
-
-Cloudflare Workers inject environment variables at request time, not at module load. This has one important consequence: `process.env.X` at the top of a file evaluates to `undefined` even on the server. Always read env inside a per-request callback — `.handler()`, middleware `.server()`, server-route handlers, etc.
-
-```tsx
-// ❌ Wrong — runs at module load, before the env exists. `apiKey` is `undefined` under Worker SSR.
-const apiKey = process.env.API_KEY
-const fetchData = createServerFn().handler(async () => {
-  return fetch(url, { headers: { Authorization: apiKey } })
-})
-
-// ✅ Correct — read per-request inside the handler
-const fetchData = createServerFn().handler(async () => {
-  const apiKey = process.env.API_KEY
-  return fetch(url, { headers: { Authorization: apiKey } })
-})
-```
-
-The same rule applies to other edge SSR runtimes. See the [Environment Variables guide](./environment-variables.md) for the full picture.
-
 ### Netlify ⭐ _Official Partner_
 
 <a href="https://www.netlify.com?utm_source=tanstack" alt="Netlify Logo">

--- a/docs/start/framework/react/guide/hosting.md
+++ b/docs/start/framework/react/guide/hosting.md
@@ -114,6 +114,26 @@ Deploy your application to Cloudflare Workers using their one-click deployment p
 
 A full TanStack Start example for Cloudflare Workers is available [here](https://github.com/TanStack/router/tree/main/examples/react/start-basic-cloudflare).
 
+#### Reading environment variables on Workers
+
+Cloudflare Workers inject environment variables at request time, not at module load. This has one important consequence: `process.env.X` at the top of a file evaluates to `undefined` even on the server. Always read env inside a per-request callback — `.handler()`, middleware `.server()`, server-route handlers, etc.
+
+```tsx
+// ❌ Wrong — runs at module load, before the env exists. `apiKey` is `undefined` under Worker SSR.
+const apiKey = process.env.API_KEY
+const fetchData = createServerFn().handler(async () => {
+  return fetch(url, { headers: { Authorization: apiKey } })
+})
+
+// ✅ Correct — read per-request inside the handler
+const fetchData = createServerFn().handler(async () => {
+  const apiKey = process.env.API_KEY
+  return fetch(url, { headers: { Authorization: apiKey } })
+})
+```
+
+The same rule applies to other edge SSR runtimes. See the [Environment Variables guide](./environment-variables.md) for the full picture.
+
 ### Netlify ⭐ _Official Partner_
 
 <a href="https://www.netlify.com?utm_source=tanstack" alt="Netlify Logo">

--- a/docs/start/framework/react/guide/middleware.md
+++ b/docs/start/framework/react/guide/middleware.md
@@ -350,7 +350,7 @@ const requestLogger = createMiddleware({ type: 'function' })
 
 You may have noticed that in the example above while client-sent context is type-safe, it is not required to be validated at runtime. If you pass dynamic user-generated data via context, that could pose a security concern, so **if you are sending dynamic data from the client to the server via context, you should validate it in the server-side middleware before using it.**
 
-> **Shape validation is not authorization.** A parsed UUID/number is a *well-formed* identifier, not an *authorized* one. If the value is going to be used as a query key, filter, or path parameter — anything that selects which row(s) get read or written — you must also verify the session principal has access to it. Otherwise a logged-in user can rewrite the value in their own request and walk other tenants' data.
+> **Shape validation is not authorization.** A parsed UUID/number is a _well-formed_ identifier, not an _authorized_ one. If the value is going to be used as a query key, filter, or path parameter — anything that selects which row(s) get read or written — you must also verify the session principal has access to it. Otherwise a logged-in user can rewrite the value in their own request and walk other tenants' data.
 
 ```tsx
 import { createMiddleware } from '@tanstack/react-start'

--- a/docs/start/framework/react/guide/middleware.md
+++ b/docs/start/framework/react/guide/middleware.md
@@ -7,6 +7,8 @@ title: Middleware
 
 Middleware allows you to customize the behavior of both server routes like GET/POST/etc (including requests to SSR your application) and server functions created with `createServerFn`. Middleware is composable and can even depend on other middleware to create a chain of operations that are executed hierarchically and in order.
 
+> **Import path**: `createMiddleware` (and `createStart`) are exported from `@tanstack/<framework>-start` (for example `@tanstack/react-start`). They are **not** exported from `@tanstack/react-router`, and there is no `@tanstack/start` package — wrong paths fail at runtime with `createMiddleware is not a function`.
+
 ### What kinds of things can I do with Middleware?
 
 - **Authentication**: Verify a user's identity before executing a server function.
@@ -348,9 +350,10 @@ const requestLogger = createMiddleware({ type: 'function' })
 
 You may have noticed that in the example above while client-sent context is type-safe, it is not required to be validated at runtime. If you pass dynamic user-generated data via context, that could pose a security concern, so **if you are sending dynamic data from the client to the server via context, you should validate it in the server-side middleware before using it.**
 
+> **Shape validation is not authorization.** A parsed UUID/number is a *well-formed* identifier, not an *authorized* one. If the value is going to be used as a query key, filter, or path parameter — anything that selects which row(s) get read or written — you must also verify the session principal has access to it. Otherwise a logged-in user can rewrite the value in their own request and walk other tenants' data.
+
 ```tsx
 import { createMiddleware } from '@tanstack/react-start'
-import { zodValidator } from '@tanstack/zod-adapter'
 import { z } from 'zod'
 
 const requestLogger = createMiddleware({ type: 'function' })
@@ -361,13 +364,22 @@ const requestLogger = createMiddleware({ type: 'function' })
       },
     })
   })
-  .server(async ({ next, data, context }) => {
-    // Validate the workspace ID before using it
-    const workspaceId = zodValidator(z.number()).parse(context.workspaceId)
-    console.log('Workspace ID:', workspaceId)
-    return next()
+  .middleware([authMiddleware]) // session loaded server-side, NOT from sendContext
+  .server(async ({ next, context }) => {
+    // 1. Validate shape
+    const workspaceId = z.string().uuid().parse(context.workspaceId)
+    // 2. Validate access — does this session principal have membership?
+    const member = await db.memberships.find({
+      userId: context.session.userId,
+      workspaceId,
+    })
+    if (!member) throw new Error('Not a member of this workspace')
+    // 3. Now safe to use as a query key.
+    return next({ context: { workspaceId } })
   })
 ```
+
+Always derive the session itself from a server-trusted source (a cookie + DB lookup in `authMiddleware`), never from `sendContext`. Anything the client can send, the client can lie about.
 
 ### Sending Server Context to the Client
 
@@ -766,6 +778,8 @@ Static middlewares are created once and reused across routes. A middleware facto
 **Authentication (Static Base Middleware) Example:**
 
 This middleware validates the session and injects it into `context` for downstream middlewares.
+
+> **Attach `authMiddleware` to every `createServerFn` that needs auth.** A route `beforeLoad` redirect protects the page experience but does NOT protect the RPC — server functions are reachable via direct POST regardless of which route renders them. Pair routing-side guards with handler-level enforcement here. See [Authentication Server Primitives](./authentication-server-primitives.md).
 
 ```tsx
 // middleware.ts

--- a/docs/start/framework/react/guide/middleware.md
+++ b/docs/start/framework/react/guide/middleware.md
@@ -7,7 +7,7 @@ title: Middleware
 
 Middleware allows you to customize the behavior of both server routes like GET/POST/etc (including requests to SSR your application) and server functions created with `createServerFn`. Middleware is composable and can even depend on other middleware to create a chain of operations that are executed hierarchically and in order.
 
-> **Import path**: `createMiddleware` (and `createStart`) are exported from `@tanstack/<framework>-start` (for example `@tanstack/react-start`). They are **not** exported from `@tanstack/react-router`, and there is no `@tanstack/start` package — wrong paths fail at runtime with `createMiddleware is not a function`.
+> **Import path**: `createMiddleware` (and `createStart`) are exported from `@tanstack/react-start`. They are **not** exported from `@tanstack/react-router`, and there is no `@tanstack/start` package — wrong paths fail at runtime with `createMiddleware is not a function`.
 
 ### What kinds of things can I do with Middleware?
 

--- a/docs/start/framework/react/guide/middleware.md
+++ b/docs/start/framework/react/guide/middleware.md
@@ -7,8 +7,6 @@ title: Middleware
 
 Middleware allows you to customize the behavior of both server routes like GET/POST/etc (including requests to SSR your application) and server functions created with `createServerFn`. Middleware is composable and can even depend on other middleware to create a chain of operations that are executed hierarchically and in order.
 
-> **Import path**: `createMiddleware` (and `createStart`) are exported from `@tanstack/react-start`. They are **not** exported from `@tanstack/react-router`, and there is no `@tanstack/start` package — wrong paths fail at runtime with `createMiddleware is not a function`.
-
 ### What kinds of things can I do with Middleware?
 
 - **Authentication**: Verify a user's identity before executing a server function.

--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -7,6 +7,8 @@ title: Server Functions
 
 Server functions let you define server-only logic that can be called from anywhere in your application - loaders, components, hooks, or other server functions. They run on the server but can be invoked from client code seamlessly.
 
+> **Import path**: `createServerFn` is exported from `@tanstack/<framework>-start` (for example `@tanstack/react-start`, `@tanstack/solid-start`, `@tanstack/vue-start`). It is **not** exported from `@tanstack/react-router`, and there is no `@tanstack/start` package — both common wrong paths fail at runtime with `createServerFn is not a function`.
+
 ```tsx
 import { createServerFn } from '@tanstack/react-start'
 
@@ -272,26 +274,44 @@ import {
   setResponseStatus,
 } from '@tanstack/react-start/server'
 
-export const getCachedData = createServerFn({ method: 'GET' }).handler(
+// Public, non-personalized data — safe to cache shared across users.
+export const getPublicData = createServerFn({ method: 'GET' }).handler(
   async () => {
-    // Access the incoming request
-    const request = getRequest()
-    const authHeader = getRequestHeader('Authorization')
-
-    // Set response headers (e.g., for caching)
     setResponseHeaders(
       new Headers({
+        // 'public' is correct ONLY when the response does not depend on identity.
+        // For anything tied to a session/user/tenant, see the authenticated example below.
         'Cache-Control': 'public, max-age=300',
         'CDN-Cache-Control': 'max-age=3600, stale-while-revalidate=600',
       }),
     )
-
-    // Optionally set status code
     setResponseStatus(200)
-
-    return fetchData()
+    return fetchPublicData()
   },
 )
+```
+
+> **Cache-Control safety:** `public` tells every CDN/proxy between you and the user that the response can be served to anyone. If the handler reads a session, cookie, or auth header — or branches on identity at all — using `public` will cache one user's response and replay it to the next user (cross-tenant data leak). For authenticated responses, use `private`:
+
+```tsx
+// Authenticated data — must NOT be 'public'.
+export const getMyOrders = createServerFn({ method: 'GET' }).handler(
+  async () => {
+    const session = await requireSession()
+    setResponseHeaders(
+      new Headers({
+        // 'private' = only the user-agent may cache. Vary by Cookie/Authorization
+        // so any intermediary that does cache keys by identity, not URL alone.
+        'Cache-Control': 'private, max-age=60',
+        Vary: 'Cookie, Authorization',
+      }),
+    )
+    return db.orders.findMany({ where: { userId: session.userId } })
+  },
+)
+
+// For sensitive data, opt out entirely:
+// setResponseHeaders(new Headers({ 'Cache-Control': 'no-store' }))
 ```
 
 Available utilities:
@@ -317,6 +337,8 @@ Use server functions without JavaScript by leveraging the `.url` property with H
 ### Middleware
 
 Compose server functions with middleware for authentication, logging, and shared logic. See the [Middleware guide](./middleware.md).
+
+> **Auth must be enforced on the server function, not the route.** A `createServerFn` is an RPC endpoint reachable by direct POST regardless of which route renders the calling UI — a route `beforeLoad` redirect protects the page experience, but it does not stop a request from hitting the RPC directly. Apply `authMiddleware` (or an equivalent in-handler check) to every server function that needs auth. See [Authentication Server Primitives](./authentication-server-primitives.md).
 
 ### Static Server Functions
 

--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -7,7 +7,7 @@ title: Server Functions
 
 Server functions let you define server-only logic that can be called from anywhere in your application - loaders, components, hooks, or other server functions. They run on the server but can be invoked from client code seamlessly.
 
-> **Import path**: `createServerFn` is exported from `@tanstack/<framework>-start` (for example `@tanstack/react-start`, `@tanstack/solid-start`, `@tanstack/vue-start`). It is **not** exported from `@tanstack/react-router`, and there is no `@tanstack/start` package — both common wrong paths fail at runtime with `createServerFn is not a function`.
+> **Import path**: `createServerFn` is exported from `@tanstack/react-start`. It is **not** exported from `@tanstack/react-router`, and there is no `@tanstack/start` package — both common wrong paths fail at runtime with `createServerFn is not a function`.
 
 ```tsx
 import { createServerFn } from '@tanstack/react-start'

--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -7,8 +7,6 @@ title: Server Functions
 
 Server functions let you define server-only logic that can be called from anywhere in your application - loaders, components, hooks, or other server functions. They run on the server but can be invoked from client code seamlessly.
 
-> **Import path**: `createServerFn` is exported from `@tanstack/react-start`. It is **not** exported from `@tanstack/react-router`, and there is no `@tanstack/start` package — both common wrong paths fail at runtime with `createServerFn is not a function`.
-
 ```tsx
 import { createServerFn } from '@tanstack/react-start'
 

--- a/packages/router-core/skills/router-core/auth-and-guards/SKILL.md
+++ b/packages/router-core/skills/router-core/auth-and-guards/SKILL.md
@@ -22,7 +22,7 @@ sources:
 # Auth and Guards
 
 > **This skill covers the routing side of auth.** For the **server-side primitives** — session cookies (`HttpOnly`/`Secure`/`SameSite`), `useSession`-style helpers, OAuth `state` + PKCE, password-reset enumeration defense, CSRF, rate limiting — see [start-core/auth-server-primitives](../../../../start-client-core/skills/start-core/auth-server-primitives/SKILL.md). The two skills are designed to be used together.
-
+>
 > **CRITICAL**: A route guard (`beforeLoad`) does NOT protect a `createServerFn` declared on that route. Server functions are RPC endpoints reachable by direct POST regardless of which route renders them. See "Route guards do not protect server functions" below.
 
 ## Setup

--- a/packages/router-core/skills/router-core/auth-and-guards/SKILL.md
+++ b/packages/router-core/skills/router-core/auth-and-guards/SKILL.md
@@ -21,6 +21,10 @@ sources:
 
 # Auth and Guards
 
+> **This skill covers the routing side of auth.** For the **server-side primitives** — session cookies (`HttpOnly`/`Secure`/`SameSite`), `useSession`-style helpers, OAuth `state` + PKCE, password-reset enumeration defense, CSRF, rate limiting — see [start-core/auth-server-primitives](../../../../start-client-core/skills/start-core/auth-server-primitives/SKILL.md). The two skills are designed to be used together.
+
+> **CRITICAL**: A route guard (`beforeLoad`) does NOT protect a `createServerFn` declared on that route. Server functions are RPC endpoints reachable by direct POST regardless of which route renders them. See "Route guards do not protect server functions" below.
+
 ## Setup
 
 Protect routes with `beforeLoad` + `redirect()` in a pathless layout route (`_authenticated`):
@@ -371,6 +375,41 @@ export const Route = createFileRoute('/_authenticated')({
 
 ## Common Mistakes
 
+### CRITICAL: Route guards do not protect server functions
+
+A `beforeLoad` redirect protects the **route's UI**, not the **server functions** declared on it. `createServerFn` produces an RPC endpoint reachable by direct POST regardless of which route renders the calling UI. An attacker doesn't have to load `/_authenticated/orders` — they can curl the RPC endpoint directly.
+
+```tsx
+// WRONG — handler has no auth check; the route guard doesn't help
+import { createServerFn } from '@tanstack/react-start'
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+const getMyOrders = createServerFn({ method: 'GET' }).handler(async () => {
+  return db.orders.findMany() // ← anyone can hit the RPC
+})
+
+export const Route = createFileRoute('/_authenticated/orders')({
+  beforeLoad: ({ context }) => {
+    if (!context.auth.isAuthenticated) throw redirect({ to: '/login' })
+  },
+  loader: () => getMyOrders(),
+})
+```
+
+```tsx
+// CORRECT — auth enforced on the handler itself, via middleware
+import { createServerFn } from '@tanstack/react-start'
+import { authMiddleware } from '~/server/auth-middleware'
+
+const getMyOrders = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    return db.orders.findMany({ where: { userId: context.session.userId } })
+  })
+```
+
+Rule of thumb: every `createServerFn` that touches user data needs `authMiddleware` (or an equivalent in-handler check). The route guard is for the page experience; the RPC guard is for the data. See [start-core/auth-server-primitives](../../../../start-client-core/skills/start-core/auth-server-primitives/SKILL.md) for the full session/middleware pattern.
+
 ### HIGH: Auth check in component instead of beforeLoad
 
 Component-level auth checks cause a **flash of protected content** before the redirect:
@@ -456,3 +495,5 @@ Place protected routes as children of the `_authenticated` layout route. Public 
 ## Cross-References
 
 - See also: **router-core/data-loading/SKILL.md** — `beforeLoad` runs before `loader`; auth context flows into loader via route context
+- See also: **start-core/auth-server-primitives/SKILL.md** — server-side session cookies, OAuth state + PKCE, CSRF, password-reset hardening, rate limiting (the server half of authentication)
+- See also: **start-core/middleware/SKILL.md** — `authMiddleware` factory pattern for protecting individual `createServerFn` calls

--- a/packages/router-core/skills/router-core/ssr/SKILL.md
+++ b/packages/router-core/skills/router-core/ssr/SKILL.md
@@ -391,22 +391,68 @@ component: () => {
 }
 ```
 
-### 3. CRITICAL: Generating Next.js or Remix SSR patterns
+### 3. CRITICAL: Generating Next.js, Remix, or React Router DOM patterns
 
-TanStack Router does NOT use `getServerSideProps`, `getStaticProps`, App Router `page.tsx`, or Remix-style server-only `loader` exports.
+TanStack Router does NOT use `getServerSideProps`, `getStaticProps`, App Router `page.tsx`, Remix-style server-only `loader` exports, or anything from `react-router-dom`.
+
+#### Wrong file structures
+
+```text
+WRONG (Next.js Pages Router):
+  src/pages/index.tsx
+  src/pages/_app.tsx
+  src/pages/posts/[id].tsx
+
+WRONG (Next.js App Router):
+  app/layout.tsx
+  app/page.tsx
+  app/posts/[id]/page.tsx
+
+WRONG (Next.js custom App):
+  _app/index.tsx
+  pages/_app.tsx, pages/_document.tsx
+
+CORRECT (TanStack Router file-based routing):
+  src/routes/__root.tsx
+  src/routes/index.tsx
+  src/routes/posts/$postId.tsx
+```
+
+#### Wrong imports
 
 ```tsx
-// WRONG — Next.js patterns
+// WRONG — react-router-dom is a different library
+import { Link, useNavigate, BrowserRouter, Route, Routes } from 'react-router-dom'
+
+// WRONG — Next.js Link/router
+import Link from 'next/link'
+import { useRouter } from 'next/router'         // Pages Router
+import { useRouter } from 'next/navigation'     // App Router
+
+// CORRECT — everything routing-related lives in @tanstack/react-router
+import {
+  Link,
+  useNavigate,
+  useRouter,
+  useLocation,
+  redirect,
+} from '@tanstack/react-router'
+```
+
+#### Wrong loader/data-fetching patterns
+
+```tsx
+// WRONG — Next.js Pages Router
 export async function getServerSideProps() {
   return { props: { data: await fetchData() } }
 }
 
-// WRONG — Remix patterns
+// WRONG — Remix
 export async function loader({ request }: LoaderFunctionArgs) {
   return json({ data: await fetchData() })
 }
 
-// CORRECT — TanStack Router pattern
+// CORRECT — TanStack Router
 export const Route = createFileRoute('/data')({
   loader: async () => {
     const data = await fetchData()
@@ -420,6 +466,8 @@ function DataPage() {
   return <div>{data}</div>
 }
 ```
+
+If you see `src/pages/`, `app/layout.tsx`, `react-router-dom`, or any of the above in agent output, the agent is generating for the wrong framework. The build will either fail or produce duplicate `/` routes that conflict at runtime.
 
 ## Tension: Client-First Loaders vs SSR
 

--- a/packages/router-core/skills/router-core/ssr/SKILL.md
+++ b/packages/router-core/skills/router-core/ssr/SKILL.md
@@ -422,12 +422,18 @@ CORRECT (TanStack Router file-based routing):
 
 ```tsx
 // WRONG — react-router-dom is a different library
-import { Link, useNavigate, BrowserRouter, Route, Routes } from 'react-router-dom'
+import {
+  Link,
+  useNavigate,
+  BrowserRouter,
+  Route,
+  Routes,
+} from 'react-router-dom'
 
 // WRONG — Next.js Link/router
 import Link from 'next/link'
-import { useRouter } from 'next/router'         // Pages Router
-import { useRouter } from 'next/navigation'     // App Router
+import { useRouter } from 'next/router' // Pages Router
+import { useRouter } from 'next/navigation' // App Router
 
 // CORRECT — everything routing-related lives in @tanstack/react-router
 import {

--- a/packages/router-core/skills/router-core/type-safety/SKILL.md
+++ b/packages/router-core/skills/router-core/type-safety/SKILL.md
@@ -329,8 +329,14 @@ import {
 export function useDelayedNavigate<
   TRouter extends RegisteredRouter = RegisteredRouter,
   TOptions = unknown,
->(options: ValidateNavigateOptions<TRouter, TOptions>, delayMs: number): () => void
-export function useDelayedNavigate(options: ValidateNavigateOptions, delayMs: number) {
+>(
+  options: ValidateNavigateOptions<TRouter, TOptions>,
+  delayMs: number,
+): () => void
+export function useDelayedNavigate(
+  options: ValidateNavigateOptions,
+  delayMs: number,
+) {
   const navigate = useNavigate()
   return () => setTimeout(() => navigate(options), delayMs)
 }
@@ -338,8 +344,14 @@ export function useDelayedNavigate(options: ValidateNavigateOptions, delayMs: nu
 export async function fetchOrRedirect<
   TRouter extends RegisteredRouter = RegisteredRouter,
   TOptions = unknown,
->(url: string, redirectOptions: ValidateRedirectOptions<TRouter, TOptions>): Promise<unknown>
-export async function fetchOrRedirect(url: string, redirectOptions: ValidateRedirectOptions) {
+>(
+  url: string,
+  redirectOptions: ValidateRedirectOptions<TRouter, TOptions>,
+): Promise<unknown>
+export async function fetchOrRedirect(
+  url: string,
+  redirectOptions: ValidateRedirectOptions,
+) {
   const response = await fetch(url)
   if (response.status === 401) throw redirect(redirectOptions)
   return response.json()

--- a/packages/router-core/skills/router-core/type-safety/SKILL.md
+++ b/packages/router-core/skills/router-core/type-safety/SKILL.md
@@ -313,61 +313,33 @@ export function NavItem(props: NavItemProps): React.ReactNode {
 <NavItem label="Post" linkOptions={{ to: '/posts/$postId', params: { postId: '1' } }} />
 ```
 
-### `ValidateNavigateOptions` — Type-Safe Navigate in Utilities
+### `ValidateNavigateOptions` and `ValidateRedirectOptions`
+
+Same pattern as `ValidateLinkOptions` above, for `useNavigate` and `redirect`:
 
 ```tsx
 import {
   useNavigate,
+  redirect,
   type RegisteredRouter,
   type ValidateNavigateOptions,
+  type ValidateRedirectOptions,
 } from '@tanstack/react-router'
 
 export function useDelayedNavigate<
   TRouter extends RegisteredRouter = RegisteredRouter,
   TOptions = unknown,
->(
-  options: ValidateNavigateOptions<TRouter, TOptions>,
-  delayMs: number,
-): () => void
-export function useDelayedNavigate(
-  options: ValidateNavigateOptions,
-  delayMs: number,
-): () => void {
+>(options: ValidateNavigateOptions<TRouter, TOptions>, delayMs: number) {
   const navigate = useNavigate()
-  return () => {
-    setTimeout(() => navigate(options), delayMs)
-  }
+  return () => setTimeout(() => navigate(options as ValidateNavigateOptions), delayMs)
 }
-
-// Usage — type-safe
-const go = useDelayedNavigate(
-  { to: '/posts/$postId', params: { postId: '1' } },
-  500,
-)
-```
-
-### `ValidateRedirectOptions` — Type-Safe Redirect in Utilities
-
-```tsx
-import {
-  redirect,
-  type RegisteredRouter,
-  type ValidateRedirectOptions,
-} from '@tanstack/react-router'
 
 export async function fetchOrRedirect<
   TRouter extends RegisteredRouter = RegisteredRouter,
   TOptions = unknown,
->(
-  url: string,
-  redirectOptions: ValidateRedirectOptions<TRouter, TOptions>,
-): Promise<unknown>
-export async function fetchOrRedirect(
-  url: string,
-  redirectOptions: ValidateRedirectOptions,
-): Promise<unknown> {
+>(url: string, redirectOptions: ValidateRedirectOptions<TRouter, TOptions>) {
   const response = await fetch(url)
-  if (!response.ok && response.status === 401) throw redirect(redirectOptions)
+  if (response.status === 401) throw redirect(redirectOptions as ValidateRedirectOptions)
   return response.json()
 }
 ```
@@ -477,21 +449,36 @@ declare module '@tanstack/react-router' {
 }
 ```
 
-### 5. CRITICAL (cross-skill): Generating Next.js or Remix patterns
+### 5. CRITICAL (cross-skill): Wrong-framework imports and file structure
+
+Wrong-framework code looks plausible (it's React) but breaks the build or produces conflicting `/` routes at runtime.
 
 ```tsx
-// WRONG — these are NOT TanStack Router APIs
-export async function getServerSideProps() { ... }
-export async function loader({ request }) { ... } // Remix-style
-const [searchParams, setSearchParams] = useSearchParams() // React Router
+// WRONG — react-router-dom and next/* are different libraries
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import Link from 'next/link'
+import { useRouter, useParams } from 'next/navigation'
 
-// CORRECT — TanStack Router APIs
+// CORRECT — all routing exports come from @tanstack/react-router
+import { Link, Outlet, useNavigate, useRouter, useLocation, useParams, redirect } from '@tanstack/react-router'
+```
+
+```tsx
+// WRONG file structures + APIs:
+//   src/pages/*.tsx with getServerSideProps / getStaticProps  (Next.js Pages Router)
+//   app/layout.tsx + app/page.tsx                              (Next.js App Router)
+//   _app/index.tsx, pages/_app.tsx, pages/_document.tsx        (Next.js custom App)
+//   loader/action exports                                       (Remix)
+
+// CORRECT — TanStack file-based routing at src/routes/*.tsx
 export const Route = createFileRoute('/posts')({
-  loader: async () => { ... },           // TanStack loader
-  validateSearch: zodValidator(schema),   // TanStack search validation
+  loader: async () => { ... },
+  validateSearch: zodValidator(schema),
   component: PostsComponent,
 })
-const search = Route.useSearch()          // TanStack hook
+const search = Route.useSearch()
 ```
+
+If a build error mentions `react-router-dom`, `next/`, `pages/_app`, or duplicate `/` routes, fix the import — don't paper over with type assertions.
 
 See also: router-core (Register setup), router-core/navigation (from narrowing), router-core/code-splitting (getRouteApi).

--- a/packages/router-core/skills/router-core/type-safety/SKILL.md
+++ b/packages/router-core/skills/router-core/type-safety/SKILL.md
@@ -315,7 +315,7 @@ export function NavItem(props: NavItemProps): React.ReactNode {
 
 ### `ValidateNavigateOptions` and `ValidateRedirectOptions`
 
-Same pattern as `ValidateLinkOptions` above, for `useNavigate` and `redirect`:
+Same pattern as `ValidateLinkOptions` above, for `useNavigate` and `redirect`. Use a generic public signature plus a non-generic implementation signature so the call site stays narrowed and the body works without casts:
 
 ```tsx
 import {
@@ -329,19 +329,19 @@ import {
 export function useDelayedNavigate<
   TRouter extends RegisteredRouter = RegisteredRouter,
   TOptions = unknown,
->(options: ValidateNavigateOptions<TRouter, TOptions>, delayMs: number) {
+>(options: ValidateNavigateOptions<TRouter, TOptions>, delayMs: number): () => void
+export function useDelayedNavigate(options: ValidateNavigateOptions, delayMs: number) {
   const navigate = useNavigate()
-  return () =>
-    setTimeout(() => navigate(options as ValidateNavigateOptions), delayMs)
+  return () => setTimeout(() => navigate(options), delayMs)
 }
 
 export async function fetchOrRedirect<
   TRouter extends RegisteredRouter = RegisteredRouter,
   TOptions = unknown,
->(url: string, redirectOptions: ValidateRedirectOptions<TRouter, TOptions>) {
+>(url: string, redirectOptions: ValidateRedirectOptions<TRouter, TOptions>): Promise<unknown>
+export async function fetchOrRedirect(url: string, redirectOptions: ValidateRedirectOptions) {
   const response = await fetch(url)
-  if (response.status === 401)
-    throw redirect(redirectOptions as ValidateRedirectOptions)
+  if (response.status === 401) throw redirect(redirectOptions)
   return response.json()
 }
 ```

--- a/packages/router-core/skills/router-core/type-safety/SKILL.md
+++ b/packages/router-core/skills/router-core/type-safety/SKILL.md
@@ -315,15 +315,13 @@ export function NavItem(props: NavItemProps): React.ReactNode {
 
 ### `ValidateNavigateOptions` and `ValidateRedirectOptions`
 
-Same pattern as `ValidateLinkOptions` above, for `useNavigate` and `redirect`. Use a generic public signature plus a non-generic implementation signature so the call site stays narrowed and the body works without casts:
+Same pattern as `ValidateLinkOptions` above, for `useNavigate` and `redirect`. Declare a generic public overload plus a non-generic implementation signature so the call site stays narrowed and the body works without casts:
 
 ```tsx
 import {
   useNavigate,
-  redirect,
   type RegisteredRouter,
   type ValidateNavigateOptions,
-  type ValidateRedirectOptions,
 } from '@tanstack/react-router'
 
 export function useDelayedNavigate<
@@ -340,23 +338,9 @@ export function useDelayedNavigate(
   const navigate = useNavigate()
   return () => setTimeout(() => navigate(options), delayMs)
 }
-
-export async function fetchOrRedirect<
-  TRouter extends RegisteredRouter = RegisteredRouter,
-  TOptions = unknown,
->(
-  url: string,
-  redirectOptions: ValidateRedirectOptions<TRouter, TOptions>,
-): Promise<unknown>
-export async function fetchOrRedirect(
-  url: string,
-  redirectOptions: ValidateRedirectOptions,
-) {
-  const response = await fetch(url)
-  if (response.status === 401) throw redirect(redirectOptions)
-  return response.json()
-}
 ```
+
+`ValidateRedirectOptions` works identically — declare a generic overload accepting `ValidateRedirectOptions<TRouter, TOptions>` and an impl signature accepting `ValidateRedirectOptions`, then call `redirect(options)` in the body.
 
 ### Render Props for Maximum Performance
 

--- a/packages/router-core/skills/router-core/type-safety/SKILL.md
+++ b/packages/router-core/skills/router-core/type-safety/SKILL.md
@@ -331,7 +331,8 @@ export function useDelayedNavigate<
   TOptions = unknown,
 >(options: ValidateNavigateOptions<TRouter, TOptions>, delayMs: number) {
   const navigate = useNavigate()
-  return () => setTimeout(() => navigate(options as ValidateNavigateOptions), delayMs)
+  return () =>
+    setTimeout(() => navigate(options as ValidateNavigateOptions), delayMs)
 }
 
 export async function fetchOrRedirect<
@@ -339,7 +340,8 @@ export async function fetchOrRedirect<
   TOptions = unknown,
 >(url: string, redirectOptions: ValidateRedirectOptions<TRouter, TOptions>) {
   const response = await fetch(url)
-  if (response.status === 401) throw redirect(redirectOptions as ValidateRedirectOptions)
+  if (response.status === 401)
+    throw redirect(redirectOptions as ValidateRedirectOptions)
   return response.json()
 }
 ```
@@ -460,7 +462,15 @@ import Link from 'next/link'
 import { useRouter, useParams } from 'next/navigation'
 
 // CORRECT — all routing exports come from @tanstack/react-router
-import { Link, Outlet, useNavigate, useRouter, useLocation, useParams, redirect } from '@tanstack/react-router'
+import {
+  Link,
+  Outlet,
+  useNavigate,
+  useRouter,
+  useLocation,
+  useParams,
+  redirect,
+} from '@tanstack/react-router'
 ```
 
 ```tsx

--- a/packages/router-core/skills/router-core/type-safety/SKILL.md
+++ b/packages/router-core/skills/router-core/type-safety/SKILL.md
@@ -336,7 +336,9 @@ export function useDelayedNavigate(
   delayMs: number,
 ) {
   const navigate = useNavigate()
-  return () => setTimeout(() => navigate(options), delayMs)
+  return () => {
+    setTimeout(() => navigate(options), delayMs)
+  }
 }
 ```
 

--- a/packages/start-client-core/skills/start-core/SKILL.md
+++ b/packages/start-client-core/skills/start-core/SKILL.md
@@ -24,13 +24,14 @@ TanStack Start is a full-stack React framework built on TanStack Router and Vite
 
 ## Sub-Skills
 
-| Task                                         | Sub-Skill                                                           |
-| -------------------------------------------- | ------------------------------------------------------------------- |
-| Type-safe RPCs, data fetching, mutations     | [start-core/server-functions/SKILL.md](./server-functions/SKILL.md) |
-| Request/function middleware, context, auth   | [start-core/middleware/SKILL.md](./middleware/SKILL.md)             |
-| Isomorphic execution, environment boundaries | [start-core/execution-model/SKILL.md](./execution-model/SKILL.md)   |
-| REST API endpoints alongside app routes      | [start-core/server-routes/SKILL.md](./server-routes/SKILL.md)       |
-| Hosting, SSR modes, prerendering, SEO        | [start-core/deployment/SKILL.md](./deployment/SKILL.md)             |
+| Task                                                  | Sub-Skill                                                                       |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Type-safe RPCs, data fetching, mutations              | [start-core/server-functions/SKILL.md](./server-functions/SKILL.md)             |
+| Request/function middleware, context, auth            | [start-core/middleware/SKILL.md](./middleware/SKILL.md)                         |
+| Server-side auth: sessions, cookies, OAuth, CSRF      | [start-core/auth-server-primitives/SKILL.md](./auth-server-primitives/SKILL.md) |
+| Isomorphic execution, environment boundaries          | [start-core/execution-model/SKILL.md](./execution-model/SKILL.md)               |
+| REST API endpoints alongside app routes               | [start-core/server-routes/SKILL.md](./server-routes/SKILL.md)                   |
+| Hosting, SSR modes, prerendering, SEO                 | [start-core/deployment/SKILL.md](./deployment/SKILL.md)                         |
 
 ## Quick Decision Tree
 
@@ -40,6 +41,9 @@ Need to run code exclusively on the server (DB, secrets)?
 
 Need auth checks, logging, or shared logic across server functions?
   → start-core/middleware
+
+Need to add login, sessions, OAuth, CSRF, password reset?
+  → start-core/auth-server-primitives
 
 Need to understand where code runs (server vs client)?
   → start-core/execution-model

--- a/packages/start-client-core/skills/start-core/SKILL.md
+++ b/packages/start-client-core/skills/start-core/SKILL.md
@@ -24,14 +24,14 @@ TanStack Start is a full-stack React framework built on TanStack Router and Vite
 
 ## Sub-Skills
 
-| Task                                                  | Sub-Skill                                                                       |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Type-safe RPCs, data fetching, mutations              | [start-core/server-functions/SKILL.md](./server-functions/SKILL.md)             |
-| Request/function middleware, context, auth            | [start-core/middleware/SKILL.md](./middleware/SKILL.md)                         |
-| Server-side auth: sessions, cookies, OAuth, CSRF      | [start-core/auth-server-primitives/SKILL.md](./auth-server-primitives/SKILL.md) |
-| Isomorphic execution, environment boundaries          | [start-core/execution-model/SKILL.md](./execution-model/SKILL.md)               |
-| REST API endpoints alongside app routes               | [start-core/server-routes/SKILL.md](./server-routes/SKILL.md)                   |
-| Hosting, SSR modes, prerendering, SEO                 | [start-core/deployment/SKILL.md](./deployment/SKILL.md)                         |
+| Task                                             | Sub-Skill                                                                       |
+| ------------------------------------------------ | ------------------------------------------------------------------------------- |
+| Type-safe RPCs, data fetching, mutations         | [start-core/server-functions/SKILL.md](./server-functions/SKILL.md)             |
+| Request/function middleware, context, auth       | [start-core/middleware/SKILL.md](./middleware/SKILL.md)                         |
+| Server-side auth: sessions, cookies, OAuth, CSRF | [start-core/auth-server-primitives/SKILL.md](./auth-server-primitives/SKILL.md) |
+| Isomorphic execution, environment boundaries     | [start-core/execution-model/SKILL.md](./execution-model/SKILL.md)               |
+| REST API endpoints alongside app routes          | [start-core/server-routes/SKILL.md](./server-routes/SKILL.md)                   |
+| Hosting, SSR modes, prerendering, SEO            | [start-core/deployment/SKILL.md](./deployment/SKILL.md)                         |
 
 ## Quick Decision Tree
 

--- a/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
+++ b/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
@@ -138,6 +138,7 @@ export const login = createServerFn({ method: 'POST' })
     if (!ok) throw new Error('Invalid email or password')
 
     // ROTATE on privilege change: destroy any existing session, then issue fresh.
+    await db.sessions.revokeAllForUser(user.id)
     const token = await db.sessions.create({ userId: user.id })
     setSessionCookie(token)
     return { ok: true }
@@ -309,6 +310,7 @@ Whenever the user's privileges change — login, logout, role change, password c
 
 ```tsx
 // In the login handler (already shown above): destroy any pre-login session, then create a fresh one.
+await db.sessions.revokeAllForUser(user.id)
 const token = await db.sessions.create({ userId: user.id })
 setSessionCookie(token)
 ```

--- a/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
+++ b/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
@@ -25,7 +25,7 @@ sources:
 This skill covers the **server half** of authentication: session storage, cookie issuance, OAuth flow, password-reset hardening, CSRF, rate limiting. For the **routing half** (`_authenticated` layout, `beforeLoad` redirects, RBAC checks), see [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md).
 
 > **CRITICAL**: A route guard does NOT protect a `createServerFn` on that route. Server functions are RPC endpoints reachable by direct POST regardless of which route renders them. Auth must be enforced **inside the handler** (or via middleware), not on the calling route.
-> **CRITICAL**: Validating the *shape* of a client-supplied identifier (`z.string().uuid().parse(...)`) is not authorization. A parsed UUID is still *some* tenant — re-check membership against the session principal before using it.
+> **CRITICAL**: Validating the _shape_ of a client-supplied identifier (`z.string().uuid().parse(...)`) is not authorization. A parsed UUID is still _some_ tenant — re-check membership against the session principal before using it.
 > **CRITICAL**: Read session/cookies inside `.handler()` or middleware `.server()`, not at module scope. Module-level reads run before requests exist (and are also undefined on Cloudflare Workers).
 
 ## Session Cookies
@@ -48,10 +48,10 @@ export function setSessionCookie(token: string) {
     'Set-Cookie',
     [
       `${SESSION_COOKIE}=${token}`,
-      `HttpOnly`,            // not readable from JS — defeats XSS exfiltration
-      `Secure`,              // HTTPS only (required for __Host- prefix)
-      `SameSite=Lax`,        // sent on top-level navigations, blocks most CSRF
-      `Path=/`,              // required for __Host- prefix
+      `HttpOnly`, // not readable from JS — defeats XSS exfiltration
+      `Secure`, // HTTPS only (required for __Host- prefix)
+      `SameSite=Lax`, // sent on top-level navigations, blocks most CSRF
+      `Path=/`, // required for __Host- prefix
       `Max-Age=${ONE_DAY}`,
     ].join('; '),
   )
@@ -274,7 +274,11 @@ A login endpoint without rate limiting is a credential-stuffing target. Limit pe
 import { createMiddleware } from '@tanstack/react-start'
 import { getRequest } from '@tanstack/react-start/server'
 
-function rateLimitMiddleware(opts: { key: string; max: number; windowMs: number }) {
+function rateLimitMiddleware(opts: {
+  key: string
+  max: number
+  windowMs: number
+}) {
   return createMiddleware().server(async ({ next }) => {
     const request = getRequest()
     const ip =
@@ -282,16 +286,21 @@ function rateLimitMiddleware(opts: { key: string; max: number; windowMs: number 
       request.headers.get('x-forwarded-for')?.split(',')[0] ??
       'unknown'
     const bucketKey = `rl:${opts.key}:${ip}`
-    const allowed = await rateLimiter.consume(bucketKey, opts.max, opts.windowMs)
+    const allowed = await rateLimiter.consume(
+      bucketKey,
+      opts.max,
+      opts.windowMs,
+    )
     if (!allowed) throw new Error('Too many requests')
     return next()
   })
 }
 
 // On the login server function:
-export const login = createServerFn({ method: 'POST' })
-  .middleware([rateLimitMiddleware({ key: 'login', max: 5, windowMs: 60_000 })])
-  // ...
+export const login = createServerFn({ method: 'POST' }).middleware([
+  rateLimitMiddleware({ key: 'login', max: 5, windowMs: 60_000 }),
+])
+// ...
 ```
 
 ## Session Rotation on Privilege Change
@@ -336,7 +345,7 @@ const getMyOrders = createServerFn({ method: 'GET' })
 
 ### CRITICAL: Treating shape validation as authorization
 
-A parsed UUID is *some* workspace, not an *authorized* workspace.
+A parsed UUID is _some_ workspace, not an _authorized_ workspace.
 
 ```tsx
 // WRONG — UUID is well-formed but the user may not be a member

--- a/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
+++ b/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
@@ -257,7 +257,9 @@ export const csrfMiddleware = createMiddleware().server(async ({ next }) => {
   const request = getRequest()
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     const origin = request.headers.get('origin')
-    if (!origin || new URL(origin).host !== process.env.APP_HOST) {
+    // Compare the FULL origin (scheme + host + port) — host alone lets
+    // http://example.com pass a check meant for https://example.com.
+    if (!origin || new URL(origin).origin !== process.env.APP_ORIGIN) {
       throw new Error('Origin check failed')
     }
   }

--- a/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
+++ b/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
@@ -1,0 +1,394 @@
+---
+name: start-core/auth-server-primitives
+description: >-
+  Server-side authentication primitives for TanStack Start: session
+  cookies (HttpOnly, Secure, SameSite, __Host- prefix), session
+  read/issue/destroy via createServerFn and middleware, OAuth
+  authorization-code flow with state and PKCE, password-reset
+  enumeration defense, CSRF for non-GET RPCs, rate limiting auth
+  endpoints, session rotation on privilege change. Pairs with
+  router-core/auth-and-guards for the routing side.
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+  - start-core/server-functions
+  - start-core/middleware
+sources:
+  - TanStack/router:docs/start/framework/react/guide/authentication-overview.md
+  - TanStack/router:docs/start/framework/react/guide/authentication-server-primitives.md
+---
+
+# Auth Server Primitives
+
+This skill covers the **server half** of authentication: session storage, cookie issuance, OAuth flow, password-reset hardening, CSRF, rate limiting. For the **routing half** (`_authenticated` layout, `beforeLoad` redirects, RBAC checks), see [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md).
+
+> **CRITICAL**: A route guard does NOT protect a `createServerFn` on that route. Server functions are RPC endpoints reachable by direct POST regardless of which route renders them. Auth must be enforced **inside the handler** (or via middleware), not on the calling route.
+> **CRITICAL**: Validating the *shape* of a client-supplied identifier (`z.string().uuid().parse(...)`) is not authorization. A parsed UUID is still *some* tenant — re-check membership against the session principal before using it.
+> **CRITICAL**: Read session/cookies inside `.handler()` or middleware `.server()`, not at module scope. Module-level reads run before requests exist (and are also undefined on Cloudflare Workers).
+
+## Session Cookies
+
+The recommended session storage is an HTTP-only cookie holding either an opaque session ID (with server-side lookup) or a signed/encrypted token. The cookie flags matter — set them all.
+
+```tsx
+// src/server/session.ts
+import '@tanstack/react-start/server-only'
+import {
+  getRequestHeader,
+  setResponseHeader,
+} from '@tanstack/react-start/server'
+
+const SESSION_COOKIE = '__Host-session' // __Host- prefix binds to the exact origin + path '/'
+const ONE_DAY = 60 * 60 * 24
+
+export function setSessionCookie(token: string) {
+  setResponseHeader(
+    'Set-Cookie',
+    [
+      `${SESSION_COOKIE}=${token}`,
+      `HttpOnly`,            // not readable from JS — defeats XSS exfiltration
+      `Secure`,              // HTTPS only (required for __Host- prefix)
+      `SameSite=Lax`,        // sent on top-level navigations, blocks most CSRF
+      `Path=/`,              // required for __Host- prefix
+      `Max-Age=${ONE_DAY}`,
+    ].join('; '),
+  )
+}
+
+export function clearSessionCookie() {
+  setResponseHeader(
+    'Set-Cookie',
+    `${SESSION_COOKIE}=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0`,
+  )
+}
+
+export function readSessionToken(): string | null {
+  const header = getRequestHeader('cookie')
+  if (!header) return null
+  for (const part of header.split(/;\s*/)) {
+    const [name, value] = part.split('=')
+    if (name === SESSION_COOKIE) return value ?? null
+  }
+  return null
+}
+```
+
+Flag rationale:
+
+- `HttpOnly` — JavaScript can't read the cookie, so an XSS bug can't steal the session.
+- `Secure` — HTTPS only. Required when using `__Host-` prefix.
+- `SameSite=Lax` — blocks CSRF on most cross-origin POST/PUT/DELETE. Use `Strict` for highest-security flows where loss of cross-site GET navigation is acceptable.
+- `__Host-` prefix — binds the cookie to the exact origin (no Domain attribute, Path must be `/`, Secure must be set). Prevents subdomain takeover from forging a session cookie.
+- `Path=/` — required by `__Host-`.
+- `Max-Age` — finite lifetime so a stolen cookie isn't useful forever. Pair with server-side session rotation.
+
+## Session Lookup as Middleware
+
+Use middleware to centralize session loading so every protected handler sees a typed session:
+
+```tsx
+// src/server/auth-middleware.ts
+import { createMiddleware } from '@tanstack/react-start'
+import { readSessionToken } from './session'
+
+export const authMiddleware = createMiddleware({ type: 'function' }).server(
+  async ({ next }) => {
+    const token = readSessionToken()
+    const session = token ? await db.sessions.findValid(token) : null
+    if (!session) throw new Error('Unauthorized')
+    return next({ context: { session } })
+  },
+)
+```
+
+Attach it to every server function that needs a logged-in user:
+
+```tsx
+import { createServerFn } from '@tanstack/react-start'
+import { authMiddleware } from '~/server/auth-middleware'
+
+export const getMyOrders = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    return db.orders.findMany({ where: { userId: context.session.userId } })
+  })
+```
+
+> **Route guards do not cover this.** A `createFileRoute('/_authenticated/orders')` with a `beforeLoad` redirect does NOT protect `getMyOrders` — the RPC is reachable via direct POST whether or not the user ever hits the route. Apply `authMiddleware` (or re-check inside `.handler()`) on every server function that needs auth.
+
+## Issuing a Session on Login
+
+```tsx
+// src/server/login.functions.ts
+import { createServerFn } from '@tanstack/react-start'
+import { z } from 'zod'
+import { setSessionCookie } from './session'
+
+export const login = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({ email: z.string().email(), password: z.string() }))
+  .handler(async ({ data }) => {
+    const user = await db.users.findByEmail(data.email)
+    // Constant-time compare — don't short-circuit on user-not-found vs wrong-password,
+    // both branches must take the same time and return the same error.
+    const ok =
+      user != null &&
+      (await verifyPasswordHash(user.passwordHash, data.password))
+    if (!ok) throw new Error('Invalid email or password')
+
+    // ROTATE on privilege change: destroy any existing session, then issue fresh.
+    const token = await db.sessions.create({ userId: user.id })
+    setSessionCookie(token)
+    return { ok: true }
+  })
+```
+
+## Logout
+
+```tsx
+import { createServerFn } from '@tanstack/react-start'
+import { authMiddleware } from '~/server/auth-middleware'
+import { clearSessionCookie } from '~/server/session'
+
+export const logout = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    await db.sessions.revoke(context.session.id)
+    clearSessionCookie()
+    return { ok: true }
+  })
+```
+
+## OAuth: state + PKCE
+
+For OAuth authorization-code flow, generate a one-time `state` (CSRF defense) and a PKCE verifier (defense against authorization-code interception). Store both in a short-lived signed cookie keyed to this exact login attempt.
+
+```tsx
+// src/server/oauth.functions.ts
+import { createServerFn } from '@tanstack/react-start'
+import { redirect } from '@tanstack/react-router'
+import {
+  getRequestHeader,
+  setResponseHeader,
+} from '@tanstack/react-start/server'
+import crypto from 'node:crypto'
+
+const OAUTH_STATE_COOKIE = '__Host-oauth' // expires fast; one-shot
+
+function base64url(buf: Buffer) {
+  return buf
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+}
+
+export const startOAuth = createServerFn({ method: 'GET' }).handler(
+  async () => {
+    const state = base64url(crypto.randomBytes(32))
+    const verifier = base64url(crypto.randomBytes(32))
+    const challenge = base64url(
+      crypto.createHash('sha256').update(verifier).digest(),
+    )
+
+    setResponseHeader(
+      'Set-Cookie',
+      `${OAUTH_STATE_COOKIE}=${signed({ state, verifier })}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=600`,
+    )
+
+    throw redirect({
+      href:
+        `https://provider.example/authorize` +
+        `?response_type=code` +
+        `&client_id=${process.env.OAUTH_CLIENT_ID}` +
+        `&redirect_uri=${encodeURIComponent(process.env.OAUTH_REDIRECT_URI!)}` +
+        `&state=${state}` +
+        `&code_challenge=${challenge}` +
+        `&code_challenge_method=S256`,
+    })
+  },
+)
+```
+
+In the callback handler, **verify the cookie state matches the returned state** and exchange the code with the verifier. If state is missing or doesn't match, abort — the request did not originate from your `startOAuth`.
+
+## Password Reset: defeat user enumeration
+
+When a user requests a reset, do not let the response shape or timing reveal whether the email is registered.
+
+```tsx
+import { createServerFn } from '@tanstack/react-start'
+import { z } from 'zod'
+
+export const requestPasswordReset = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({ email: z.string().email() }))
+  .handler(async ({ data }) => {
+    const user = await db.users.findByEmail(data.email)
+    if (user) {
+      const token = await db.passwordResets.issue(user.id)
+      await sendResetEmail(user.email, token)
+    }
+    // Always 200, always the same body, regardless of whether the user exists.
+    // The user is told to check their inbox; no confirmation either way.
+    return { ok: true }
+  })
+```
+
+Do NOT:
+
+- Return 200 if exists, 404 if not.
+- Use a different message ("we sent you a link" vs "no account found").
+- Skip the work when the user doesn't exist (timing leak — measurable from the wire).
+
+## CSRF for non-GET RPCs
+
+`SameSite=Lax` on the session cookie blocks most cross-site CSRF for POST/PUT/DELETE. Two cases need extra defense:
+
+1. **Top-level GET navigation that mutates** — never do this. Always use POST/PUT/DELETE for mutations.
+2. **POST from a page on a sibling subdomain** — `SameSite=Lax` does NOT block this; verify the `Origin` header matches your app's origin in middleware.
+
+```tsx
+import { createMiddleware } from '@tanstack/react-start'
+import { getRequest } from '@tanstack/react-start/server'
+
+export const csrfMiddleware = createMiddleware().server(async ({ next }) => {
+  const request = getRequest()
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    const origin = request.headers.get('origin')
+    if (!origin || new URL(origin).host !== process.env.APP_HOST) {
+      throw new Error('Origin check failed')
+    }
+  }
+  return next()
+})
+```
+
+Attach this to global request middleware in `src/start.ts` so it covers every non-GET request, including server routes and SSR.
+
+## Rate Limiting Auth Endpoints
+
+A login endpoint without rate limiting is a credential-stuffing target. Limit per-IP (and ideally per-account) with a sliding window.
+
+```tsx
+import { createMiddleware } from '@tanstack/react-start'
+import { getRequest } from '@tanstack/react-start/server'
+
+function rateLimitMiddleware(opts: { key: string; max: number; windowMs: number }) {
+  return createMiddleware().server(async ({ next }) => {
+    const request = getRequest()
+    const ip =
+      request.headers.get('cf-connecting-ip') ??
+      request.headers.get('x-forwarded-for')?.split(',')[0] ??
+      'unknown'
+    const bucketKey = `rl:${opts.key}:${ip}`
+    const allowed = await rateLimiter.consume(bucketKey, opts.max, opts.windowMs)
+    if (!allowed) throw new Error('Too many requests')
+    return next()
+  })
+}
+
+// On the login server function:
+export const login = createServerFn({ method: 'POST' })
+  .middleware([rateLimitMiddleware({ key: 'login', max: 5, windowMs: 60_000 })])
+  // ...
+```
+
+## Session Rotation on Privilege Change
+
+Whenever the user's privileges change — login, logout, role change, password change — **destroy the old session and issue a new one**. This neutralizes session-fixation attacks where an attacker plants their own session ID in the victim's browser before login.
+
+```tsx
+// In the login handler (already shown above): destroy any pre-login session, then create a fresh one.
+const token = await db.sessions.create({ userId: user.id })
+setSessionCookie(token)
+```
+
+```tsx
+// On password change / role grant:
+await db.sessions.revokeAllForUser(user.id) // destroy existing
+const token = await db.sessions.create({ userId: user.id }) // issue fresh
+setSessionCookie(token)
+```
+
+## Common Mistakes
+
+### CRITICAL: Trusting the route guard for server-function auth
+
+```tsx
+// WRONG — the RPC is callable directly via POST regardless of the route
+export const Route = createFileRoute('/_authenticated/orders')({
+  beforeLoad: ({ context }) => {
+    if (!context.auth.isAuthenticated) throw redirect({ to: '/login' })
+  },
+})
+const getMyOrders = createServerFn({ method: 'GET' }).handler(async () => {
+  return db.orders.findMany() // ← anyone can hit the RPC and get all orders
+})
+
+// CORRECT — auth enforced on the handler itself
+const getMyOrders = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    return db.orders.findMany({ where: { userId: context.session.userId } })
+  })
+```
+
+### CRITICAL: Treating shape validation as authorization
+
+A parsed UUID is *some* workspace, not an *authorized* workspace.
+
+```tsx
+// WRONG — UUID is well-formed but the user may not be a member
+const getWorkspaceData = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ workspaceId: z.string().uuid() }))
+  .handler(async ({ context, data }) => {
+    return db.workspaces.findById(data.workspaceId) // missing membership check!
+  })
+
+// CORRECT — verify the session principal has access to that workspace
+const getWorkspaceData = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ workspaceId: z.string().uuid() }))
+  .handler(async ({ context, data }) => {
+    const member = await db.memberships.find({
+      userId: context.session.userId,
+      workspaceId: data.workspaceId,
+    })
+    if (!member) throw new Error('Not a member of this workspace')
+    return db.workspaces.findById(data.workspaceId)
+  })
+```
+
+### HIGH: Returning different responses based on email existence
+
+Already covered above — `requestPasswordReset` must return the same body regardless of whether the email matches a user.
+
+### HIGH: Reading cookies/env at module scope
+
+```tsx
+// WRONG — module-load time, before any request exists
+const SESSION_SECRET = process.env.SESSION_SECRET
+export function signSession(payload) {
+  return sign(payload, SESSION_SECRET)
+}
+
+// CORRECT — read inside per-request callback
+export function signSession(payload) {
+  return sign(payload, process.env.SESSION_SECRET)
+}
+```
+
+On Cloudflare Workers and other edge runtimes, the module-level read evaluates to `undefined` even on the server because env is injected per-request. See [start-core/execution-model](../execution-model/SKILL.md).
+
+### MEDIUM: Long-lived sessions with no rotation
+
+A session token that never rotates is functionally a long-lived credential. Rotate on login, logout, password change, and role/permission change.
+
+## Cross-References
+
+- [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md) — the routing side: `_authenticated` layout, `beforeLoad`, `redirect`, RBAC checks.
+- [start-core/server-functions](../server-functions/SKILL.md) — how to expose RPCs (and how the route guard does NOT cover them).
+- [start-core/middleware](../middleware/SKILL.md) — composing `authMiddleware` and others.
+- [start-core/execution-model](../execution-model/SKILL.md) — why module-level env/secret reads are wrong.

--- a/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
+++ b/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
@@ -68,8 +68,10 @@ export function readSessionToken(): string | null {
   const header = getRequestHeader('cookie')
   if (!header) return null
   for (const part of header.split(/;\s*/)) {
-    const [name, value] = part.split('=')
-    if (name === SESSION_COOKIE) return value ?? null
+    // Split only on the FIRST '=' — signed/base64 values often contain '='.
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    if (part.slice(0, eq) === SESSION_COOKIE) return part.slice(eq + 1)
   }
   return null
 }
@@ -130,11 +132,13 @@ export const login = createServerFn({ method: 'POST' })
   .inputValidator(z.object({ email: z.string().email(), password: z.string() }))
   .handler(async ({ data }) => {
     const user = await db.users.findByEmail(data.email)
-    // Constant-time compare — don't short-circuit on user-not-found vs wrong-password,
-    // both branches must take the same time and return the same error.
-    const ok =
-      user != null &&
-      (await verifyPasswordHash(user.passwordHash, data.password))
+    // Always run verifyPasswordHash — even when the user doesn't exist —
+    // so the user-not-found branch takes the same time as wrong-password.
+    // DUMMY_PASSWORD_HASH is a hash of any throwaway password computed once
+    // at startup with the same algorithm/cost as real password hashes.
+    const hashToCheck = user?.passwordHash ?? DUMMY_PASSWORD_HASH
+    const passwordMatches = await verifyPasswordHash(hashToCheck, data.password)
+    const ok = user != null && passwordMatches
     if (!ok) throw new Error('Invalid email or password')
 
     // ROTATE on privilege change: destroy any existing session, then issue fresh.

--- a/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
+++ b/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
@@ -34,7 +34,6 @@ The recommended session storage is an HTTP-only cookie holding either an opaque 
 
 ```tsx
 // src/server/session.ts
-import '@tanstack/react-start/server-only'
 import {
   getRequestHeader,
   setResponseHeader,

--- a/packages/start-client-core/skills/start-core/deployment/SKILL.md
+++ b/packages/start-client-core/skills/start-core/deployment/SKILL.md
@@ -57,7 +57,14 @@ export default defineConfig({
 
 Deploy: `npx wrangler login && pnpm run deploy`
 
-> **Worker env is per-request.** Cloudflare Workers (and other edge SSR runtimes) inject env vars at request time. `process.env.X` at module scope evaluates to `undefined` even on the server — the file is loaded before the env exists. Always read env inside `.handler()`, middleware `.server()`, or another per-request function. See [start-core/execution-model](../execution-model/SKILL.md) for the full rule.
+> **Worker env is per-request.** Cloudflare Workers inject env vars at request time. `process.env.X` at module scope evaluates to `undefined` even on the server. The Cloudflare-canonical way to read env (including from module scope) is the `cloudflare:workers` env binding:
+>
+> ```ts
+> import { env } from 'cloudflare:workers'
+> const apiHost = env.API_HOST
+> ```
+>
+> Or read `process.env.X` per-request inside `.handler()` / middleware `.server()`. See [Cloudflare's environment-variables docs](https://developers.cloudflare.com/workers/configuration/environment-variables/) and [start-core/execution-model](../execution-model/SKILL.md).
 
 ### Netlify
 

--- a/packages/start-client-core/skills/start-core/deployment/SKILL.md
+++ b/packages/start-client-core/skills/start-core/deployment/SKILL.md
@@ -57,6 +57,8 @@ export default defineConfig({
 
 Deploy: `npx wrangler login && pnpm run deploy`
 
+> **Worker env is per-request.** Cloudflare Workers (and other edge SSR runtimes) inject env vars at request time. `process.env.X` at module scope evaluates to `undefined` even on the server — the file is loaded before the env exists. Always read env inside `.handler()`, middleware `.server()`, or another per-request function. See [start-core/execution-model](../execution-model/SKILL.md) for the full rule.
+
 ### Netlify
 
 ```bash

--- a/packages/start-client-core/skills/start-core/execution-model/SKILL.md
+++ b/packages/start-client-core/skills/start-core/execution-model/SKILL.md
@@ -27,16 +27,16 @@ Understanding where code runs is fundamental to TanStack Start. This skill cover
 
 ## Execution Control APIs
 
-| API                                              | Use Case                            | Client Behavior           | Server Behavior       |
-| ------------------------------------------------ | ----------------------------------- | ------------------------- | --------------------- |
-| `createServerFn()`                               | RPC calls, data mutations           | Network request to server | Direct execution      |
-| `createServerOnlyFn(fn)`                         | Utility functions                   | Throws error              | Direct execution      |
-| `createClientOnlyFn(fn)`                         | Browser utilities                   | Direct execution          | Throws error          |
-| `createIsomorphicFn()`                           | Different impl per env              | Uses `.client()` impl     | Uses `.server()` impl |
-| `<ClientOnly>`                                   | Browser-only components             | Renders children          | Renders fallback      |
-| `useHydrated()`                                  | Hydration-dependent logic           | `true` after hydration    | `false`               |
-| `import '@tanstack/<fw>-start/server-only'`      | Mark whole file server-only         | Import denied             | Allowed               |
-| `import '@tanstack/<fw>-start/client-only'`      | Mark whole file client-only         | Allowed                   | Import denied         |
+| API                                         | Use Case                    | Client Behavior           | Server Behavior       |
+| ------------------------------------------- | --------------------------- | ------------------------- | --------------------- |
+| `createServerFn()`                          | RPC calls, data mutations   | Network request to server | Direct execution      |
+| `createServerOnlyFn(fn)`                    | Utility functions           | Throws error              | Direct execution      |
+| `createClientOnlyFn(fn)`                    | Browser utilities           | Direct execution          | Throws error          |
+| `createIsomorphicFn()`                      | Different impl per env      | Uses `.client()` impl     | Uses `.server()` impl |
+| `<ClientOnly>`                              | Browser-only components     | Renders children          | Renders fallback      |
+| `useHydrated()`                             | Hydration-dependent logic   | `true` after hydration    | `false`               |
+| `import '@tanstack/<fw>-start/server-only'` | Mark whole file server-only | Import denied             | Allowed               |
+| `import '@tanstack/<fw>-start/client-only'` | Mark whole file client-only | Allowed                   | Import denied         |
 
 ## Server-Only Execution
 

--- a/packages/start-client-core/skills/start-core/execution-model/SKILL.md
+++ b/packages/start-client-core/skills/start-core/execution-model/SKILL.md
@@ -14,6 +14,7 @@ requires:
 sources:
   - TanStack/router:docs/start/framework/react/guide/execution-model.md
   - TanStack/router:docs/start/framework/react/guide/environment-variables.md
+  - TanStack/router:docs/start/framework/react/guide/import-protection.md
 ---
 
 # Execution Model
@@ -21,19 +22,21 @@ sources:
 Understanding where code runs is fundamental to TanStack Start. This skill covers the isomorphic execution model and how to control environment boundaries.
 
 > **CRITICAL**: ALL code in TanStack Start is isomorphic by default — it runs in BOTH server and client bundles. Route loaders run on BOTH server (during SSR) AND client (during navigation). Server-only operations MUST use `createServerFn`.
-> **CRITICAL**: Module-level `process.env` access runs in both environments. Secret values leak into the client bundle. Access secrets ONLY inside `createServerFn` or `createServerOnlyFn`.
+> **CRITICAL**: Module-level `process.env` access is wrong on **two** axes — security (values leak into the client bundle) AND runtime correctness (on Cloudflare Workers and other edge runtimes, env is injected per-request, so module-level reads evaluate to `undefined` even on the server). Read env inside `.handler()` or another per-request function, never at module scope.
 > **CRITICAL**: `VITE_` prefixed environment variables are exposed to the client bundle. Server secrets must NOT have the `VITE_` prefix.
 
 ## Execution Control APIs
 
-| API                      | Use Case                  | Client Behavior           | Server Behavior       |
-| ------------------------ | ------------------------- | ------------------------- | --------------------- |
-| `createServerFn()`       | RPC calls, data mutations | Network request to server | Direct execution      |
-| `createServerOnlyFn(fn)` | Utility functions         | Throws error              | Direct execution      |
-| `createClientOnlyFn(fn)` | Browser utilities         | Direct execution          | Throws error          |
-| `createIsomorphicFn()`   | Different impl per env    | Uses `.client()` impl     | Uses `.server()` impl |
-| `<ClientOnly>`           | Browser-only components   | Renders children          | Renders fallback      |
-| `useHydrated()`          | Hydration-dependent logic | `true` after hydration    | `false`               |
+| API                                              | Use Case                            | Client Behavior           | Server Behavior       |
+| ------------------------------------------------ | ----------------------------------- | ------------------------- | --------------------- |
+| `createServerFn()`                               | RPC calls, data mutations           | Network request to server | Direct execution      |
+| `createServerOnlyFn(fn)`                         | Utility functions                   | Throws error              | Direct execution      |
+| `createClientOnlyFn(fn)`                         | Browser utilities                   | Direct execution          | Throws error          |
+| `createIsomorphicFn()`                           | Different impl per env              | Uses `.client()` impl     | Uses `.server()` impl |
+| `<ClientOnly>`                                   | Browser-only components             | Renders children          | Renders fallback      |
+| `useHydrated()`                                  | Hydration-dependent logic           | `true` after hydration    | `false`               |
+| `import '@tanstack/<fw>-start/server-only'`      | Mark whole file server-only         | Import denied             | Allowed               |
+| `import '@tanstack/<fw>-start/client-only'`      | Mark whole file client-only         | Allowed                   | Import denied         |
 
 ## Server-Only Execution
 
@@ -124,6 +127,45 @@ const getDeviceInfo = createIsomorphicFn()
   .server(() => ({ type: 'server', platform: process.platform }))
   .client(() => ({ type: 'client', userAgent: navigator.userAgent }))
 ```
+
+## Import Protection: File Markers
+
+> Experimental.
+
+The `.server.*` and `.client.*` filename suffixes (e.g. `db.server.ts`) opt a file into Start's import protection — it can't be imported from the wrong environment. When you can't or don't want to rename the file, add a side-effect import at the top of the file to apply the same protection by marker:
+
+```ts
+// src/lib/secrets.ts (filename can't be *.server.ts)
+import '@tanstack/react-start/server-only'
+// (or @tanstack/solid-start/server-only, @tanstack/vue-start/server-only)
+
+export function getApiKey() {
+  return process.env.API_KEY
+}
+```
+
+```ts
+// src/lib/storage.ts
+import '@tanstack/react-start/client-only'
+// (or @tanstack/solid-start/client-only, @tanstack/vue-start/client-only)
+
+export function savePreferences(prefs: Record<string, string>) {
+  localStorage.setItem('prefs', JSON.stringify(prefs))
+}
+```
+
+Rules:
+
+- Both markers in the same file is an error.
+- Type-only imports are ignored (they erase to nothing at runtime).
+- Default behavior is `error` in production builds and `mock` in dev. The mock returns a recursive Proxy so dev keeps running while you fix the import graph.
+
+Pick the right tool:
+
+- File should never run on the wrong side **and** has no client API → `*.server.ts` filename or `import '@tanstack/<fw>-start/server-only'`.
+- One symbol needs to behave differently per environment → `createIsomorphicFn().client(...).server(...)`.
+- One function should error if called from the wrong side → `createServerOnlyFn` / `createClientOnlyFn`.
+- Component renders only after hydration → `<ClientOnly>` or `useHydrated()`.
 
 ## Environment Variables
 
@@ -229,21 +271,28 @@ export const Route = createFileRoute('/dashboard')({
 })
 ```
 
-### 2. CRITICAL: Exposing secrets via module-level process.env
+### 2. CRITICAL: Reading process.env at module scope
+
+Module-level `process.env` reads are wrong for **two** reasons, not one:
+
+1. **Security:** the value can be inlined into the client bundle, leaking secrets.
+2. **Runtime correctness (edge runtimes):** Cloudflare Workers and other edge SSR runtimes inject env at request time. Module-level code runs at module load, before the env exists, so the read evaluates to `undefined` even on the server. The bug only surfaces at deploy time.
 
 ```tsx
-// WRONG — runs in both environments, value in client bundle
+// WRONG — leaks to client AND is undefined on Workers
 const apiKey = process.env.SECRET_KEY
 export function fetchData() {
-  /* uses apiKey */
+  /* uses apiKey, which is undefined under Worker SSR */
 }
 
-// CORRECT — access inside server function only
+// CORRECT — read per-request, inside the handler
 const fetchData = createServerFn({ method: 'GET' }).handler(async () => {
   const apiKey = process.env.SECRET_KEY
   return fetch(url, { headers: { Authorization: apiKey } })
 })
 ```
+
+The same rule applies to middleware `.server()` callbacks, server-route handlers, and any function that runs per request — read env there, not at the top of the file.
 
 ### 3. CRITICAL: Using VITE\_ prefix for server secrets
 

--- a/packages/start-client-core/skills/start-core/middleware/SKILL.md
+++ b/packages/start-client-core/skills/start-core/middleware/SKILL.md
@@ -20,7 +20,6 @@ sources:
 
 Middleware customizes the behavior of server functions and server routes. It is composable — middleware can depend on other middleware to form a chain.
 
-> **CRITICAL**: Import `createMiddleware` from `@tanstack/<framework>-start` (e.g. `@tanstack/react-start`). NOT from `@tanstack/react-router` and NOT from `@tanstack/start` (no such package). Wrong path produces `createMiddleware is not a function`.
 > **CRITICAL**: TypeScript enforces method order: `middleware()` → `inputValidator()` → `client()` → `server()`. Wrong order causes type errors.
 > **CRITICAL**: Validating the _shape_ of `sendContext` (e.g. `z.string().uuid().parse(...)`) is NOT authorization. A parsed identifier is a well-formed identifier, not an authorized one. Always re-check access against the session principal before using a client-sent ID as a query key, filter, or path parameter.
 
@@ -304,25 +303,7 @@ Fetch precedence (highest to lowest): call site → later middleware → earlier
 
 ## Common Mistakes
 
-### 1. HIGH: Wrong import path for `createMiddleware`
-
-`createMiddleware` lives in the framework-scoped Start package, not in the router or a non-existent generic `@tanstack/start`. The wrong path looks plausible but throws `createMiddleware is not a function` at runtime.
-
-```tsx
-// WRONG — does not export createMiddleware
-import { createMiddleware } from '@tanstack/react-router'
-
-// WRONG — package does not exist
-import { createMiddleware } from '@tanstack/start'
-
-// CORRECT — framework-scoped start package
-import { createMiddleware } from '@tanstack/react-start'
-// (or @tanstack/solid-start, @tanstack/vue-start)
-```
-
-Same applies to `createStart` and other Start runtime exports.
-
-### 2. CRITICAL: Trusting client sendContext — shape check is not access check
+### 1. CRITICAL: Trusting client sendContext — shape check is not access check
 
 `sendContext` from a client middleware arrives on the server as untrusted client input. Most agents stop after parsing the shape with Zod and assume the value is safe. It isn't: a parsed UUID is _some_ workspace, not the requesting user's workspace. Without a membership check against the session principal, you've built a tenant-walking endpoint.
 
@@ -366,11 +347,11 @@ Same applies to `createStart` and other Start runtime exports.
 
 The session itself must come from a server-trusted source (the cookie + DB lookup in `authMiddleware`), never from `sendContext` — anything the client can send, the client can lie about. See [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md).
 
-### 3. MEDIUM: Confusing request vs server function middleware
+### 2. MEDIUM: Confusing request vs server function middleware
 
 Request middleware runs on ALL requests (SSR, routes, functions). Server function middleware runs only for `createServerFn` calls and has `.client()` method.
 
-### 4. HIGH: Browser APIs in .client() crash during SSR
+### 3. HIGH: Browser APIs in .client() crash during SSR
 
 During SSR, `.client()` callbacks run on the server. Browser-only APIs like `localStorage` or `window` will throw `ReferenceError`:
 
@@ -393,7 +374,7 @@ const middleware = createMiddleware({ type: 'function' }).client(
 )
 ```
 
-### 5. MEDIUM: Wrong method order
+### 4. MEDIUM: Wrong method order
 
 ```tsx
 // WRONG — type error

--- a/packages/start-client-core/skills/start-core/middleware/SKILL.md
+++ b/packages/start-client-core/skills/start-core/middleware/SKILL.md
@@ -22,7 +22,7 @@ Middleware customizes the behavior of server functions and server routes. It is 
 
 > **CRITICAL**: Import `createMiddleware` from `@tanstack/<framework>-start` (e.g. `@tanstack/react-start`). NOT from `@tanstack/react-router` and NOT from `@tanstack/start` (no such package). Wrong path produces `createMiddleware is not a function`.
 > **CRITICAL**: TypeScript enforces method order: `middleware()` → `inputValidator()` → `client()` → `server()`. Wrong order causes type errors.
-> **CRITICAL**: Validating the *shape* of `sendContext` (e.g. `z.string().uuid().parse(...)`) is NOT authorization. A parsed identifier is a well-formed identifier, not an authorized one. Always re-check access against the session principal before using a client-sent ID as a query key, filter, or path parameter.
+> **CRITICAL**: Validating the _shape_ of `sendContext` (e.g. `z.string().uuid().parse(...)`) is NOT authorization. A parsed identifier is a well-formed identifier, not an authorized one. Always re-check access against the session principal before using a client-sent ID as a query key, filter, or path parameter.
 
 ## Two Types of Middleware
 
@@ -324,7 +324,7 @@ Same applies to `createStart` and other Start runtime exports.
 
 ### 2. CRITICAL: Trusting client sendContext — shape check is not access check
 
-`sendContext` from a client middleware arrives on the server as untrusted client input. Most agents stop after parsing the shape with Zod and assume the value is safe. It isn't: a parsed UUID is *some* workspace, not the requesting user's workspace. Without a membership check against the session principal, you've built a tenant-walking endpoint.
+`sendContext` from a client middleware arrives on the server as untrusted client input. Most agents stop after parsing the shape with Zod and assume the value is safe. It isn't: a parsed UUID is _some_ workspace, not the requesting user's workspace. Without a membership check against the session principal, you've built a tenant-walking endpoint.
 
 **Layer 1 — WRONG (no validation):**
 

--- a/packages/start-client-core/skills/start-core/middleware/SKILL.md
+++ b/packages/start-client-core/skills/start-core/middleware/SKILL.md
@@ -20,8 +20,9 @@ sources:
 
 Middleware customizes the behavior of server functions and server routes. It is composable — middleware can depend on other middleware to form a chain.
 
+> **CRITICAL**: Import `createMiddleware` from `@tanstack/<framework>-start` (e.g. `@tanstack/react-start`). NOT from `@tanstack/react-router` and NOT from `@tanstack/start` (no such package). Wrong path produces `createMiddleware is not a function`.
 > **CRITICAL**: TypeScript enforces method order: `middleware()` → `inputValidator()` → `client()` → `server()`. Wrong order causes type errors.
-> **CRITICAL**: Client context sent via `sendContext` is NOT validated by default. If you send dynamic user-generated data, validate it in server-side middleware before use.
+> **CRITICAL**: Validating the *shape* of `sendContext` (e.g. `z.string().uuid().parse(...)`) is NOT authorization. A parsed identifier is a well-formed identifier, not an authorized one. Always re-check access against the session principal before using a client-sent ID as a query key, filter, or path parameter.
 
 ## Two Types of Middleware
 
@@ -241,7 +242,11 @@ const authMiddleware = createMiddleware().server(async ({ next, request }) => {
   if (!session) throw new Error('Unauthorized')
   return next({ context: { session } })
 })
+```
 
+> **Attach `authMiddleware` to every `createServerFn` that needs auth.** Server functions are RPC endpoints — a route `beforeLoad` does NOT protect the RPC, only the route's UI. Pair every protected route with handler-level enforcement here. See [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md) and [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md).
+
+```tsx
 type Permissions = Record<string, string[]>
 
 function authorizationMiddleware(permissions: Permissions) {
@@ -299,28 +304,73 @@ Fetch precedence (highest to lowest): call site → later middleware → earlier
 
 ## Common Mistakes
 
-### 1. HIGH: Trusting client sendContext without validation
+### 1. HIGH: Wrong import path for `createMiddleware`
+
+`createMiddleware` lives in the framework-scoped Start package, not in the router or a non-existent generic `@tanstack/start`. The wrong path looks plausible but throws `createMiddleware is not a function` at runtime.
 
 ```tsx
-// WRONG — client can send arbitrary data
+// WRONG — does not export createMiddleware
+import { createMiddleware } from '@tanstack/react-router'
+
+// WRONG — package does not exist
+import { createMiddleware } from '@tanstack/start'
+
+// CORRECT — framework-scoped start package
+import { createMiddleware } from '@tanstack/react-start'
+// (or @tanstack/solid-start, @tanstack/vue-start)
+```
+
+Same applies to `createStart` and other Start runtime exports.
+
+### 2. CRITICAL: Trusting client sendContext — shape check is not access check
+
+`sendContext` from a client middleware arrives on the server as untrusted client input. Most agents stop after parsing the shape with Zod and assume the value is safe. It isn't: a parsed UUID is *some* workspace, not the requesting user's workspace. Without a membership check against the session principal, you've built a tenant-walking endpoint.
+
+**Layer 1 — WRONG (no validation):**
+
+```tsx
 .server(async ({ next, context }) => {
+  // SQL-injectable AND tenant-walkable
   await db.query(`SELECT * FROM workspace_${context.workspaceId}`)
   return next()
 })
+```
 
-// CORRECT — validate before use
+**Layer 2 — STILL WRONG (shape only):**
+
+```tsx
 .server(async ({ next, context }) => {
+  // Looks safe, isn't. UUID is well-formed but the user may not be a member.
   const workspaceId = z.string().uuid().parse(context.workspaceId)
   await db.query('SELECT * FROM workspaces WHERE id = $1', [workspaceId])
   return next()
 })
 ```
 
-### 2. MEDIUM: Confusing request vs server function middleware
+**Layer 3 — CORRECT (shape AND access):**
+
+```tsx
+.middleware([authMiddleware]) // session loaded from cookie, NOT from sendContext
+.server(async ({ next, context }) => {
+  const workspaceId = z.string().uuid().parse(context.workspaceId)
+  // Verify the session principal can access this workspace.
+  const member = await db.memberships.find({
+    userId: context.session.userId,
+    workspaceId,
+  })
+  if (!member) throw new Error('Not a member of this workspace')
+  await db.query('SELECT * FROM workspaces WHERE id = $1', [workspaceId])
+  return next({ context: { workspaceId } })
+})
+```
+
+The session itself must come from a server-trusted source (the cookie + DB lookup in `authMiddleware`), never from `sendContext` — anything the client can send, the client can lie about. See [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md).
+
+### 3. MEDIUM: Confusing request vs server function middleware
 
 Request middleware runs on ALL requests (SSR, routes, functions). Server function middleware runs only for `createServerFn` calls and has `.client()` method.
 
-### 3. HIGH: Browser APIs in .client() crash during SSR
+### 4. HIGH: Browser APIs in .client() crash during SSR
 
 During SSR, `.client()` callbacks run on the server. Browser-only APIs like `localStorage` or `window` will throw `ReferenceError`:
 
@@ -343,7 +393,7 @@ const middleware = createMiddleware({ type: 'function' }).client(
 )
 ```
 
-### 4. MEDIUM: Wrong method order
+### 5. MEDIUM: Wrong method order
 
 ```tsx
 // WRONG — type error
@@ -363,3 +413,5 @@ createMiddleware({ type: 'function' })
 
 - [start-core/server-functions](../server-functions/SKILL.md) — what middleware wraps
 - [start-core/server-routes](../server-routes/SKILL.md) — middleware on API endpoints
+- [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md) — building the `authMiddleware` factory itself: session cookie reads, OAuth state, CSRF
+- [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md) — routing-side guards (route `beforeLoad` does NOT protect server functions; pair guards with `authMiddleware` on every protected RPC)

--- a/packages/start-client-core/skills/start-core/server-functions/SKILL.md
+++ b/packages/start-client-core/skills/start-core/server-functions/SKILL.md
@@ -19,6 +19,8 @@ sources:
 
 Server functions are type-safe RPCs created with `createServerFn`. They run exclusively on the server but can be called from anywhere — loaders, components, hooks, event handlers, or other server functions.
 
+> **CRITICAL**: Import `createServerFn` from `@tanstack/<framework>-start` (e.g. `@tanstack/react-start`). NOT from `@tanstack/react-router` and NOT from `@tanstack/start` (no such package). Wrong path produces `createServerFn is not a function`.
+> **CRITICAL**: Server functions are RPC endpoints. They are reachable by direct POST regardless of which route renders the calling UI. **Auth must be enforced inside the handler (or via middleware) — a route `beforeLoad` does NOT protect the RPC.** See [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md) for the session/middleware pattern.
 > **CRITICAL**: Loaders are ISOMORPHIC — they run on BOTH client and server. Database queries, file system access, and secret API keys MUST go inside `createServerFn`, NOT in loaders directly.
 > **CRITICAL**: Do not use `"use server"` directives, `getServerSideProps`, or any Next.js/Remix server patterns. TanStack Start uses `createServerFn` exclusively.
 
@@ -199,16 +201,29 @@ import {
   setResponseStatus,
 } from '@tanstack/react-start/server'
 
-const getCachedData = createServerFn({ method: 'GET' }).handler(async () => {
-  const request = getRequest()
-  const authHeader = getRequestHeader('Authorization')
-
+// Public, non-personalized data — safe to cache shared across users.
+const getPublicData = createServerFn({ method: 'GET' }).handler(async () => {
   setResponseHeaders({
+    // 'public' is correct ONLY when the response does not depend on identity.
+    // For anything tied to a session/user/tenant, use 'private' or 'no-store'.
     'Cache-Control': 'public, max-age=300',
   })
   setResponseStatus(200)
+  return fetchPublicData()
+})
 
-  return fetchData()
+// Authenticated data — must NOT be 'public'.
+const getMyData = createServerFn({ method: 'GET' }).handler(async () => {
+  const authHeader = getRequestHeader('Authorization')
+  // ... auth check ...
+
+  setResponseHeaders({
+    // 'private' = only the user-agent may cache. Vary by Cookie/Authorization
+    // so any intermediary that does cache keys by identity, not URL alone.
+    'Cache-Control': 'private, max-age=60',
+    Vary: 'Cookie, Authorization',
+  })
+  return fetchPersonalizedData()
 })
 ```
 
@@ -254,7 +269,51 @@ Static imports of server functions are safe — the build replaces implementatio
 
 ## Common Mistakes
 
-### 1. CRITICAL: Putting server-only code in loaders
+### 1. HIGH: Wrong import path for `createServerFn`
+
+`createServerFn` lives in the framework-scoped Start package, not in the router or a non-existent generic `@tanstack/start`. The wrong path looks plausible but throws `createServerFn is not a function` at runtime.
+
+```tsx
+// WRONG — does not export createServerFn
+import { createServerFn } from '@tanstack/react-router'
+
+// WRONG — package does not exist
+import { createServerFn } from '@tanstack/start'
+
+// CORRECT — framework-scoped start package
+import { createServerFn } from '@tanstack/react-start'
+// (or @tanstack/solid-start, @tanstack/vue-start)
+```
+
+Server-context utilities (`getRequest`, `getRequestHeader`, `setResponseHeader`, etc.) live at `@tanstack/<framework>-start/server` — same framework prefix.
+
+### 2. CRITICAL: Relying on a route guard to protect a server function
+
+A `beforeLoad` redirect protects the **route's UI**, not the **RPC**. `createServerFn` exposes a callable endpoint that an attacker can hit directly — no need to load the route at all. Auth on the route is necessary but not sufficient.
+
+```tsx
+// WRONG — the route guard doesn't reach the handler
+const getMyOrders = createServerFn({ method: 'GET' }).handler(async () => {
+  return db.orders.findMany() // ← anyone can call the RPC
+})
+export const Route = createFileRoute('/_authenticated/orders')({
+  beforeLoad: ({ context }) => {
+    if (!context.auth.isAuthenticated) throw redirect({ to: '/login' })
+  },
+  loader: () => getMyOrders(),
+})
+
+// CORRECT — auth enforced on the handler itself
+const getMyOrders = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    return db.orders.findMany({ where: { userId: context.session.userId } })
+  })
+```
+
+Apply `authMiddleware` (or an equivalent in-handler check) to **every** `createServerFn` that needs auth. See [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md) for the full session/middleware pattern and [start-core/middleware](../middleware/SKILL.md) for composing the factory.
+
+### 3. CRITICAL: Putting server-only code in loaders
 
 ```tsx
 // WRONG — loader is ISOMORPHIC, runs on BOTH client and server
@@ -276,22 +335,47 @@ export const Route = createFileRoute('/posts')({
 })
 ```
 
-### 2. CRITICAL: Using Next.js/Remix server patterns
+### 4. CRITICAL: Using Next.js / Remix / React Router DOM patterns
+
+If the file lives at `src/pages/`, `app/layout.tsx`, `_app/`, or imports anything from `react-router-dom` or `next/`, it is wrong-framework code. TanStack Start uses `src/routes/` + `createFileRoute` + `createServerFn`.
 
 ```tsx
 // WRONG — "use server" is a React directive, not used in TanStack Start
 'use server'
 export async function getUser() { ... }
 
-// WRONG — getServerSideProps is Next.js
+// WRONG — getServerSideProps is Next.js Pages Router
 export async function getServerSideProps() { ... }
 
-// CORRECT — TanStack Start uses createServerFn
+// WRONG — Next.js App Router server component data fetching
+export default async function Page() {
+  const data = await fetch(...).then(r => r.json())
+  return <div>{data}</div>
+}
+
+// WRONG — Remix
+export async function loader({ request }) { ... }
+export async function action({ request }) { ... }
+
+// WRONG — react-router-dom (a different library)
+import { Link, useNavigate } from 'react-router-dom'
+
+// CORRECT — TanStack Start
+import { createServerFn } from '@tanstack/react-start'
+import { Link, useNavigate, createFileRoute } from '@tanstack/react-router'
+
 const getUser = createServerFn({ method: 'GET' })
   .handler(async () => { ... })
+
+export const Route = createFileRoute('/users/$id')({
+  loader: ({ params }) => getUser({ data: { id: params.id } }),
+  component: UserPage,
+})
 ```
 
-### 3. HIGH: Dynamic imports for server functions
+If you see `src/pages/`, `app/layout.tsx`, or `react-router-dom` in agent output, the agent is generating for the wrong framework. Build will fail or routes will conflict at runtime.
+
+### 5. HIGH: Dynamic imports for server functions
 
 ```tsx
 // WRONG — can cause bundler issues
@@ -301,7 +385,7 @@ const { getUser } = await import('~/utils/users.functions')
 import { getUser } from '~/utils/users.functions'
 ```
 
-### 4. HIGH: Awaiting server function without calling it
+### 6. HIGH: Awaiting server function without calling it
 
 `createServerFn` returns a function — it must be invoked with `()`:
 
@@ -316,7 +400,35 @@ const data = await getItems()
 const data = await getItems({ data: { id: '1' } })
 ```
 
-### 5. MEDIUM: Not using useServerFn for component calls
+### 7. CRITICAL: Caching authenticated responses with `Cache-Control: public`
+
+`Cache-Control: public, max-age=N` tells every CDN, proxy, and shared cache between you and the user that this response can be served to anyone. If the response depends on the session (user, tenant, role), the first user's response gets cached and replayed to the next user — a cross-tenant data leak.
+
+```tsx
+// WRONG — auth'd response, public cache, leaks to next user via CDN
+const getMyOrders = createServerFn({ method: 'GET' }).handler(async () => {
+  const session = await requireSession() // identity-dependent
+  setResponseHeaders({ 'Cache-Control': 'public, max-age=300' })
+  return db.orders.findMany({ where: { userId: session.userId } })
+})
+
+// CORRECT — private + Vary so any cache that does store it keys by identity
+const getMyOrders = createServerFn({ method: 'GET' }).handler(async () => {
+  const session = await requireSession()
+  setResponseHeaders({
+    'Cache-Control': 'private, max-age=60',
+    Vary: 'Cookie, Authorization',
+  })
+  return db.orders.findMany({ where: { userId: session.userId } })
+})
+
+// ALSO CORRECT — opt out entirely for sensitive data
+setResponseHeaders({ 'Cache-Control': 'no-store' })
+```
+
+Rule of thumb: if the handler reads a session/cookie/auth header or branches on identity, the response is **not** `public`. Default to `private` (or `no-store` for sensitive data); reach for `public` only on responses that are byte-for-byte identical regardless of who asks. See also [start-core/deployment](../deployment/SKILL.md) for ISR/Cache-Control on full pages.
+
+### 8. MEDIUM: Not using useServerFn for component calls
 
 When calling server functions from event handlers in components, use `useServerFn` to get proper React integration:
 
@@ -333,3 +445,5 @@ const deletePostFn = useServerFn(deletePost)
 
 - [start-core/execution-model](../execution-model/SKILL.md) — understanding where code runs
 - [start-core/middleware](../middleware/SKILL.md) — composing server functions with middleware
+- [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md) — sessions, cookies, OAuth, CSRF, rate limiting (the server-side half of auth; `getCurrentUser`/`useSession`-style helpers belong here, not at module scope)
+- [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md) — the routing side: route guards do NOT protect server functions, so always re-check auth in the handler or via middleware

--- a/packages/start-client-core/skills/start-core/server-functions/SKILL.md
+++ b/packages/start-client-core/skills/start-core/server-functions/SKILL.md
@@ -19,7 +19,6 @@ sources:
 
 Server functions are type-safe RPCs created with `createServerFn`. They run exclusively on the server but can be called from anywhere — loaders, components, hooks, event handlers, or other server functions.
 
-> **CRITICAL**: Import `createServerFn` from `@tanstack/<framework>-start` (e.g. `@tanstack/react-start`). NOT from `@tanstack/react-router` and NOT from `@tanstack/start` (no such package). Wrong path produces `createServerFn is not a function`.
 > **CRITICAL**: Server functions are RPC endpoints. They are reachable by direct POST regardless of which route renders the calling UI. **Auth must be enforced inside the handler (or via middleware) — a route `beforeLoad` does NOT protect the RPC.** See [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md) for the session/middleware pattern.
 > **CRITICAL**: Loaders are ISOMORPHIC — they run on BOTH client and server. Database queries, file system access, and secret API keys MUST go inside `createServerFn`, NOT in loaders directly.
 > **CRITICAL**: Do not use `"use server"` directives, `getServerSideProps`, or any Next.js/Remix server patterns. TanStack Start uses `createServerFn` exclusively.
@@ -269,25 +268,7 @@ Static imports of server functions are safe — the build replaces implementatio
 
 ## Common Mistakes
 
-### 1. HIGH: Wrong import path for `createServerFn`
-
-`createServerFn` lives in the framework-scoped Start package, not in the router or a non-existent generic `@tanstack/start`. The wrong path looks plausible but throws `createServerFn is not a function` at runtime.
-
-```tsx
-// WRONG — does not export createServerFn
-import { createServerFn } from '@tanstack/react-router'
-
-// WRONG — package does not exist
-import { createServerFn } from '@tanstack/start'
-
-// CORRECT — framework-scoped start package
-import { createServerFn } from '@tanstack/react-start'
-// (or @tanstack/solid-start, @tanstack/vue-start)
-```
-
-Server-context utilities (`getRequest`, `getRequestHeader`, `setResponseHeader`, etc.) live at `@tanstack/<framework>-start/server` — same framework prefix.
-
-### 2. CRITICAL: Relying on a route guard to protect a server function
+### 1. CRITICAL: Relying on a route guard to protect a server function
 
 A `beforeLoad` redirect protects the **route's UI**, not the **RPC**. `createServerFn` exposes a callable endpoint that an attacker can hit directly — no need to load the route at all. Auth on the route is necessary but not sufficient.
 
@@ -313,7 +294,7 @@ const getMyOrders = createServerFn({ method: 'GET' })
 
 Apply `authMiddleware` (or an equivalent in-handler check) to **every** `createServerFn` that needs auth. See [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md) for the full session/middleware pattern and [start-core/middleware](../middleware/SKILL.md) for composing the factory.
 
-### 3. CRITICAL: Putting server-only code in loaders
+### 2. CRITICAL: Putting server-only code in loaders
 
 ```tsx
 // WRONG — loader is ISOMORPHIC, runs on BOTH client and server
@@ -335,7 +316,7 @@ export const Route = createFileRoute('/posts')({
 })
 ```
 
-### 4. CRITICAL: Using Next.js / Remix / React Router DOM patterns
+### 3. CRITICAL: Using Next.js / Remix / React Router DOM patterns
 
 If the file lives at `src/pages/`, `app/layout.tsx`, `_app/`, or imports anything from `react-router-dom` or `next/`, it is wrong-framework code. TanStack Start uses `src/routes/` + `createFileRoute` + `createServerFn`.
 
@@ -375,7 +356,7 @@ export const Route = createFileRoute('/users/$id')({
 
 If you see `src/pages/`, `app/layout.tsx`, or `react-router-dom` in agent output, the agent is generating for the wrong framework. Build will fail or routes will conflict at runtime.
 
-### 5. HIGH: Dynamic imports for server functions
+### 4. HIGH: Dynamic imports for server functions
 
 ```tsx
 // WRONG — can cause bundler issues
@@ -385,7 +366,7 @@ const { getUser } = await import('~/utils/users.functions')
 import { getUser } from '~/utils/users.functions'
 ```
 
-### 6. HIGH: Awaiting server function without calling it
+### 5. HIGH: Awaiting server function without calling it
 
 `createServerFn` returns a function — it must be invoked with `()`:
 
@@ -400,7 +381,7 @@ const data = await getItems()
 const data = await getItems({ data: { id: '1' } })
 ```
 
-### 7. CRITICAL: Caching authenticated responses with `Cache-Control: public`
+### 6. CRITICAL: Caching authenticated responses with `Cache-Control: public`
 
 `Cache-Control: public, max-age=N` tells every CDN, proxy, and shared cache between you and the user that this response can be served to anyone. If the response depends on the session (user, tenant, role), the first user's response gets cached and replayed to the next user — a cross-tenant data leak.
 
@@ -428,7 +409,7 @@ setResponseHeaders({ 'Cache-Control': 'no-store' })
 
 Rule of thumb: if the handler reads a session/cookie/auth header or branches on identity, the response is **not** `public`. Default to `private` (or `no-store` for sensitive data); reach for `public` only on responses that are byte-for-byte identical regardless of who asks. See also [start-core/deployment](../deployment/SKILL.md) for ISR/Cache-Control on full pages.
 
-### 8. MEDIUM: When to wrap with `useServerFn`
+### 7. MEDIUM: When to wrap with `useServerFn`
 
 `useServerFn` is **required** when the server function uses `throw redirect()` or `throw notFound()` — the hook wires the throw into the router so the redirect actually navigates. For server functions that just return data (call them directly or via `useMutation`/`useQuery`), the hook is optional.
 

--- a/packages/start-client-core/skills/start-core/server-functions/SKILL.md
+++ b/packages/start-client-core/skills/start-core/server-functions/SKILL.md
@@ -428,18 +428,21 @@ setResponseHeaders({ 'Cache-Control': 'no-store' })
 
 Rule of thumb: if the handler reads a session/cookie/auth header or branches on identity, the response is **not** `public`. Default to `private` (or `no-store` for sensitive data); reach for `public` only on responses that are byte-for-byte identical regardless of who asks. See also [start-core/deployment](../deployment/SKILL.md) for ISR/Cache-Control on full pages.
 
-### 8. MEDIUM: Not using useServerFn for component calls
+### 8. MEDIUM: When to wrap with `useServerFn`
 
-When calling server functions from event handlers in components, use `useServerFn` to get proper React integration:
+`useServerFn` is **required** when the server function uses `throw redirect()` or `throw notFound()` — the hook wires the throw into the router so the redirect actually navigates. For server functions that just return data (call them directly or via `useMutation`/`useQuery`), the hook is optional.
 
 ```tsx
-// WRONG — direct call doesn't integrate with React lifecycle
+// Plain data — direct call is fine (also fine to pass to useMutation/useQuery)
 <button onClick={() => deletePost({ data: { id } })}>Delete</button>
+useMutation({ mutationFn: deletePost })
 
-// CORRECT — useServerFn integrates with React
-const deletePostFn = useServerFn(deletePost)
-<button onClick={() => deletePostFn({ data: { id } })}>Delete</button>
+// Throws redirect/notFound — MUST wrap with useServerFn so the router handles the throw
+const signupFn = useServerFn(signup) // signup throws redirect on success
+<button onClick={() => signupFn({ data: form })}>Sign up</button>
 ```
+
+If in doubt: wrap with `useServerFn`. It's a no-op for plain-data functions and the safe default when a function might later add a redirect.
 
 ## Cross-References
 


### PR DESCRIPTION
## Summary

Targeted feedback on how AI agents perform when reading our TanStack Router/Start skills. They identified 8 concrete failure modes — split across security/trust and code quality — where agents produce insecure output, copy a footgun verbatim, or default to wrong-framework patterns. This PR fixes each one at the source the agent reads (the SKILL.md files indexed by `intent`) and keeps the docs site in sync.

The 8 items, with their fixes:

| # | Failure mode | Fix |
|---|---|---|
| 1 | No canonical baseline for the server half of auth | New `start-core/auth-server-primitives` skill (+ companion doc) covering sessions, cookies, OAuth+PKCE, password-reset enumeration defense, CSRF, rate limiting, session rotation |
| 2 | Route guard ≠ RPC guard — agents protect the route but ship an unprotected `createServerFn` | New CRITICAL note + WRONG/CORRECT mistake in `auth-and-guards`, `server-functions`, `middleware` skills + matching docs |
| 3 | `sendContext` shape validation treated as authorization | Rewrote middleware mistake to a 3-layer pattern: WRONG → STILL WRONG (shape only) → CORRECT (shape AND membership check against the session principal) |
| 4 | `Cache-Control: 'public, max-age=300'` example copied onto authenticated handlers, leaks via CDN | Replaced the example with safe-by-default `private` + `Vary` and added a CRITICAL Common Mistake about the cross-tenant leak path |
| 5 | `import '@tanstack/<fw>-start/server-only'` / `'client-only'` markers existed in docs but no skill mentioned them | Added a dedicated section to `execution-model` skill + an API-table row + a docs section pointing at the canonical reference |
| 6 | Most common runtime error: `createServerFn`/`createMiddleware` imported from `@tanstack/react-router` or non-existent `@tanstack/start` | New CRITICAL line + Common Mistake in `server-functions` and `middleware` skills + a callout in matching docs |
| 7 | `process.env` at module scope: framed only as a leak risk; on Cloudflare Workers it's also `undefined` | Updated the existing mistake in `execution-model` to cover both axes; added a Cloudflare Workers env-at-request-time note in `deployment` skill + `hosting.md` doc |
| 8 | Cross-framework contamination: `src/pages/`, `app/layout.tsx`, `_app/index.tsx`, imports from `react-router-dom` | Wrong-framework subsections in `ssr`, `type-safety`, `server-functions` skills + corresponding docs |

## Files

**Skills (8 modified, 1 new):**
- new: `packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md`
- modified: `auth-and-guards`, `server-functions`, `middleware`, `execution-model`, `deployment`, `ssr`, `type-safety`, parent `start-core/SKILL.md` (registers new sub-skill in table + decision tree)

**Docs (8 modified, 1 new):**
- new: `docs/start/framework/react/guide/authentication-server-primitives.md`
- modified: `authentication-overview.md`, `server-functions.md`, `middleware.md`, `execution-model.md`, `environment-variables.md`, `hosting.md`, `docs/router/guide/authenticated-routes.md`, `docs/router/guide/ssr.md`

## Notes for reviewers

- `npx @tanstack/intent@latest validate` passes — 30 skill files (was 29). All skills under the 500-line cap.
- The `type-safety` skill was at 543 lines after item 8; the existing `ValidateNavigateOptions` / `ValidateRedirectOptions` examples were consolidated into a single combined block (same patterns, just compressed) to bring it back to 484.
- `intent stale` shows pre-existing `library_version` drift on every skill (1.166.2 → 1.169.1) — unrelated to this PR; out of scope.
- We will ask users to re-run their evals against these changes rather than scheduling our own follow-up.

## Test plan

- [ ] `pnpm install`
- [ ] `pnpm test:eslint`
- [ ] `pnpm test:types`
- [ ] `npx @tanstack/intent@latest validate` — confirm 30 skills pass
- [ ] `npx @tanstack/intent@latest list` — confirm `start-core/auth-server-primitives` appears
- [ ] Spot-check rendered skill output via `intent load` for each touched skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New server-side authentication guide: secure __Host- cookies, login/logout patterns, OAuth (state+PKCE), CSRF, rate limiting, password-reset hardening, and session rotation.
  * Explicit warnings that route UI guards do not protect RPC/server endpoints — require handler- or middleware-level authentication enforcement.
  * Edge/SSR env guidance: avoid module-scope env reads (Cloudflare/Workers), use per-request APIs and file-marker patterns for server/client boundaries.
  * Clarified SSR/routing anti-patterns, import/runtime mismatch warnings, and caching best practices (public vs private).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->