### PR TITLE
fix(start-server-core): fall back to GET handler for HEAD requests (RFC 9110 §9.3.2)

### DIFF
--- a/.changeset/fix-head-request-server-route-fallback.md
+++ b/.changeset/fix-head-request-server-route-fallback.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/start-server-core": patch
+'@tanstack/start-server-core': patch
 ---
 
 fix(start-server-core): fall back HEAD requests to GET then ANY per RFC 9110 §9.3.2

--- a/.changeset/fix-head-request-server-route-fallback.md
+++ b/.changeset/fix-head-request-server-route-fallback.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/start-server-core": patch
+---
+
+fix(start-server-core): fall back HEAD requests to GET then ANY per RFC 9110 §9.3.2

--- a/e2e/react-start/server-routes/src/routeTree.gen.ts
+++ b/e2e/react-start/server-routes/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as ApiOnlyAnyRouteImport } from './routes/api/only-any'
 import { Route as ApiMiddlewareContextRouteImport } from './routes/api/middleware-context'
 import { Route as ApiHeadFallbackRouteImport } from './routes/api/head-fallback'
 import { Route as ApiGetAndAnyRouteImport } from './routes/api/get-and-any'
+import { Route as ApiHeadRedirectFallbackRouteImport } from './routes/api/head-redirect-fallback'
 import { Route as ApiParamsFooRouteRouteImport } from './routes/api/params/$foo/route'
 import { Route as ApiParamsFooBarRouteImport } from './routes/api/params/$foo/$bar'
 
@@ -61,6 +62,11 @@ const ApiGetAndAnyRoute = ApiGetAndAnyRouteImport.update({
   path: '/api/get-and-any',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiHeadRedirectFallbackRoute = ApiHeadRedirectFallbackRouteImport.update({
+  id: '/api/head-redirect-fallback',
+  path: '/api/head-redirect-fallback',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiMiddlewareContextRoute = ApiMiddlewareContextRouteImport.update({
   id: '/api/middleware-context',
   path: '/api/middleware-context',
@@ -85,6 +91,7 @@ export interface FileRoutesByFullPath {
   '/api/only-any': typeof ApiOnlyAnyRoute
   '/api/head-fallback': typeof ApiHeadFallbackRoute
   '/api/get-and-any': typeof ApiGetAndAnyRoute
+  '/api/head-redirect-fallback': typeof ApiHeadRedirectFallbackRoute
   '/methods/only-any': typeof MethodsOnlyAnyRoute
   '/methods/': typeof MethodsIndexRoute
   '/api/params/$foo': typeof ApiParamsFooRouteRouteWithChildren
@@ -97,6 +104,7 @@ export interface FileRoutesByTo {
   '/api/only-any': typeof ApiOnlyAnyRoute
   '/api/head-fallback': typeof ApiHeadFallbackRoute
   '/api/get-and-any': typeof ApiGetAndAnyRoute
+  '/api/head-redirect-fallback': typeof ApiHeadRedirectFallbackRoute
   '/methods/only-any': typeof MethodsOnlyAnyRoute
   '/methods': typeof MethodsIndexRoute
   '/api/params/$foo': typeof ApiParamsFooRouteRouteWithChildren
@@ -111,6 +119,7 @@ export interface FileRoutesById {
   '/api/only-any': typeof ApiOnlyAnyRoute
   '/api/head-fallback': typeof ApiHeadFallbackRoute
   '/api/get-and-any': typeof ApiGetAndAnyRoute
+  '/api/head-redirect-fallback': typeof ApiHeadRedirectFallbackRoute
   '/methods/only-any': typeof MethodsOnlyAnyRoute
   '/methods/': typeof MethodsIndexRoute
   '/api/params/$foo': typeof ApiParamsFooRouteRouteWithChildren
@@ -126,6 +135,7 @@ export interface FileRouteTypes {
     | '/api/only-any'
     | '/api/head-fallback'
     | '/api/get-and-any'
+    | '/api/head-redirect-fallback'
     | '/methods/only-any'
     | '/methods/'
     | '/api/params/$foo'
@@ -138,6 +148,7 @@ export interface FileRouteTypes {
     | '/api/only-any'
     | '/api/head-fallback'
     | '/api/get-and-any'
+    | '/api/head-redirect-fallback'
     | '/methods/only-any'
     | '/methods'
     | '/api/params/$foo'
@@ -151,6 +162,7 @@ export interface FileRouteTypes {
     | '/api/only-any'
     | '/api/head-fallback'
     | '/api/get-and-any'
+    | '/api/head-redirect-fallback'
     | '/methods/only-any'
     | '/methods/'
     | '/api/params/$foo'
@@ -165,6 +177,7 @@ export interface RootRouteChildren {
   ApiOnlyAnyRoute: typeof ApiOnlyAnyRoute
   ApiHeadFallbackRoute: typeof ApiHeadFallbackRoute
   ApiGetAndAnyRoute: typeof ApiGetAndAnyRoute
+  ApiHeadRedirectFallbackRoute: typeof ApiHeadRedirectFallbackRoute
   ApiParamsFooRouteRoute: typeof ApiParamsFooRouteRouteWithChildren
 }
 
@@ -226,6 +239,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiGetAndAnyRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/head-redirect-fallback': {
+      id: '/api/head-redirect-fallback'
+      path: '/api/head-redirect-fallback'
+      fullPath: '/api/head-redirect-fallback'
+      preLoaderRoute: typeof ApiHeadRedirectFallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/middleware-context': {
       id: '/api/middleware-context'
       path: '/api/middleware-context'
@@ -283,6 +303,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiOnlyAnyRoute: ApiOnlyAnyRoute,
   ApiHeadFallbackRoute: ApiHeadFallbackRoute,
   ApiGetAndAnyRoute: ApiGetAndAnyRoute,
+  ApiHeadRedirectFallbackRoute: ApiHeadRedirectFallbackRoute,
   ApiParamsFooRouteRoute: ApiParamsFooRouteRouteWithChildren,
 }
 export const routeTree = rootRouteImport

--- a/e2e/react-start/server-routes/src/routeTree.gen.ts
+++ b/e2e/react-start/server-routes/src/routeTree.gen.ts
@@ -16,6 +16,8 @@ import { Route as MethodsIndexRouteImport } from './routes/methods/index'
 import { Route as MethodsOnlyAnyRouteImport } from './routes/methods/only-any'
 import { Route as ApiOnlyAnyRouteImport } from './routes/api/only-any'
 import { Route as ApiMiddlewareContextRouteImport } from './routes/api/middleware-context'
+import { Route as ApiHeadFallbackRouteImport } from './routes/api/head-fallback'
+import { Route as ApiGetAndAnyRouteImport } from './routes/api/get-and-any'
 import { Route as ApiParamsFooRouteRouteImport } from './routes/api/params/$foo/route'
 import { Route as ApiParamsFooBarRouteImport } from './routes/api/params/$foo/$bar'
 
@@ -49,6 +51,16 @@ const ApiOnlyAnyRoute = ApiOnlyAnyRouteImport.update({
   path: '/api/only-any',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiHeadFallbackRoute = ApiHeadFallbackRouteImport.update({
+  id: '/api/head-fallback',
+  path: '/api/head-fallback',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiGetAndAnyRoute = ApiGetAndAnyRouteImport.update({
+  id: '/api/get-and-any',
+  path: '/api/get-and-any',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiMiddlewareContextRoute = ApiMiddlewareContextRouteImport.update({
   id: '/api/middleware-context',
   path: '/api/middleware-context',
@@ -71,6 +83,8 @@ export interface FileRoutesByFullPath {
   '/merge-middleware-context': typeof MergeMiddlewareContextRoute
   '/api/middleware-context': typeof ApiMiddlewareContextRoute
   '/api/only-any': typeof ApiOnlyAnyRoute
+  '/api/head-fallback': typeof ApiHeadFallbackRoute
+  '/api/get-and-any': typeof ApiGetAndAnyRoute
   '/methods/only-any': typeof MethodsOnlyAnyRoute
   '/methods/': typeof MethodsIndexRoute
   '/api/params/$foo': typeof ApiParamsFooRouteRouteWithChildren
@@ -81,6 +95,8 @@ export interface FileRoutesByTo {
   '/merge-middleware-context': typeof MergeMiddlewareContextRoute
   '/api/middleware-context': typeof ApiMiddlewareContextRoute
   '/api/only-any': typeof ApiOnlyAnyRoute
+  '/api/head-fallback': typeof ApiHeadFallbackRoute
+  '/api/get-and-any': typeof ApiGetAndAnyRoute
   '/methods/only-any': typeof MethodsOnlyAnyRoute
   '/methods': typeof MethodsIndexRoute
   '/api/params/$foo': typeof ApiParamsFooRouteRouteWithChildren
@@ -93,6 +109,8 @@ export interface FileRoutesById {
   '/merge-middleware-context': typeof MergeMiddlewareContextRoute
   '/api/middleware-context': typeof ApiMiddlewareContextRoute
   '/api/only-any': typeof ApiOnlyAnyRoute
+  '/api/head-fallback': typeof ApiHeadFallbackRoute
+  '/api/get-and-any': typeof ApiGetAndAnyRoute
   '/methods/only-any': typeof MethodsOnlyAnyRoute
   '/methods/': typeof MethodsIndexRoute
   '/api/params/$foo': typeof ApiParamsFooRouteRouteWithChildren
@@ -106,6 +124,8 @@ export interface FileRouteTypes {
     | '/merge-middleware-context'
     | '/api/middleware-context'
     | '/api/only-any'
+    | '/api/head-fallback'
+    | '/api/get-and-any'
     | '/methods/only-any'
     | '/methods/'
     | '/api/params/$foo'
@@ -116,6 +136,8 @@ export interface FileRouteTypes {
     | '/merge-middleware-context'
     | '/api/middleware-context'
     | '/api/only-any'
+    | '/api/head-fallback'
+    | '/api/get-and-any'
     | '/methods/only-any'
     | '/methods'
     | '/api/params/$foo'
@@ -127,6 +149,8 @@ export interface FileRouteTypes {
     | '/merge-middleware-context'
     | '/api/middleware-context'
     | '/api/only-any'
+    | '/api/head-fallback'
+    | '/api/get-and-any'
     | '/methods/only-any'
     | '/methods/'
     | '/api/params/$foo'
@@ -139,6 +163,8 @@ export interface RootRouteChildren {
   MergeMiddlewareContextRoute: typeof MergeMiddlewareContextRoute
   ApiMiddlewareContextRoute: typeof ApiMiddlewareContextRoute
   ApiOnlyAnyRoute: typeof ApiOnlyAnyRoute
+  ApiHeadFallbackRoute: typeof ApiHeadFallbackRoute
+  ApiGetAndAnyRoute: typeof ApiGetAndAnyRoute
   ApiParamsFooRouteRoute: typeof ApiParamsFooRouteRouteWithChildren
 }
 
@@ -184,6 +210,20 @@ declare module '@tanstack/react-router' {
       path: '/api/only-any'
       fullPath: '/api/only-any'
       preLoaderRoute: typeof ApiOnlyAnyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/head-fallback': {
+      id: '/api/head-fallback'
+      path: '/api/head-fallback'
+      fullPath: '/api/head-fallback'
+      preLoaderRoute: typeof ApiHeadFallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/get-and-any': {
+      id: '/api/get-and-any'
+      path: '/api/get-and-any'
+      fullPath: '/api/get-and-any'
+      preLoaderRoute: typeof ApiGetAndAnyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/middleware-context': {
@@ -241,6 +281,8 @@ const rootRouteChildren: RootRouteChildren = {
   MergeMiddlewareContextRoute: MergeMiddlewareContextRoute,
   ApiMiddlewareContextRoute: ApiMiddlewareContextRoute,
   ApiOnlyAnyRoute: ApiOnlyAnyRoute,
+  ApiHeadFallbackRoute: ApiHeadFallbackRoute,
+  ApiGetAndAnyRoute: ApiGetAndAnyRoute,
   ApiParamsFooRouteRoute: ApiParamsFooRouteRouteWithChildren,
 }
 export const routeTree = rootRouteImport

--- a/e2e/react-start/server-routes/src/routes/api/get-and-any.ts
+++ b/e2e/react-start/server-routes/src/routes/api/get-and-any.ts
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/get-and-any')({
+  server: {
+    handlers: {
+      GET: () =>
+        new Response(null, {
+          headers: { 'x-handler': 'GET' },
+        }),
+      ANY: ({ request }) =>
+        new Response(null, {
+          headers: { 'x-handler': 'ANY', 'x-method': request.method },
+        }),
+    },
+  },
+})

--- a/e2e/react-start/server-routes/src/routes/api/head-fallback.ts
+++ b/e2e/react-start/server-routes/src/routes/api/head-fallback.ts
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+// A server-only route with only a GET handler.
+// Used to test that HEAD requests fall back to the GET handler per RFC 9110.
+export const Route = createFileRoute('/api/head-fallback')({
+  server: {
+    handlers: {
+      GET: () =>
+        new Response('body', {
+          headers: { 'content-type': 'application/xml; charset=utf-8' },
+        }),
+    },
+  },
+})

--- a/e2e/react-start/server-routes/src/routes/api/head-redirect-fallback.ts
+++ b/e2e/react-start/server-routes/src/routes/api/head-redirect-fallback.ts
@@ -1,0 +1,9 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/head-redirect-fallback')({
+  server: {
+    handlers: {
+      GET: () => redirect({ to: '/api/head-fallback', statusCode: 307 }),
+    },
+  },
+})

--- a/e2e/react-start/server-routes/tests/server-routes.spec.ts
+++ b/e2e/react-start/server-routes/tests/server-routes.spec.ts
@@ -68,6 +68,26 @@ test.describe('HEAD fallback', () => {
     expect(result.xHandler).toBe('GET')
     expect(result.body).toBe('')
   })
+
+  test('preserves Location header when GET handler returns a redirect', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    // HEAD /api/head-redirect-fallback → server returns 307 Location:/api/head-fallback
+    // Browser follows the redirect: HEAD /api/head-fallback → 200 with correct headers
+    // If the Location header were lost, the browser could not follow and would see a 307.
+    const result = await page.evaluate(async () => {
+      const res = await fetch('/api/head-redirect-fallback', { method: 'HEAD' })
+      return {
+        status: res.status,
+        contentType: res.headers.get('content-type'),
+        body: await res.text(),
+      }
+    })
+    expect(result.status).toBe(200)
+    expect(result.contentType).toBe('application/xml; charset=utf-8')
+    expect(result.body).toBe('')
+  })
 })
 
 test.describe('methods', () => {

--- a/e2e/react-start/server-routes/tests/server-routes.spec.ts
+++ b/e2e/react-start/server-routes/tests/server-routes.spec.ts
@@ -17,6 +17,59 @@ test('merge-middleware-context', async ({ page }) => {
   expect(contextResult).toContain('test')
 })
 
+test.describe('HEAD fallback', () => {
+  test('strips body and preserves headers when falling back to GET', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    const result = await page.evaluate(async () => {
+      const res = await fetch('/api/head-fallback', { method: 'HEAD' })
+      return {
+        status: res.status,
+        contentType: res.headers.get('content-type'),
+        body: await res.text(),
+      }
+    })
+    expect(result.status).toBe(200)
+    expect(result.contentType).toBe('application/xml; charset=utf-8')
+    expect(result.body).toBe('')
+  })
+
+  test('strips body and preserves headers when falling back to ANY', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    const result = await page.evaluate(async () => {
+      const res = await fetch('/api/only-any', { method: 'HEAD' })
+      return {
+        status: res.status,
+        xHandler: res.headers.get('x-handler'),
+        xMethod: res.headers.get('x-method'),
+        body: await res.text(),
+      }
+    })
+    expect(result.status).toBe(200)
+    expect(result.xHandler).toBe('ANY')
+    expect(result.xMethod).toBe('HEAD')
+    expect(result.body).toBe('')
+  })
+
+  test('prefers GET over ANY for HEAD requests', async ({ page }) => {
+    await page.goto('/')
+    const result = await page.evaluate(async () => {
+      const res = await fetch('/api/get-and-any', { method: 'HEAD' })
+      return {
+        status: res.status,
+        xHandler: res.headers.get('x-handler'),
+        body: await res.text(),
+      }
+    })
+    expect(result.status).toBe(200)
+    expect(result.xHandler).toBe('GET')
+    expect(result.body).toBe('')
+  })
+})
+
 test.describe('methods', () => {
   test('only ANY', async ({ page }) => {
     await page.goto('/methods/only-any')

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -947,11 +947,7 @@ async function handleServerRoutes({
       request,
       getRouter,
     )
-    return new Response(null, {
-      status: resolved.status,
-      statusText: resolved.statusText,
-      headers: resolved.headers,
-    })
+    return new Response(null, resolved)
   }
 
   return ctx.response

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -941,8 +941,12 @@ async function handleServerRoutes({
 
   // RFC 9110 §9.3.2: HEAD must carry the same header fields as GET but no body.
   // Resolve any redirect before stripping so the Location header survives.
-  if (isHeadFallback && ctx.response instanceof Response) {
-    const resolved = await handleRedirectResponse(ctx.response, request, getRouter)
+  if (isHeadFallback) {
+    const resolved = await handleRedirectResponse(
+      ctx.response as Response,
+      request,
+      getRouter,
+    )
     return new Response(null, {
       status: resolved.status,
       statusText: resolved.statusText,

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -891,6 +891,7 @@ async function handleServerRoutes({
 
   // Add handler middleware if exact match
   const server = foundRoute?.options.server
+  let isHeadFallback = false
   if (server?.handlers && isExactMatch) {
     const handlers =
       typeof server.handlers === 'function'
@@ -898,7 +899,14 @@ async function handleServerRoutes({
         : server.handlers
 
     const requestMethod = request.method.toUpperCase() as RouteMethod
-    const handler = handlers[requestMethod] ?? handlers['ANY']
+    // Per RFC 9110 §9.3.2, HEAD must return the same header fields as GET.
+    // Priority for HEAD: explicit HEAD handler → GET → ANY (last resort).
+    const handler =
+      requestMethod === 'HEAD'
+        ? handlers['HEAD'] ?? handlers['GET'] ?? handlers['ANY']
+        : handlers[requestMethod] ?? handlers['ANY']
+    isHeadFallback =
+      requestMethod === 'HEAD' && handler !== undefined && !handlers['HEAD']
 
     if (handler) {
       const mayDefer = !!foundRoute.options.component
@@ -930,6 +938,17 @@ async function handleServerRoutes({
     params: routeParams,
     pathname,
   })
+
+  // RFC 9110 §9.3.2: HEAD must carry the same header fields as GET but no body.
+  // Resolve any redirect before stripping so the Location header survives.
+  if (isHeadFallback && ctx.response instanceof Response) {
+    const resolved = await handleRedirectResponse(ctx.response, request, getRouter)
+    return new Response(null, {
+      status: resolved.status,
+      statusText: resolved.statusText,
+      headers: resolved.headers,
+    })
+  }
 
   return ctx.response
 }

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -903,8 +903,8 @@ async function handleServerRoutes({
     // Priority for HEAD: explicit HEAD handler → GET → ANY (last resort).
     const handler =
       requestMethod === 'HEAD'
-        ? handlers['HEAD'] ?? handlers['GET'] ?? handlers['ANY']
-        : handlers[requestMethod] ?? handlers['ANY']
+        ? (handlers['HEAD'] ?? handlers['GET'] ?? handlers['ANY'])
+        : (handlers[requestMethod] ?? handlers['ANY'])
     isHeadFallback =
       requestMethod === 'HEAD' && handler !== undefined && !handlers['HEAD']
 

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -903,8 +903,8 @@ async function handleServerRoutes({
     // Priority for HEAD: explicit HEAD handler → GET → ANY (last resort).
     const handler =
       requestMethod === 'HEAD'
-        ? (handlers['HEAD'] ?? handlers['GET'] ?? handlers['ANY'])
-        : (handlers[requestMethod] ?? handlers['ANY'])
+        ? handlers['HEAD'] ?? handlers['GET'] ?? handlers['ANY']
+        : handlers[requestMethod] ?? handlers['ANY']
     isHeadFallback =
       requestMethod === 'HEAD' && handler !== undefined && !handlers['HEAD']
 
@@ -942,8 +942,12 @@ async function handleServerRoutes({
   // RFC 9110 §9.3.2: HEAD must carry the same header fields as GET but no body.
   // Resolve any redirect before stripping so the Location header survives.
   if (isHeadFallback) {
+    if (!ctx.response) {
+      throwRouteHandlerError()
+    }
+
     const resolved = await handleRedirectResponse(
-      ctx.response as Response,
+      ctx.response,
       request,
       getRouter,
     )


### PR DESCRIPTION
Fixes #7270.

RFC 9110 §9.3.2 requires HEAD responses to match GET in headers and status, with no body. When a route has no explicit `HEAD` handler, the server falls back to GET and strips the body.

### What changed

- Handler priority: HEAD now tries `HEAD → GET → ANY`. Previously `ANY` beat `GET`, so a route with both a GET and an ANY handler would skip the GET for HEAD requests entirely — wrong per RFC 9110.
- Body stripping now covers the ANY fallback too, not just GET. If HEAD falls back to ANY, the body is stripped.
- Redirect before strip: the old code stripped the body before resolving redirects, converting a `RedirectResponse` to a plain `Response` before `handleRedirectResponse` could process it. The `Location` header was lost as a result. The fix resolves the redirect first, then strips.
- `statusText` is now copied to the stripped response.

### E2E coverage

Three new Playwright tests in `e2e/react-start/server-routes`:
- HEAD to a GET-only route: body empty, content-type preserved
- HEAD to an ANY-only route: body empty, `X-HANDLER: ANY` and `X-METHOD: HEAD` preserved
- HEAD to a route with both GET and ANY: GET wins, body empty

## Test plan

- [ ] `pnpm test` in `packages/start-server-core`
- [ ] E2E tests pass in `e2e/react-start/server-routes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three API endpoints: /api/head-fallback, /api/get-and-any, and /api/head-redirect-fallback.

* **Bug Fixes**
  * HEAD requests now prefer HEAD → GET → ANY (RFC 9110), return empty bodies for HEAD fallbacks, preserve status/headers, and correctly resolve redirects.

* **Tests**
  * Added end-to-end tests validating HEAD behavior, handler selection, header preservation, and redirect flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->