### PR TITLE
fix: disable rsbuild server compression

### DIFF
--- a/packages/start-plugin-core/src/rsbuild/plugin.ts
+++ b/packages/start-plugin-core/src/rsbuild/plugin.ts
@@ -199,6 +199,9 @@ export function tanStackStartRsbuild(
             },
           },
           server: {
+            // Rsbuild compression currently treats Node's raw header array
+            // writeHead form as an object, which corrupts SSR response headers.
+            compress: false,
             // SSR apps render every route on the server — disable HTML
             // fallback so rsbuild doesn't intercept /_serverFn/ URLs.
             htmlFallback: false,


### PR DESCRIPTION
fixes #7344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with Server-Side Rendering response header handling to prevent data corruption during transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->