### PR TITLE
fix: update deps

### DIFF
--- a/.changeset/fresh-seroval-lift.md
+++ b/.changeset/fresh-seroval-lift.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/router-core': patch
+'@tanstack/start-client-core': patch
+'@tanstack/start-plugin-core': patch
+'@tanstack/start-server-core': patch
+'@tanstack/start-static-server-functions': patch
+---
+
+Update seroval dependencies to version 1.5.4.

--- a/packages/router-core/package.json
+++ b/packages/router-core/package.json
@@ -184,8 +184,8 @@
   "dependencies": {
     "@tanstack/history": "workspace:*",
     "cookie-es": "^3.0.0",
-    "seroval": "^1.5.0",
-    "seroval-plugins": "^1.5.0"
+    "seroval": "^1.5.4",
+    "seroval-plugins": "^1.5.4"
   },
   "devDependencies": {
     "@tanstack/store": "^0.9.3",

--- a/packages/start-client-core/package.json
+++ b/packages/start-client-core/package.json
@@ -88,7 +88,7 @@
     "@tanstack/router-core": "workspace:*",
     "@tanstack/start-fn-stubs": "workspace:*",
     "@tanstack/start-storage-context": "workspace:*",
-    "seroval": "^1.5.0"
+    "seroval": "^1.5.4"
   },
   "devDependencies": {
     "vite": "*",

--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -95,7 +95,7 @@
     "@tanstack/router-utils": "workspace:*",
     "@tanstack/start-client-core": "workspace:*",
     "@tanstack/start-server-core": "workspace:*",
-    "seroval": "^1.5.0",
+    "seroval": "^1.5.4",
     "cheerio": "^1.0.0",
     "exsolve": "^1.0.7",
     "lightningcss": "^1.32.0",

--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -84,7 +84,7 @@
     "@tanstack/start-storage-context": "workspace:*",
     "fetchdts": "^0.1.6",
     "h3-v2": "npm:h3@2.0.1-rc.20",
-    "seroval": "^1.5.0"
+    "seroval": "^1.5.4"
   },
   "devDependencies": {
     "@standard-schema/spec": "^1.0.0",

--- a/packages/start-static-server-functions/package.json
+++ b/packages/start-static-server-functions/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@tanstack/start-client-core": "workspace:*",
-    "seroval": "^1.5.0"
+    "seroval": "^1.5.4"
   },
   "devDependencies": {
     "vite": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12609,11 +12609,11 @@ importers:
         specifier: ^3.0.0
         version: 3.1.1
       seroval:
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^1.5.4
+        version: 1.5.4
       seroval-plugins:
-        specifier: ^1.5.0
-        version: 1.5.0(seroval@1.5.0)
+        specifier: ^1.5.4
+        version: 1.5.4(seroval@1.5.4)
     devDependencies:
       '@tanstack/store':
         specifier: ^0.9.3
@@ -13075,8 +13075,8 @@ importers:
         specifier: workspace:*
         version: link:../start-storage-context
       seroval:
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^1.5.4
+        version: 1.5.4
     devDependencies:
       '@types/node':
         specifier: 25.0.9
@@ -13139,8 +13139,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       seroval:
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^1.5.4
+        version: 1.5.4
       source-map:
         specifier: ^0.7.6
         version: 0.7.6
@@ -13203,8 +13203,8 @@ importers:
         specifier: npm:h3@2.0.1-rc.20
         version: h3@2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
       seroval:
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^1.5.4
+        version: 1.5.4
     devDependencies:
       '@standard-schema/spec':
         specifier: ^1.0.0
@@ -13231,8 +13231,8 @@ importers:
         specifier: workspace:*
         version: link:../start-client-core
       seroval:
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^1.5.4
+        version: 1.5.4
     devDependencies:
       '@types/node':
         specifier: 25.0.9
@@ -24744,8 +24744,18 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
   seroval@1.5.0:
     resolution: {integrity: sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==}
+    engines: {node: '>=10'}
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
   serve-index@1.9.1:
@@ -39442,7 +39452,13 @@ snapshots:
     dependencies:
       seroval: 1.5.0
 
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
   seroval@1.5.0: {}
+
+  seroval@1.5.4: {}
 
   serve-index@1.9.1:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Seroval and Seroval plugins to version 1.5.4 across multiple TanStack packages (router-core, start-client-core, start-plugin-core, start-server-core, start-static-server-functions) to synchronize runtime dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->