### PR TITLE
feat(vue-router): add styles support on head

### DIFF
--- a/packages/vue-router/src/Matches.tsx
+++ b/packages/vue-router/src/Matches.tsx
@@ -28,6 +28,7 @@ declare module '@tanstack/router-core' {
     meta?: Array<Vue.ComponentOptions['meta'] | undefined>
     links?: Array<Vue.ComponentOptions['link'] | undefined>
     scripts?: Array<Vue.ComponentOptions['script'] | undefined>
+    styles?: Array<Vue.ComponentOptions['style'] | undefined>
     headScripts?: Array<Vue.ComponentOptions['script'] | undefined>
   }
 }

--- a/packages/vue-router/src/headContentUtils.tsx
+++ b/packages/vue-router/src/headContentUtils.tsx
@@ -117,6 +117,21 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
     return preloadMeta
   })
 
+  const styles = Vue.computed<Array<RouterManagedTag>>(() =>
+    (
+      matches.value
+        .map((match) => match.styles!)
+        .flat(1)
+        .filter(Boolean) as Array<RouterManagedTag>
+    ).map(({ children, ...style }) => ({
+      tag: 'style',
+      attrs: {
+        ...style,
+      },
+      children,
+    })),
+  )
+
   const headScripts = Vue.computed<Array<RouterManagedTag>>(() =>
     (
       matches.value
@@ -182,6 +197,7 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
         ...meta.value,
         ...preloadMeta.value,
         ...links.value,
+        ...styles.value,
         ...headScripts.value,
       ] as Array<RouterManagedTag>,
       (d) => {


### PR DESCRIPTION
## Summary

Closes #7318.

- Add the missing `styles` field to the Vue `RouteMatchExtensions` module augmentation in `packages/vue-router/src/Matches.tsx`, alongside `meta`, `links`, `scripts`, and `headScripts` — bringing Vue to parity with the React and Solid counterparts.
- Wire up the runtime in `packages/vue-router/src/headContentUtils.tsx` so `head().styles` declared on routes is actually rendered (mirroring the existing `headScripts` pattern, then included in the final `uniqBy` output).

## Test plan

- [x] `pnpm --filter @tanstack/vue-router test:unit` (45 files, 783 tests, 0 type errors). The existing `route.test.tsx` `styles` and `styles w/loader` tests now exercise the typed field end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for route-level style definitions in Vue Router, allowing styles to be automatically managed and applied through route configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->