### PR TITLE
fix(deps): move fetchdts from devDependencies to dependencies

### DIFF
--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -82,6 +82,7 @@
     "@tanstack/router-core": "workspace:*",
     "@tanstack/start-client-core": "workspace:*",
     "@tanstack/start-storage-context": "workspace:*",
+    "fetchdts": "^0.1.6",
     "h3-v2": "npm:h3@2.0.1-rc.20",
     "seroval": "^1.5.0"
   },
@@ -89,7 +90,6 @@
     "@standard-schema/spec": "^1.0.0",
     "@tanstack/intent": "^0.0.14",
     "cookie-es": "^3.0.0",
-    "fetchdts": "^0.1.6",
     "vite": "*",
     "@types/node": ">=20"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13162,6 +13162,9 @@ importers:
       '@tanstack/start-storage-context':
         specifier: workspace:*
         version: link:../start-storage-context
+      fetchdts:
+        specifier: ^0.1.6
+        version: 0.1.7
       h3-v2:
         specifier: npm:h3@2.0.1-rc.20
         version: h3@2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -13181,9 +13184,6 @@ importers:
       cookie-es:
         specifier: ^3.0.0
         version: 3.1.1
-      fetchdts:
-        specifier: ^0.1.6
-        version: 0.1.7
       vite:
         specifier: ^8.0.0
         version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)


### PR DESCRIPTION
should resolve https://github.com/TanStack/router/issues/7316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency placement so a previously development-only package is now a runtime dependency, ensuring it is available when the package is executed and aligning dependency management with runtime needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->