### PR TITLE
fix: fix plain TypeScript parser handling

### DIFF
--- a/.changeset/calm-type-assertions.md
+++ b/.changeset/calm-type-assertions.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/router-generator': patch
+'@tanstack/router-plugin': patch
+'@tanstack/router-utils': patch
+'@tanstack/start-plugin-core': patch
+---
+
+Parse plain TypeScript files without JSX when a filename is available, preventing angle-bracket type assertions from being interpreted as JSX during route and Start import-protection transforms.

--- a/e2e/react-start/basic/src/routeTree.gen.ts
+++ b/e2e/react-start/basic/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as StreamRouteImport } from './routes/stream'
 import { Route as ScriptsRouteImport } from './routes/scripts'
 import { Route as RawStreamRouteImport } from './routes/raw-stream'
 import { Route as PostsRouteImport } from './routes/posts'
+import { Route as PlainTsTypeAssertionRouteImport } from './routes/plain-ts-type-assertion'
 import { Route as LinksRouteImport } from './routes/links'
 import { Route as InlineScriptsRouteImport } from './routes/inline-scripts'
 import { Route as DeferredRouteImport } from './routes/deferred'
@@ -106,6 +107,11 @@ const RawStreamRoute = RawStreamRouteImport.update({
 const PostsRoute = PostsRouteImport.update({
   id: '/posts',
   path: '/posts',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PlainTsTypeAssertionRoute = PlainTsTypeAssertionRouteImport.update({
+  id: '/plain-ts-type-assertion',
+  path: '/plain-ts-type-assertion',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LinksRoute = LinksRouteImport.update({
@@ -443,6 +449,7 @@ export interface FileRoutesByFullPath {
   '/deferred': typeof DeferredRoute
   '/inline-scripts': typeof InlineScriptsRoute
   '/links': typeof LinksRoute
+  '/plain-ts-type-assertion': typeof PlainTsTypeAssertionRoute
   '/posts': typeof PostsRouteWithChildren
   '/raw-stream': typeof RawStreamRouteWithChildren
   '/scripts': typeof ScriptsRoute
@@ -509,6 +516,7 @@ export interface FileRoutesByTo {
   '/deferred': typeof DeferredRoute
   '/inline-scripts': typeof InlineScriptsRoute
   '/links': typeof LinksRoute
+  '/plain-ts-type-assertion': typeof PlainTsTypeAssertionRoute
   '/scripts': typeof ScriptsRoute
   '/stream': typeof StreamRoute
   '/type-only-reexport': typeof TypeOnlyReexportRoute
@@ -572,6 +580,7 @@ export interface FileRoutesById {
   '/deferred': typeof DeferredRoute
   '/inline-scripts': typeof InlineScriptsRoute
   '/links': typeof LinksRoute
+  '/plain-ts-type-assertion': typeof PlainTsTypeAssertionRoute
   '/posts': typeof PostsRouteWithChildren
   '/raw-stream': typeof RawStreamRouteWithChildren
   '/scripts': typeof ScriptsRoute
@@ -643,6 +652,7 @@ export interface FileRouteTypes {
     | '/deferred'
     | '/inline-scripts'
     | '/links'
+    | '/plain-ts-type-assertion'
     | '/posts'
     | '/raw-stream'
     | '/scripts'
@@ -709,6 +719,7 @@ export interface FileRouteTypes {
     | '/deferred'
     | '/inline-scripts'
     | '/links'
+    | '/plain-ts-type-assertion'
     | '/scripts'
     | '/stream'
     | '/type-only-reexport'
@@ -771,6 +782,7 @@ export interface FileRouteTypes {
     | '/deferred'
     | '/inline-scripts'
     | '/links'
+    | '/plain-ts-type-assertion'
     | '/posts'
     | '/raw-stream'
     | '/scripts'
@@ -842,6 +854,7 @@ export interface RootRouteChildren {
   DeferredRoute: typeof DeferredRoute
   InlineScriptsRoute: typeof InlineScriptsRoute
   LinksRoute: typeof LinksRoute
+  PlainTsTypeAssertionRoute: typeof PlainTsTypeAssertionRoute
   PostsRoute: typeof PostsRouteWithChildren
   RawStreamRoute: typeof RawStreamRouteWithChildren
   ScriptsRoute: typeof ScriptsRoute
@@ -899,6 +912,13 @@ declare module '@tanstack/react-router' {
       path: '/posts'
       fullPath: '/posts'
       preLoaderRoute: typeof PostsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/plain-ts-type-assertion': {
+      id: '/plain-ts-type-assertion'
+      path: '/plain-ts-type-assertion'
+      fullPath: '/plain-ts-type-assertion'
+      preLoaderRoute: typeof PlainTsTypeAssertionRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/links': {
@@ -1598,6 +1618,7 @@ const rootRouteChildren: RootRouteChildren = {
   DeferredRoute: DeferredRoute,
   InlineScriptsRoute: InlineScriptsRoute,
   LinksRoute: LinksRoute,
+  PlainTsTypeAssertionRoute: PlainTsTypeAssertionRoute,
   PostsRoute: PostsRouteWithChildren,
   RawStreamRoute: RawStreamRouteWithChildren,
   ScriptsRoute: ScriptsRoute,

--- a/e2e/react-start/basic/src/routes/plain-ts-type-assertion.tsx
+++ b/e2e/react-start/basic/src/routes/plain-ts-type-assertion.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { cast } from '~/utils/cast'
+
+export const Route = createFileRoute('/plain-ts-type-assertion')({
+  component: PlainTsTypeAssertion,
+})
+
+const regressionValue = cast<string>('plain .ts cast parsed')
+
+function PlainTsTypeAssertion() {
+  return (
+    <div className="p-2">
+      <h3>Plain TS Type Assertion</h3>
+      <p data-testid="plain-ts-parser-regression">{regressionValue}</p>
+    </div>
+  )
+}

--- a/e2e/react-start/basic/src/utils/cast.ts
+++ b/e2e/react-start/basic/src/utils/cast.ts
@@ -1,0 +1,3 @@
+export function cast<T>(value: unknown): T {
+  return <T>value
+}

--- a/e2e/react-start/basic/tests/navigation.spec.ts
+++ b/e2e/react-start/basic/tests/navigation.spec.ts
@@ -17,6 +17,15 @@ test('Navigating to post', async ({ page }) => {
   await expect(page.getByRole('heading')).toContainText('sunt aut facere')
 })
 
+test('plain .ts modules with angle-bracket type assertions build and render', async ({
+  page,
+}) => {
+  await page.goto('/plain-ts-type-assertion')
+  await expect(page.getByTestId('plain-ts-parser-regression')).toContainText(
+    'plain .ts cast parsed',
+  )
+})
+
 test('Navigating to user', async ({ page }) => {
   await page.goto('/')
   await page.waitForURL('/')

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -1069,6 +1069,7 @@ ${acc.routeTree.map((child) => `${child.variableName}Route: typeof ${getResolved
       // transform the file
       const transformResult = await transform({
         source: updatedCacheEntry.fileContent,
+        filename: node.fullPath,
         ctx: {
           target: this.config.target,
           routeId: escapedRoutePath,

--- a/packages/router-generator/src/transform/transform.ts
+++ b/packages/router-generator/src/transform/transform.ts
@@ -48,12 +48,13 @@ type RouteCallAnalysis = {
 export function transform({
   ctx,
   source,
+  filename,
   node,
 }: TransformOptions): TransformResult {
   let ast: ReturnType<typeof parseAst>
 
   try {
-    ast = parseAst({ code: source })
+    ast = parseAst({ code: source, filename })
   } catch (error) {
     return {
       result: 'error',

--- a/packages/router-generator/src/transform/types.ts
+++ b/packages/router-generator/src/transform/types.ts
@@ -3,6 +3,7 @@ import type { Config } from '../config'
 
 export interface TransformOptions {
   source: string
+  filename?: string
   ctx: TransformContext
   node: RouteNode
 }

--- a/packages/router-plugin/src/core/code-splitter/compilers.ts
+++ b/packages/router-plugin/src/core/code-splitter/compilers.ts
@@ -237,6 +237,7 @@ export function buildDependencyGraph(
  */
 export function computeSharedBindings(opts: {
   code: string
+  filename?: string
   codeSplitGroupings: CodeSplitGroupings
 }): Set<string> {
   const ast = parseAst(opts)

--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -116,6 +116,7 @@ export function createRouterCodeSplitterPlugin(
 
     const fromCode = detectCodeSplitGroupingsFromRoute({
       code,
+      filename: id,
     })
 
     if (fromCode.groupings !== undefined) {
@@ -150,6 +151,7 @@ export function createRouterCodeSplitterPlugin(
     // Compute shared bindings before compiling the reference route
     const sharedBindings = computeSharedBindings({
       code,
+      filename: id,
       codeSplitGroupings: splitGroupings,
     })
     if (sharedBindings.size > 0) {

--- a/packages/router-plugin/src/core/router-hmr-plugin.ts
+++ b/packages/router-plugin/src/core/router-hmr-plugin.ts
@@ -83,7 +83,7 @@ export function createRouterHmrPlugin(
           }
         }
 
-        const ast = parseAst({ code })
+        const ast = parseAst({ code, filename: normalizedId })
         ast.program.body.push(
           ...createRouteHmrStatement([], {
             hmrStyle,

--- a/packages/router-utils/src/ast.ts
+++ b/packages/router-utils/src/ast.ts
@@ -11,23 +11,51 @@ import type * as _babel_types from '@babel/types'
 
 export type ParseAstOptions = ParserOptions & {
   code: string
+  filename?: string
 }
 
 export type ParseAstResult = ParseResult<_babel_types.File>
-export function parseAst({ code, ...opts }: ParseAstOptions): ParseAstResult {
+export function parseAst({
+  code,
+  filename,
+  sourceFilename,
+  plugins,
+  ...opts
+}: ParseAstOptions): ParseAstResult {
+  const inferredFilename = filename ?? sourceFilename
   return parse(code, {
-    plugins: [
-      'jsx',
-      'typescript',
-      'explicitResourceManagement',
-      'importAttributes',
-      'deprecatedImportAssert',
-      ['decorators', { decoratorsBeforeExport: true }],
-      'decoratorAutoAccessors',
-    ],
+    plugins: plugins ?? getDefaultParserPluginsForFilename(inferredFilename),
     sourceType: 'module',
+    sourceFilename,
     ...opts,
   })
+}
+
+function getDefaultParserPluginsForFilename(
+  filename: string | undefined,
+): NonNullable<ParserOptions['plugins']> {
+  const plugins: NonNullable<ParserOptions['plugins']> = [
+    'typescript',
+    'explicitResourceManagement',
+    'importAttributes',
+    'deprecatedImportAssert',
+    ['decorators', { decoratorsBeforeExport: true }],
+    'decoratorAutoAccessors',
+  ]
+
+  if (!isPlainTypeScriptFile(filename)) {
+    plugins.unshift('jsx')
+  }
+
+  return plugins
+}
+
+function isPlainTypeScriptFile(filename: string | undefined): boolean {
+  if (!filename) {
+    return false
+  }
+
+  return /\.[cm]?ts(?:$|[?#])/.test(filename)
 }
 
 let generate = _generate

--- a/packages/router-utils/tests/stripTypeExports.test.ts
+++ b/packages/router-utils/tests/stripTypeExports.test.ts
@@ -25,6 +25,14 @@ export const value = data`
 
       expect(() => parseAst({ code })).not.toThrow()
     })
+
+    test('parses angle-bracket type assertions in .ts files without JSX', () => {
+      const code = `export function cast<T>(value: any): T {
+  return <T>value
+}`
+
+      expect(() => parseAst({ code, filename: 'cast.ts' })).not.toThrow()
+    })
   })
 
   describe('type alias declarations', () => {

--- a/packages/start-plugin-core/src/import-protection/analysis.ts
+++ b/packages/start-plugin-core/src/import-protection/analysis.ts
@@ -1,10 +1,10 @@
 import * as t from '@babel/types'
+import { parseAst } from '@tanstack/router-utils'
 
-import { parseImportProtectionAst } from './ast'
 import { buildLineIndex } from './sourceLocation'
 import { getOrCreate } from './utils'
 import type { LineIndex, TransformResult } from './sourceLocation'
-import type { ParsedAst } from './ast'
+import type { ParseAstResult } from '@tanstack/router-utils'
 
 export type UsagePos = { line: number; column0: number }
 
@@ -18,7 +18,7 @@ type ImportBindingInfo = {
 type UsageCacheKey = `${BoundaryEnv | 'post'}::${string}`
 
 export type ImportAnalysis = {
-  ast: ParsedAst
+  ast: ParseAstResult
   lineIndex: LineIndex
   importSourcesInOrder: Array<string>
   importSpecifierLocationIndex: Map<string, number>
@@ -28,9 +28,10 @@ export type ImportAnalysis = {
   usageByKey: Map<UsageCacheKey, UsagePos | null>
 }
 
-function makeTransientResult(code: string): TransformResult {
+function makeTransientResult(code: string, filename?: string): TransformResult {
   return {
     code,
+    filename,
     map: undefined,
     originalCode: undefined,
   }
@@ -131,7 +132,9 @@ export function isValidExportName(name: string): boolean {
 }
 
 function buildImportAnalysis(result: TransformResult): ImportAnalysis {
-  const ast = result.parsedAst ?? parseImportProtectionAst(result.code)
+  const ast =
+    result.parsedAst ??
+    parseAst({ code: result.code, filename: result.filename })
   result.parsedAst = ast
 
   const importSourcesInOrder: Array<string> = []
@@ -325,8 +328,11 @@ export function getImportSourcesFromResult(
   return getOrCreateImportAnalysis(result).importSourcesInOrder
 }
 
-export function getImportSources(code: string): Array<string> {
-  return getImportSourcesFromResult(makeTransientResult(code))
+export function getImportSources(
+  code: string,
+  filename?: string,
+): Array<string> {
+  return getImportSourcesFromResult(makeTransientResult(code, filename))
 }
 
 export function getImportSpecifierLocationFromResult(
@@ -348,8 +354,11 @@ export function getMockExportNamesBySourceFromResult(
 
 export function getMockExportNamesBySource(
   code: string,
+  filename?: string,
 ): Map<string, Array<string>> {
-  return getMockExportNamesBySourceFromResult(makeTransientResult(code))
+  return getMockExportNamesBySourceFromResult(
+    makeTransientResult(code, filename),
+  )
 }
 
 export function getNamedExportsFromResult(
@@ -358,8 +367,11 @@ export function getNamedExportsFromResult(
   return getOrCreateImportAnalysis(result).namedExports
 }
 
-export function getNamedExports(code: string): Array<string> {
-  return getNamedExportsFromResult(makeTransientResult(code))
+export function getNamedExports(
+  code: string,
+  filename?: string,
+): Array<string> {
+  return getNamedExportsFromResult(makeTransientResult(code, filename))
 }
 
 function isCompilerSafeBoundaryCall(

--- a/packages/start-plugin-core/src/import-protection/ast.ts
+++ b/packages/start-plugin-core/src/import-protection/ast.ts
@@ -1,7 +1,0 @@
-import { parseAst } from '@tanstack/router-utils'
-
-export type ParsedAst = ReturnType<typeof parseAst>
-
-export function parseImportProtectionAst(code: string): ParsedAst {
-  return parseAst({ code })
-}

--- a/packages/start-plugin-core/src/import-protection/rewrite.ts
+++ b/packages/start-plugin-core/src/import-protection/rewrite.ts
@@ -1,10 +1,9 @@
 import * as t from '@babel/types'
-import { generateFromAst } from '@tanstack/router-utils'
+import { generateFromAst, parseAst } from '@tanstack/router-utils'
 
-import { parseImportProtectionAst } from './ast'
 import { MOCK_MODULE_ID } from './constants'
-import type { ParsedAst } from './ast'
 import type { SourceMapLike } from './sourceLocation'
+import type { ParseAstResult } from '@tanstack/router-utils'
 
 function getModuleExportName(node: t.Identifier | t.StringLiteral): string {
   return t.isIdentifier(node) ? node.name : node.value
@@ -67,7 +66,7 @@ export function rewriteDeniedImports(
   getMockModuleId: (source: string) => string = () => MOCK_MODULE_ID,
 ): { code: string; map?: SourceMapLike } | undefined {
   return rewriteDeniedImportsFromAst(
-    parseImportProtectionAst(code),
+    parseAst({ code, filename: id }),
     id,
     deniedSources,
     getMockModuleId,
@@ -75,7 +74,7 @@ export function rewriteDeniedImports(
 }
 
 function rewriteDeniedImportsFromAst(
-  ast: ParsedAst,
+  ast: ParseAstResult,
   id: string,
   deniedSources: Set<string>,
   getMockModuleId: (source: string) => string = () => MOCK_MODULE_ID,

--- a/packages/start-plugin-core/src/import-protection/sourceLocation.ts
+++ b/packages/start-plugin-core/src/import-protection/sourceLocation.ts
@@ -8,8 +8,8 @@ import {
 } from './analysis'
 import { getOrCreate, normalizeFilePath } from './utils'
 import type { ImportAnalysis } from './analysis'
-import type { ParsedAst } from './ast'
 import type { Loc } from './trace'
+import type { ParseAstResult } from '@tanstack/router-utils'
 import type { RawSourceMap } from 'source-map'
 
 // Source-map type compatible with both Rollup's SourceMap and source-map's
@@ -31,12 +31,13 @@ export interface SourceMapLike {
 // Transform result provider (replaces ctx.load() which doesn't work in dev)
 export interface TransformResult {
   code: string
+  filename?: string
   map: SourceMapLike | undefined
   originalCode: string | undefined
   originalResult?: TransformResult
   /** Precomputed line index for `code` (index → line/col). */
   lineIndex?: LineIndex
-  parsedAst?: ParsedAst
+  parsedAst?: ParseAstResult
   analysis?: ImportAnalysis
 }
 
@@ -335,6 +336,7 @@ export function getOrCreateOriginalTransformResult(
   if (!result.originalResult) {
     result.originalResult = {
       code: result.originalCode,
+      filename: result.filename,
       map: undefined,
       originalCode: result.originalCode,
     }

--- a/packages/start-plugin-core/src/rsbuild/import-protection.ts
+++ b/packages/start-plugin-core/src/rsbuild/import-protection.ts
@@ -559,6 +559,7 @@ async function buildTransformResultProvider(opts: {
 
     const result: TransformResult = {
       code,
+      filename: resource ?? file,
       map,
       originalCode,
       lineIndex: buildLineIndex(code),
@@ -844,7 +845,7 @@ async function getMarkerKindForFile(opts: {
         return undefined
       }
 
-      const imports = getImportSources(code)
+      const imports = getImportSources(code, opts.file)
       const hasServerOnly = imports.some((source) =>
         opts.config.markerSpecifiers.serverOnly.has(source),
       )
@@ -1107,7 +1108,7 @@ export function registerImportProtection(
 
         const matchers = getRulesForEnvironment(config, envName)
         const relativeFile = getImportProtectionRelativePath(config.root, file)
-        const importSources = getImportSources(ctx.code)
+        const importSources = getImportSources(ctx.code, file)
         const transformedImportSources = new Set(importSources)
         const transformInputFileSystem = shared.inputFileSystems[envName]
         const loadOriginalCodeForTransform: OriginalCodeLoader =
@@ -1127,12 +1128,13 @@ export function registerImportProtection(
               )
             : undefined
         const buildImportSources = originalCode
-          ? getImportSources(originalCode)
+          ? getImportSources(originalCode, file)
           : []
         const buildTransformResult: TransformResult | undefined =
           config.command === 'build'
             ? {
                 code: ctx.code,
+                filename: file,
                 map: undefined,
                 originalCode,
                 lineIndex: buildLineIndex(ctx.code),
@@ -1191,7 +1193,7 @@ export function registerImportProtection(
           let exportNames: Array<string> = []
 
           try {
-            exportNames = getNamedExports(ctx.code)
+            exportNames = getNamedExports(ctx.code, file)
           } catch {
             exportNames = []
           }
@@ -1215,7 +1217,7 @@ export function registerImportProtection(
         const deniedSpecifierReplacements = new Map<string, string>()
         const exportsBySource = (() => {
           try {
-            return getMockExportNamesBySource(ctx.code)
+            return getMockExportNamesBySource(ctx.code, file)
           } catch {
             return new Map<string, Array<string>>()
           }

--- a/packages/start-plugin-core/src/start-compiler/compiler.ts
+++ b/packages/start-plugin-core/src/start-compiler/compiler.ts
@@ -872,7 +872,7 @@ export class StartCompiler {
     id: string
     parserFilename?: string
   }) {
-    const ast = parseAst({ code, filename: parserFilename ?? id })
+    const ast = parseAst({ code, filename: parserFilename ?? cleanId(id) })
     const info = this.extractModuleInfo(ast, id)
     return { info, ast }
   }

--- a/packages/start-plugin-core/src/start-compiler/compiler.ts
+++ b/packages/start-plugin-core/src/start-compiler/compiler.ts
@@ -863,8 +863,16 @@ export class StartCompiler {
     return info
   }
 
-  public ingestModule({ code, id }: { code: string; id: string }) {
-    const ast = parseAst({ code })
+  public ingestModule({
+    code,
+    id,
+    parserFilename,
+  }: {
+    code: string
+    id: string
+    parserFilename?: string
+  }) {
+    const ast = parseAst({ code, filename: parserFilename ?? id })
     const info = this.extractModuleInfo(ast, id)
     return { info, ast }
   }
@@ -974,10 +982,12 @@ export class StartCompiler {
   public async compile({
     code,
     id,
+    parserFilename,
     detectedKinds,
   }: {
     code: string
     id: string
+    parserFilename?: string
     /** Pre-detected kinds present in this file. If not provided, all valid kinds are checked. */
     detectedKinds?: Set<LookupKind>
   }) {
@@ -1008,7 +1018,7 @@ export class StartCompiler {
 
     // Always parse and extract module info upfront.
     // This ensures the module is cached for import resolution even if no candidates are found.
-    const { ast } = this.ingestModule({ code, id })
+    const { ast } = this.ingestModule({ code, id, parserFilename })
 
     // Single-pass traversal to:
     // 1. Collect candidate paths (only candidates, not all CallExpressions)

--- a/packages/start-plugin-core/src/vite/import-protection-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/import-protection-plugin/plugin.ts
@@ -539,7 +539,7 @@ export function importProtectionPlugin(
         return []
 
       try {
-        parsedBySource = getMockExportNamesBySource(importerCode)
+        parsedBySource = getMockExportNamesBySource(importerCode, importerFile)
 
         // Also index by resolved physical IDs so later lookups match.
         await recordMockExportsForImporter(
@@ -1853,7 +1853,7 @@ export function importProtectionPlugin(
             // Falls back to empty list on non-standard syntax.
             let exportNames: Array<string> = []
             try {
-              exportNames = getNamedExports(code)
+              exportNames = getNamedExports(code, file)
             } catch {
               // Parsing may fail on non-standard syntax
             }
@@ -1913,6 +1913,7 @@ export function importProtectionPlugin(
 
           const result: TransformResult = {
             code,
+            filename: file,
             map,
             originalCode,
             lineIndex,
@@ -1931,7 +1932,7 @@ export function importProtectionPlugin(
           // Dev mode: resolve imports, populate graph, detect violations,
           // and rewrite denied imports.
           const isDevMock = config.effectiveBehavior === 'mock'
-          const importSources = getImportSources(code)
+          const importSources = getImportSources(code, file)
           const resolvedChildren = new Set<string>()
           const deniedSourceReplacements = new Map<string, string>()
           for (const src of importSources) {

--- a/packages/start-plugin-core/tests/createServerFn/createServerFn.test.ts
+++ b/packages/start-plugin-core/tests/createServerFn/createServerFn.test.ts
@@ -23,6 +23,7 @@ const TSS_SERVERFN_SPLIT_PARAM = 'tss-serverfn-split'
 async function compile(opts: {
   env: 'client' | 'server'
   code: string
+  parserFilename?: string
   isProviderFile: boolean
   mode: 'dev' | 'build'
 }) {
@@ -55,6 +56,7 @@ async function compile(opts: {
   const result = await compiler.compile({
     code: opts.code,
     id,
+    parserFilename: opts.parserFilename,
   })
   return result
 }
@@ -77,6 +79,7 @@ describe('createServerFn compiles correctly', async () => {
         env: env.type,
         isProviderFile: env.isProviderFile,
         code,
+        parserFilename: `/test/src/${filename}`,
         mode: 'build',
       })
 


### PR DESCRIPTION
fixes #7341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new example route at /plain-ts-type-assertion that displays a regression/test value.

* **Bug Fixes**
  * Fixed parsing of angle-bracket TypeScript assertions in plain .ts files so they're no longer misinterpreted as JSX during builds.

* **Chores**
  * Patch version bumps for router generator, plugin, utils, and Start plugin core.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->