### PR TITLE
chore: fix duplicate "the" typo across router packages

### DIFF
--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -183,7 +183,7 @@ export function FileRouteLoader<
 ) => TLoaderFn {
   if (process.env.NODE_ENV !== 'production') {
     console.warn(
-      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options`,
+      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options`,
     )
   }
   return (loaderFn) => loaderFn as any

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -713,7 +713,7 @@ const runLoader = async (
       const pendingPromise = match._nonReactive.minPendingPromise
       if (pendingPromise) await pendingPromise
 
-      // Last but not least, wait for the the components
+      // Last but not least, wait for the components
       // to be preloaded before we resolve the match
       if (route._componentsPromise) await route._componentsPromise
       inner.updateMatch(matchId, (prev) => ({

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -711,7 +711,7 @@ describe('matchPathname', () => {
         expectedMatchedParams: { id: '123' },
       },
       {
-        name: 'should match and return the the splat param',
+        name: 'should match and return the splat param',
         input: '/users/123',
         matchingOptions: {
           to: '/users/$',

--- a/packages/solid-router/src/fileRoute.ts
+++ b/packages/solid-router/src/fileRoute.ts
@@ -148,7 +148,7 @@ export class FileRoute<
 
 /** 
   @deprecated It's recommended not to split loaders into separate files.
-  Instead, place the loader function in the the main route file, inside the
+  Instead, place the loader function in the main route file, inside the
   `createFileRoute('/path/to/file)(options)` options.
 */
 export function FileRouteLoader<
@@ -173,7 +173,7 @@ export function FileRouteLoader<
 ) => TLoaderFn {
   if (process.env.NODE_ENV !== 'production') {
     console.warn(
-      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options`,
+      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options`,
     )
   }
   return (loaderFn) => loaderFn as any

--- a/packages/vue-router/src/fileRoute.ts
+++ b/packages/vue-router/src/fileRoute.ts
@@ -148,7 +148,7 @@ export class FileRoute<
 
 /**
   @deprecated It's recommended not to split loaders into separate files.
-  Instead, place the loader function in the the main route file, inside the
+  Instead, place the loader function in the main route file, inside the
   `createFileRoute('/path/to/file)(options)` options.
 */
 export function FileRouteLoader<
@@ -173,7 +173,7 @@ export function FileRouteLoader<
 ) => TLoaderFn {
   if (process.env.NODE_ENV !== 'production') {
     console.warn(
-      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options`,
+      `Warning: FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options`,
     )
   }
   return (loaderFn) => loaderFn as any


### PR DESCRIPTION
Removes a duplicate "the" that appears 7 times across 5 files in the router monorepo:

- `packages/vue-router/src/fileRoute.ts` (JSDoc + console.warn): "in the the main route file" -> "in the main route file"
- `packages/solid-router/src/fileRoute.ts` (JSDoc + console.warn): same
- `packages/react-router/src/fileRoute.ts` (console.warn): same
- `packages/router-core/src/load-matches.ts` (comment): "wait for the the components" -> "wait for the components"
- `packages/router-core/tests/path.test.ts` (test name): "should match and return the the splat param" -> "should match and return the splat param"

Net zero lines added/removed - just removes the duplicated word in each spot. No behavior change beyond the slightly cleaner `console.warn` message that ships with the deprecated `FileRouteLoader`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected duplicated words ("the the") in deprecation warnings, code comments, and test descriptions across router packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->