### PR TITLE
perf: patch @solidjs/signals with upstream perf commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,9 @@
       "@tanstack/router-utils": "workspace:*",
       "@tanstack/start-static-server-functions": "workspace:*",
       "@tanstack/nitro-v2-vite-plugin": "workspace:*"
+    },
+    "patchedDependencies": {
+      "@solidjs/signals@2.0.0-beta.10": "patches/@solidjs__signals@2.0.0-beta.10.patch"
     }
   }
 }

--- a/patches/@solidjs__signals@2.0.0-beta.10.patch
+++ b/patches/@solidjs__signals@2.0.0-beta.10.patch
@@ -1,0 +1,9887 @@
+diff --git a/dist/dev.js b/dist/dev.js
+index c8999debf3034bc810052a669774780f6d97f20b..0cdfa245bef9a94d1d546e5eda144d63e9cc9462 100644
+--- a/dist/dev.js
++++ b/dist/dev.js
+@@ -35,12 +35,14 @@ const REACTIVE_DISPOSED = 1 << 6;
+ const REACTIVE_OPTIMISTIC_DIRTY = 1 << 7;
+ const REACTIVE_SNAPSHOT_STALE = 1 << 8;
+ const REACTIVE_LAZY = 1 << 9;
++const REACTIVE_MANUAL_WRITE = 1 << 10;
+ const CONFIG_OWNED_WRITE = 1 << 0;
+ const CONFIG_NO_SNAPSHOT = 1 << 1;
+ const CONFIG_TRANSPARENT = 1 << 2;
+ const CONFIG_IN_SNAPSHOT_SCOPE = 1 << 3;
+ const CONFIG_CHILDREN_FORBIDDEN = 1 << 4;
+ const CONFIG_AUTO_DISPOSE = 1 << 5;
++const CONFIG_SYNC = 1 << 6;
+ const STATUS_PENDING = 1 << 0;
+ const STATUS_ERROR = 1 << 1;
+ const STATUS_UNINITIALIZED = 1 << 2;
+@@ -53,6 +55,91 @@ const STORE_SNAPSHOT_PROPS = "sp";
+ const SUPPORTS_PROXY = typeof Proxy === "function";
+ const defaultContext = {};
+ const $REFRESH = Symbol("refresh");
++const hooks = {};
++const diagnosticListeners = new Set();
++const diagnosticCaptures = new Set();
++let diagnosticSequence = 0;
++const diagnostics = {
++  subscribe(listener) {
++    diagnosticListeners.add(listener);
++    return () => diagnosticListeners.delete(listener);
++  },
++  capture() {
++    const events = [];
++    diagnosticCaptures.add(events);
++    return {
++      get events() {
++        return events;
++      },
++      clear() {
++        events.length = 0;
++      },
++      stop() {
++        diagnosticCaptures.delete(events);
++        return [...events];
++      }
++    };
++  }
++};
++const DEV$1 = {
++  hooks: hooks,
++  diagnostics: diagnostics,
++  getChildren: getChildren,
++  getSignals: getSignals,
++  getParent: getParent,
++  getSources: getSources,
++  getObservers: getObservers
++};
++function emitDiagnostic(event) {
++  const entry = { sequence: ++diagnosticSequence, ...event };
++  for (const listener of diagnosticListeners) listener(entry);
++  for (const capture of diagnosticCaptures) capture.push(entry);
++  return entry;
++}
++function registerGraph(value, owner) {
++  value._owner = owner;
++  if (owner) {
++    if (!owner._signals) owner._signals = [];
++    owner._signals.push(value);
++  }
++  DEV$1.hooks.onGraph?.(value, owner);
++}
++function clearSignals(node) {
++  node._signals = undefined;
++}
++function getChildren(owner) {
++  const children = [];
++  let child = owner._firstChild;
++  while (child) {
++    children.push(child);
++    child = child._nextSibling;
++  }
++  return children;
++}
++function getSignals(owner) {
++  return owner._signals ? [...owner._signals] : [];
++}
++function getParent(owner) {
++  return owner._parent;
++}
++function getSources(computation) {
++  const sources = [];
++  let link = computation._deps;
++  while (link) {
++    sources.push(link._dep);
++    link = link._nextDep;
++  }
++  return sources;
++}
++function getObservers(node) {
++  const observers = [];
++  let link = node._subs;
++  while (link) {
++    observers.push(link._sub);
++    link = link._nextSub;
++  }
++  return observers;
++}
+ function actualInsertIntoHeap(n, heap) {
+   const parentHeight =
+     (n._parent?._root ? n._parent._parentComputed?._height : n._parent?._height) ?? -1;
+@@ -70,7 +157,7 @@ function actualInsertIntoHeap(n, heap) {
+ }
+ function insertIntoHeap(n, heap) {
+   let flags = n._flags;
+-  if (flags & (REACTIVE_IN_HEAP | REACTIVE_RECOMPUTING_DEPS)) return;
++  if (flags & (REACTIVE_IN_HEAP | REACTIVE_RECOMPUTING_DEPS | REACTIVE_MANUAL_WRITE)) return;
+   if (flags & REACTIVE_CHECK) {
+     n._flags = (flags & -4) | REACTIVE_DIRTY | REACTIVE_IN_HEAP;
+   } else n._flags = flags | REACTIVE_IN_HEAP;
+@@ -78,7 +165,11 @@ function insertIntoHeap(n, heap) {
+ }
+ function insertIntoHeapHeight(n, heap) {
+   let flags = n._flags;
+-  if (flags & (REACTIVE_IN_HEAP | REACTIVE_RECOMPUTING_DEPS | REACTIVE_IN_HEAP_HEIGHT)) return;
++  if (
++    flags &
++    (REACTIVE_IN_HEAP | REACTIVE_RECOMPUTING_DEPS | REACTIVE_IN_HEAP_HEIGHT | REACTIVE_MANUAL_WRITE)
++  )
++    return;
+   n._flags = flags | REACTIVE_IN_HEAP_HEIGHT;
+   actualInsertIntoHeap(n, heap);
+ }
+@@ -150,97 +241,13 @@ function adjustHeight(el, heap) {
+     }
+   }
+ }
+-const hooks = {};
+-const diagnosticListeners = new Set();
+-const diagnosticCaptures = new Set();
+-let diagnosticSequence = 0;
+-const diagnostics = {
+-  subscribe(listener) {
+-    diagnosticListeners.add(listener);
+-    return () => diagnosticListeners.delete(listener);
+-  },
+-  capture() {
+-    const events = [];
+-    diagnosticCaptures.add(events);
+-    return {
+-      get events() {
+-        return events;
+-      },
+-      clear() {
+-        events.length = 0;
+-      },
+-      stop() {
+-        diagnosticCaptures.delete(events);
+-        return [...events];
+-      }
+-    };
+-  }
+-};
+-const DEV$1 = {
+-  hooks: hooks,
+-  diagnostics: diagnostics,
+-  getChildren: getChildren,
+-  getSignals: getSignals,
+-  getParent: getParent,
+-  getSources: getSources,
+-  getObservers: getObservers
+-};
+-function emitDiagnostic(event) {
+-  const entry = { sequence: ++diagnosticSequence, ...event };
+-  for (const listener of diagnosticListeners) listener(entry);
+-  for (const capture of diagnosticCaptures) capture.push(entry);
+-  return entry;
+-}
+-function registerGraph(value, owner) {
+-  value._owner = owner;
+-  if (owner) {
+-    if (!owner._signals) owner._signals = [];
+-    owner._signals.push(value);
+-  }
+-  DEV$1.hooks.onGraph?.(value, owner);
+-}
+-function clearSignals(node) {
+-  node._signals = undefined;
+-}
+-function getChildren(owner) {
+-  const children = [];
+-  let child = owner._firstChild;
+-  while (child) {
+-    children.push(child);
+-    child = child._nextSibling;
+-  }
+-  return children;
+-}
+-function getSignals(owner) {
+-  return owner._signals ? [...owner._signals] : [];
+-}
+-function getParent(owner) {
+-  return owner._parent;
+-}
+-function getSources(computation) {
+-  const sources = [];
+-  let link = computation._deps;
+-  while (link) {
+-    sources.push(link._dep);
+-    link = link._nextDep;
+-  }
+-  return sources;
+-}
+-function getObservers(node) {
+-  const observers = [];
+-  let link = node._subs;
+-  while (link) {
+-    observers.push(link._sub);
+-    link = link._nextSub;
+-  }
+-  return observers;
+-}
+ const transitions = new Set();
+ const dirtyQueue = { _heap: new Array(2e3).fill(undefined), _marked: false, _min: 0, _max: 0 };
+ const zombieQueue = { _heap: new Array(2e3).fill(undefined), _marked: false, _min: 0, _max: 0 };
+ let clock = 0;
+ let activeTransition = null;
+ let scheduled = false;
++let syncDepth = 0;
+ let projectionWriteActive = false;
+ let inTrackedQueueCallback = false;
+ let _enforceLoadingBoundary = false;
+@@ -250,6 +257,16 @@ const transientStoreNodes = new Set();
+ function registerTransientStoreNode(node) {
+   transientStoreNodes.add(node);
+ }
++function canUseSimpleSyncFlush(queue) {
++  return (
++    transitions.size === 0 &&
++    activeLanes.size === 0 &&
++    queue._children.length === 0 &&
++    queue._optimisticNodes.length === 0 &&
++    queue._optimisticStores.size === 0 &&
++    transientStoreNodes.size === 0
++  );
++}
+ function sweepTransientStoreNodes() {
+   if (transientStoreNodes.size === 0) return;
+   for (const node of transientStoreNodes) {
+@@ -353,7 +370,7 @@ function cleanupCompletedLanes(completingTransition) {
+ function schedule() {
+   if (scheduled) return;
+   scheduled = true;
+-  if (!globalQueue._running && !projectionWriteActive) queueMicrotask(flush);
++  if (!syncDepth && !globalQueue._running && !projectionWriteActive) queueMicrotask(flush);
+ }
+ class Queue {
+   _parent = null;
+@@ -420,11 +437,13 @@ class Queue {
+ }
+ class GlobalQueue extends Queue {
+   _running = false;
++  _pendingNode = null;
+   _pendingNodes = [];
+   _optimisticNodes = [];
+   _optimisticStores = new Set();
+   static _update;
+   static _dispose;
++  static _runEffect;
+   static _clearOptimisticStore = null;
+   flush() {
+     if (this._running) return;
+@@ -436,6 +455,7 @@ class GlobalQueue extends Queue {
+         if (!isComplete) {
+           const stashedTransition = activeTransition;
+           runHeap(zombieQueue, GlobalQueue._update);
++          this._pendingNode = null;
+           this._pendingNodes = [];
+           this._optimisticNodes = [];
+           this._optimisticStores = new Set();
+@@ -475,14 +495,22 @@ class GlobalQueue extends Queue {
+         reassignPendingTransition(this._pendingNodes);
+         finalizePureQueue(completingTransition);
+       } else {
+-        if (transitions.size) runHeap(zombieQueue, GlobalQueue._update);
+-        finalizePureQueue();
++        if (canUseSimpleSyncFlush(this)) {
++          commitPendingNodes();
++          if (dirtyQueue._max >= dirtyQueue._min) {
++            runHeap(dirtyQueue, GlobalQueue._update);
++            commitPendingNodes();
++          }
++        } else {
++          if (transitions.size) runHeap(zombieQueue, GlobalQueue._update);
++          finalizePureQueue();
++        }
+       }
+       clock++;
+       scheduled = dirtyQueue._max >= dirtyQueue._min;
+-      runLaneEffects(EFFECT_RENDER);
++      activeLanes.size && runLaneEffects(EFFECT_RENDER);
+       this.run(EFFECT_RENDER);
+-      runLaneEffects(EFFECT_USER);
++      activeLanes.size && runLaneEffects(EFFECT_USER);
+       this.run(EFFECT_USER);
+       if (true) DEV$1.hooks.onUpdate?.();
+     } finally {
+@@ -531,6 +559,11 @@ class GlobalQueue extends Queue {
+     }
+     transitions.add(activeTransition);
+     activeTransition._time = clock;
++    if (this._pendingNode !== null) {
++      this._pendingNode._transition = activeTransition;
++      activeTransition._pendingNodes.push(this._pendingNode);
++      this._pendingNode = null;
++    }
+     if (this._pendingNodes !== activeTransition._pendingNodes) {
+       for (let i = 0; i < this._pendingNodes.length; i++) {
+         const node = this._pendingNodes[i];
+@@ -556,6 +589,21 @@ class GlobalQueue extends Queue {
+     }
+   }
+ }
++function queuePendingNode(node) {
++  if (activeTransition) {
++    globalQueue._pendingNodes.push(node);
++    return;
++  }
++  if (globalQueue._pendingNode === null && globalQueue._pendingNodes.length === 0) {
++    globalQueue._pendingNode = node;
++    return;
++  }
++  if (globalQueue._pendingNode !== null) {
++    globalQueue._pendingNodes.push(globalQueue._pendingNode);
++    globalQueue._pendingNode = null;
++  }
++  globalQueue._pendingNodes.push(node);
++}
+ function insertSubs(node, optimistic = false) {
+   const sourceLane = node._optimisticLane || currentOptimisticLane;
+   const hasSnapshot = node._snapshotValue !== undefined;
+@@ -584,27 +632,44 @@ function insertSubs(node, optimistic = false) {
+     insertIntoHeap(s._sub, queue);
+   }
+ }
+-function commitPendingNodes() {
+-  const pendingNodes = globalQueue._pendingNodes;
+-  for (let i = 0; i < pendingNodes.length; i++) {
+-    const n = pendingNodes[i];
++function commitPendingNode(n) {
++  const c = n;
++  if (!c._fn) {
+     if (n._pendingValue !== NOT_PENDING) {
+       n._value = n._pendingValue;
+       n._pendingValue = NOT_PENDING;
+-      if (n._type && n._type !== EFFECT_TRACKED) n._modified = true;
+     }
+-    if (!(n._statusFlags & STATUS_PENDING)) n._statusFlags &= ~STATUS_UNINITIALIZED;
+-    if (n._fn) GlobalQueue._dispose(n, false, true);
++    return;
++  }
++  if (n._pendingValue !== NOT_PENDING) {
++    n._value = n._pendingValue;
++    n._pendingValue = NOT_PENDING;
++    if (n._type && n._type !== EFFECT_TRACKED) n._modified = true;
++  }
++  c._flags &= ~REACTIVE_MANUAL_WRITE;
++  if (!(c._statusFlags & STATUS_PENDING)) c._statusFlags &= ~STATUS_UNINITIALIZED;
++  if (c._pendingFirstChild !== null || c._pendingDisposal !== null)
++    GlobalQueue._dispose(c, false, true);
++}
++function commitPendingNodes() {
++  if (globalQueue._pendingNode !== null) {
++    commitPendingNode(globalQueue._pendingNode);
++    globalQueue._pendingNode = null;
++  }
++  const pendingNodes = globalQueue._pendingNodes;
++  for (let i = 0; i < pendingNodes.length; i++) {
++    commitPendingNode(pendingNodes[i]);
+   }
+   pendingNodes.length = 0;
+ }
+ function finalizePureQueue(completingTransition = null, incomplete = false) {
+   const resolvePending = !incomplete;
+   if (resolvePending) commitPendingNodes();
+-  if (!incomplete) checkBoundaryChildren(globalQueue);
+-  if (dirtyQueue._max >= dirtyQueue._min) runHeap(dirtyQueue, GlobalQueue._update);
++  if (!incomplete && globalQueue._children.length) checkBoundaryChildren(globalQueue);
++  const ranHeap = dirtyQueue._max >= dirtyQueue._min;
++  if (ranHeap) runHeap(dirtyQueue, GlobalQueue._update);
+   if (resolvePending) {
+-    commitPendingNodes();
++    if (ranHeap) commitPendingNodes();
+     resolveOptimisticNodes(
+       completingTransition ? completingTransition._optimisticNodes : globalQueue._optimisticNodes
+     );
+@@ -654,7 +719,16 @@ function reassignPendingTransition(pendingNodes) {
+   }
+ }
+ const globalQueue = new GlobalQueue();
+-function flush() {
++function flush(fn) {
++  if (fn) {
++    syncDepth++;
++    try {
++      return fn();
++    } finally {
++      flush();
++      syncDepth--;
++    }
++  }
+   if (globalQueue._running) {
+     if (inTrackedQueueCallback) {
+       throw new Error(
+@@ -899,8 +973,9 @@ function dispose(node) {
+   disposeChildren(node, true);
+ }
+ function disposeChildren(node, self = false, zombie) {
+-  if (node._flags & REACTIVE_DISPOSED) return;
+-  if (self) node._flags = REACTIVE_DISPOSED;
++  const flags = node._flags;
++  if (flags & REACTIVE_DISPOSED) return;
++  if (self) node._flags = flags | REACTIVE_DISPOSED;
+   if (self && true) clearSignals(node);
+   if (self && node._fn) node._inFlight = null;
+   let child = zombie ? node._pendingFirstChild : node._firstChild;
+@@ -925,6 +1000,20 @@ function disposeChildren(node, self = false, zombie) {
+     node._firstChild = null;
+     node._childCount = 0;
+   }
++  if (
++    self &&
++    !zombie &&
++    !(flags & REACTIVE_ZOMBIE) &&
++    node._parent !== null &&
++    !(node._parent._flags & REACTIVE_DISPOSED)
++  ) {
++    const prev = node._prevSibling;
++    const next = node._nextSibling;
++    if (prev !== null) prev._nextSibling = next;
++    else node._parent._firstChild = next;
++    if (next !== null) next._prevSibling = prev;
++    node._prevSibling = null;
++  }
+   runDisposal(node, zombie);
+ }
+ function runDisposal(node, zombie) {
+@@ -975,6 +1064,9 @@ function cleanup(fn) {
+ function isDisposed(node) {
+   return !!(node._flags & (REACTIVE_DISPOSED | REACTIVE_ZOMBIE));
+ }
++function disposeRootSelf(self = true) {
++  disposeChildren(this, self);
++}
+ function createOwner(options) {
+   const parent = context;
+   const transparent = options?.transparent ?? false;
+@@ -987,6 +1079,7 @@ function createOwner(options) {
+     _parentComputed: parent?._root ? parent._parentComputed : parent,
+     _firstChild: null,
+     _nextSibling: null,
++    _prevSibling: null,
+     _disposal: null,
+     _queue: parent?._queue ?? globalQueue,
+     _context: parent?._context || defaultContext,
+@@ -994,9 +1087,7 @@ function createOwner(options) {
+     _pendingDisposal: null,
+     _pendingFirstChild: null,
+     _parent: parent,
+-    dispose(self = true) {
+-      disposeChildren(owner, self);
+-    }
++    dispose: disposeRootSelf
+   };
+   if (parent && parent._config & CONFIG_CHILDREN_FORBIDDEN) {
+     emitDiagnostic({
+@@ -1015,6 +1106,7 @@ function createOwner(options) {
+       parent._firstChild = owner;
+     } else {
+       owner._nextSibling = lastChild;
++      lastChild._prevSibling = owner;
+       parent._firstChild = owner;
+     }
+   }
+@@ -1023,7 +1115,7 @@ function createOwner(options) {
+ }
+ function createRoot(init, options) {
+   const owner = createOwner(options);
+-  return runWithOwner(owner, () => init(owner.dispose));
++  return runWithOwner(owner, () => init(() => owner.dispose()));
+ }
+ function addPendingSource(el, source) {
+   if (el._pendingSource === source || el._pendingSources?.has(source)) return false;
+@@ -1116,13 +1208,34 @@ function settlePendingSource(el) {
+   if (scheduled) schedule();
+ }
+ function handleAsync(el, result, setter) {
+-  const isObject = typeof result === "object" && result !== null;
+-  const iterator = isObject && untrack(() => result[Symbol.asyncIterator]);
+-  const isThenable = !iterator && isObject && untrack(() => typeof result.then === "function");
++  let iterator = false;
++  let isThenable = false;
++  if (typeof result === "object" && result !== null) {
++    untrack(() => {
++      iterator = result[Symbol.asyncIterator];
++      isThenable = !iterator && typeof result.then === "function";
++    });
++  }
+   if (!isThenable && !iterator) {
+     el._inFlight = null;
+     return result;
+   }
++  if (el._config & CONFIG_SYNC) {
++    const message =
++      `[SYNC_NODE_RECEIVED_ASYNC] A computed/effect created with \`sync: true\` returned ` +
++      `${isThenable ? "a Promise" : "an AsyncIterable"}. The value would be stored as-is and ` +
++      `never awaited in production; remove \`sync: true\` to use async-aware behavior, or ` +
++      `unwrap the value before returning.`;
++    emitDiagnostic({
++      code: "SYNC_NODE_RECEIVED_ASYNC",
++      kind: "lifecycle",
++      severity: "error",
++      message: message,
++      ownerId: el.id,
++      ownerName: el._name
++    });
++    throw new Error(message);
++  }
+   el._inFlight = result;
+   let syncValue;
+   const handleError = error => {
+@@ -1245,12 +1358,12 @@ function handleAsync(el, result, setter) {
+   return syncValue;
+ }
+ function clearStatus(el, clearUninitialized = false) {
+-  clearPendingSources(el);
+-  el._blocked = false;
++  if (el._pendingSource || el._pendingSources) clearPendingSources(el);
++  if (el._blocked) el._blocked = false;
+   el._statusFlags = clearUninitialized ? 0 : el._statusFlags & STATUS_UNINITIALIZED;
+-  setPendingError(el);
+-  updatePendingSignal(el);
+-  el._notifyStatus?.();
++  if (el._error) setPendingError(el);
++  if (el._pendingSignal) updatePendingSignal(el);
++  if (el._notifyStatus) el._notifyStatus();
+ }
+ function notifyStatus(el, status, error, blockStatus, lane) {
+   if (
+@@ -1304,7 +1417,7 @@ function notifyStatus(el, status, error, blockStatus, lane) {
+       (status !== STATUS_PENDING &&
+         (sub._error !== error || sub._pendingSource || sub._pendingSources))
+     ) {
+-      if (!downstreamBlockStatus && !sub._transition) globalQueue._pendingNodes.push(sub);
++      if (!downstreamBlockStatus && !sub._transition) queuePendingNode(sub);
+       notifyStatus(sub, status, error, downstreamBlockStatus, downstreamLane);
+     }
+   });
+@@ -1339,6 +1452,7 @@ const PRIMITIVE_IN_FORBIDDEN_SCOPE_MESSAGE =
+ let tracking = false;
+ let stale = false;
+ let refreshing = false;
++let refreshTrigger = false;
+ let pendingCheckActive = false;
+ let foundPending = false;
+ let latestReadActive = false;
+@@ -1404,7 +1518,7 @@ function recompute(el, create = false) {
+     deleteFromHeap(el, el._flags & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
+     el._inFlight = null;
+     if (el._transition || isEffect === EFFECT_TRACKED) disposeChildren(el);
+-    else {
++    else if (el._firstChild !== null || el._disposal !== null) {
+       markDisposal(el);
+       el._pendingDisposal = el._disposal;
+       el._pendingFirstChild = el._firstChild;
+@@ -1412,7 +1526,7 @@ function recompute(el, create = false) {
+       el._firstChild = null;
+       el._childCount = 0;
+       clearSignals(el);
+-    }
++    } else clearSignals(el);
+   }
+   let isOptimisticDirty = !!(el._flags & REACTIVE_OPTIMISTIC_DIRTY);
+   const hasOverride = el._overrideValue !== undefined && el._overrideValue !== NOT_PENDING;
+@@ -1451,15 +1565,26 @@ function recompute(el, create = false) {
+       }
+     }
+   }
++  const isStaleEffect = isEffect && isEffect !== EFFECT_USER;
++  const prevStale = stale;
++  if (isStaleEffect) stale = true;
+   try {
+-    const prevInFlight = el._inFlight;
+-    const fnResult = el._fn(value);
+-    value = el._inFlight !== prevInFlight ? fnResult : handleAsync(el, fnResult);
++    if (!true && el._config & CONFIG_SYNC);
++    else {
++      const prevInFlight = el._inFlight;
++      const fnResult = el._fn(value);
++      const isAsyncResult = typeof fnResult === "object" && fnResult !== null;
++      const inFlightChanged = el._inFlight !== prevInFlight;
++      value = inFlightChanged || !isAsyncResult ? fnResult : handleAsync(el, fnResult);
++      if (!inFlightChanged && !isAsyncResult) el._inFlight = null;
++    }
+     clearStatus(el, create);
+-    const resolvedLane = resolveLane(el);
+-    if (resolvedLane) {
+-      resolvedLane._pendingAsync.delete(el);
+-      updatePendingSignal(resolvedLane._source);
++    if (el._optimisticLane) {
++      const resolvedLane = resolveLane(el);
++      if (resolvedLane) {
++        resolvedLane._pendingAsync.delete(el);
++        updatePendingSignal(resolvedLane._source);
++      }
+     }
+   } catch (e) {
+     if (e instanceof NotReadyError && currentOptimisticLane) {
+@@ -1481,6 +1606,7 @@ function recompute(el, create = false) {
+   } finally {
+     tracking = prevTracking;
+     strictRead = prevStrictRead;
++    if (isStaleEffect) stale = prevStale;
+     el._flags = REACTIVE_NONE | (create ? el._flags & REACTIVE_SNAPSHOT_STALE : 0);
+     context = oldcontext;
+   }
+@@ -1501,6 +1627,10 @@ function recompute(el, create = false) {
+         : el._pendingValue;
+     const valueChanged =
+       (!isEffect && wasUninitialized) || !el._equals || !el._equals(compareValue, value);
++    if (isEffect && valueChanged) {
++      el._modified = !el._error;
++      if (!create) el._queue.enqueue(isEffect, GlobalQueue._runEffect.bind(null, el));
++    }
+     if (valueChanged) {
+       const prevVisible = hasOverride ? el._overrideValue : undefined;
+       if (create || (isEffect && activeTransition !== el._transition) || isOptimisticDirty) {
+@@ -1523,10 +1653,16 @@ function recompute(el, create = false) {
+     }
+   }
+   currentOptimisticLane = prevLane;
+-  (!create || el._statusFlags & STATUS_PENDING) &&
++  const needsPendingCommit =
++    el._pendingValue !== NOT_PENDING ||
++    el._pendingFirstChild !== null ||
++    el._pendingDisposal !== null ||
++    !!(el._statusFlags & (STATUS_PENDING | STATUS_UNINITIALIZED));
++  needsPendingCommit &&
++    (!create || el._statusFlags & STATUS_PENDING) &&
+     !el._transition &&
+     !(activeTransition && hasOverride) &&
+-    globalQueue._pendingNodes.push(el);
++    queuePendingNode(el);
+   el._transition &&
+     isEffect &&
+     activeTransition !== el._transition &&
+@@ -1563,6 +1699,7 @@ function computed(fn, options) {
+       (transparent ? CONFIG_TRANSPARENT : 0) |
+       (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+       (!context || options?.lazy ? CONFIG_AUTO_DISPOSE : 0) |
++      (options?.sync ? CONFIG_SYNC : 0) |
+       (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
+     _equals: options?.equals != null ? options.equals : isEqual,
+     _unobserved: options?.unobserved,
+@@ -1582,6 +1719,7 @@ function computed(fn, options) {
+     _subsTail: null,
+     _parent: context,
+     _nextSibling: null,
++    _prevSibling: null,
+     _firstChild: null,
+     _flags: options?.lazy ? REACTIVE_LAZY : REACTIVE_NONE,
+     _statusFlags: STATUS_UNINITIALIZED,
+@@ -1593,6 +1731,63 @@ function computed(fn, options) {
+     _transition: null
+   };
+   self._name = options?.name ?? "computed";
++  setupComputedNode(self, options);
++  return self;
++}
++function createEffectNode(fn, effectFn, errorFn, type, notifyStatus, options) {
++  const transparent = options?.transparent ?? false;
++  const self = {
++    id:
++      options?.id ??
++      (transparent ? context?.id : context?.id != null ? getNextChildId(context) : undefined),
++    _config:
++      (transparent ? CONFIG_TRANSPARENT : 0) |
++      (options?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
++      (options?.sync ? CONFIG_SYNC : 0) |
++      (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
++    _equals: false,
++    _unobserved: options?.unobserved,
++    _disposal: null,
++    _queue: context?._queue ?? globalQueue,
++    _context: context?._context ?? defaultContext,
++    _childCount: 0,
++    _fn: fn,
++    _value: undefined,
++    _height: 0,
++    _child: null,
++    _nextHeap: undefined,
++    _prevHeap: null,
++    _deps: null,
++    _depsTail: null,
++    _subs: null,
++    _subsTail: null,
++    _parent: context,
++    _nextSibling: null,
++    _prevSibling: null,
++    _firstChild: null,
++    _flags: REACTIVE_LAZY,
++    _statusFlags: STATUS_UNINITIALIZED,
++    _time: clock,
++    _pendingValue: NOT_PENDING,
++    _pendingDisposal: null,
++    _pendingFirstChild: null,
++    _inFlight: null,
++    _transition: null,
++    _modified: false,
++    _prevValue: undefined,
++    _effectFn: effectFn,
++    _errorFn: errorFn,
++    _cleanup: undefined,
++    _cleanupRegistered: false,
++    _type: type,
++    _notifyStatus: notifyStatus
++  };
++  self._name = options?.name ?? "effect";
++  setupComputedNode(self, lazyOptions);
++  return self;
++}
++const lazyOptions = { lazy: true };
++function setupComputedNode(self, options) {
+   self._prevHeap = self;
+   const parent = context?._root ? context._parentComputed : context;
+   if (context && context._config & CONFIG_CHILDREN_FORBIDDEN) {
+@@ -1612,6 +1807,7 @@ function computed(fn, options) {
+       context._firstChild = self;
+     } else {
+       self._nextSibling = lastChild;
++      lastChild._prevSibling = self;
+       context._firstChild = self;
+     }
+   }
+@@ -1635,7 +1831,6 @@ function computed(fn, options) {
+       snapshotSources.add(self);
+     }
+   }
+-  return self;
+ }
+ function signal(v, options, firewall = null) {
+   const s = {
+@@ -1756,7 +1951,11 @@ function read(el) {
+   const computed = el;
+   if (typeof computed._fn === "function") {
+     const comp = el;
+-    if (refreshing && !(comp._flags & REACTIVE_DISPOSED)) recompute(comp);
++    if (refreshTrigger && !(comp._flags & REACTIVE_DISPOSED)) {
++      refreshTrigger = false;
++      recompute(comp);
++      refreshTrigger = true;
++    }
+     if (comp._flags & REACTIVE_LAZY) {
+       comp._flags &= ~REACTIVE_LAZY;
+       recompute(comp, true);
+@@ -1765,6 +1964,19 @@ function read(el) {
+     }
+   }
+   const owner = el._firewall || el;
++  if (
++    !computed._fn &&
++    owner === el &&
++    el._overrideValue === undefined &&
++    el._snapshotValue === undefined &&
++    activeTransition === null &&
++    currentOptimisticLane === null &&
++    !snapshotCaptureActive &&
++    !strictRead
++  ) {
++    if (c && tracking) link(el, c);
++    return !c || el._pendingValue === NOT_PENDING ? el._value : el._pendingValue;
++  }
+   if (strictRead && owner._statusFlags & STATUS_PENDING) {
+     const message =
+       `[PENDING_ASYNC_UNTRACKED_READ] Reading a pending async value directly in ${strictRead}. ` +
+@@ -1955,10 +2167,10 @@ function setSignal(el, v) {
+     el._optimisticLane = lane;
+     el._overrideValue = v;
+   } else {
+-    if (el._pendingValue === NOT_PENDING) globalQueue._pendingNodes.push(el);
++    if (el._pendingValue === NOT_PENDING) queuePendingNode(el);
+     el._pendingValue = v;
+   }
+-  updatePendingSignal(el);
++  if (el._pendingSignal) updatePendingSignal(el);
+   if (el._latestValueComputed) {
+     setSignal(el._latestValueComputed, v);
+   }
+@@ -1967,6 +2179,17 @@ function setSignal(el, v) {
+   schedule();
+   return v;
+ }
++function suppressComputedRecompute(el) {
++  deleteFromHeap(el, el._flags & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
++  if (!(el._flags & REACTIVE_MANUAL_WRITE) && el._pendingValue === NOT_PENDING)
++    queuePendingNode(el);
++  el._flags = (el._flags & -4) | REACTIVE_MANUAL_WRITE;
++}
++function setMemo(el, v) {
++  const result = setSignal(el, v);
++  suppressComputedRecompute(el);
++  return result;
++}
+ function runWithOwner(owner, fn) {
+   if (owner && owner._flags & REACTIVE_DISPOSED) {
+     const message =
+@@ -2092,15 +2315,19 @@ function isPending(fn) {
+ }
+ function refresh(fn) {
+   let prevRefreshing = refreshing;
++  let prevRefreshTrigger = refreshTrigger;
+   refreshing = true;
++  refreshTrigger = true;
+   try {
+     if (typeof fn !== "function") {
++      refreshTrigger = false;
+       recompute(fn[$REFRESH]);
+       return fn;
+     }
+     return untrack(fn);
+   } finally {
+     refreshing = prevRefreshing;
++    refreshTrigger = prevRefreshTrigger;
+     if (!prevRefreshing) {
+       schedule();
+     }
+@@ -2138,69 +2365,20 @@ function isUndefined(value) {
+   return typeof value === "undefined";
+ }
+ function effect(compute, effect, error, options) {
+-  let initialized = false;
+   const isUser = !!options?.user;
+-  const node = computed(isUser ? compute : p => staleValues(() => compute(p)), {
+-    ...options,
+-    equals: () => {
+-      node._modified = !node._error;
+-      if (initialized) node._queue.enqueue(node._type, runEffect.bind(node));
+-      return false;
+-    },
+-    lazy: true
+-  });
+-  node._config &= ~CONFIG_AUTO_DISPOSE;
+-  node._prevValue = undefined;
+-  node._effectFn = effect;
+-  node._errorFn = error;
+-  node._cleanup = undefined;
+-  node._type = isUser ? EFFECT_USER : EFFECT_RENDER;
+-  node._notifyStatus = (status, error) => {
+-    const actualStatus = status !== undefined ? status : node._statusFlags;
+-    const actualError = error !== undefined ? error : node._error;
+-    if (actualStatus & STATUS_ERROR) {
+-      let err = actualError;
+-      node._queue.notify(node, STATUS_PENDING, 0);
+-      if (node._type === EFFECT_USER) {
+-        try {
+-          return node._errorFn
+-            ? node._errorFn(err, () => {
+-                node._cleanup?.();
+-                node._cleanup = undefined;
+-              })
+-            : console.error(err);
+-        } catch (e) {
+-          err = e;
+-        }
+-      }
+-      if (!node._queue.notify(node, STATUS_ERROR, STATUS_ERROR)) throw err;
+-    } else if (node._type === EFFECT_RENDER) {
+-      node._queue.notify(node, STATUS_PENDING | STATUS_ERROR, actualStatus, actualError);
+-      if (_hitUnhandledAsync) {
+-        resetUnhandledAsync();
+-        if (!node._queue.notify(node, STATUS_ERROR, STATUS_ERROR)) {
+-          const message =
+-            "[ASYNC_OUTSIDE_LOADING_BOUNDARY] An async value was read outside a Loading boundary. The root mount will be deferred until all pending async settles.";
+-          emitDiagnostic({
+-            code: "ASYNC_OUTSIDE_LOADING_BOUNDARY",
+-            kind: "async",
+-            severity: "warn",
+-            message: message,
+-            ownerId: node.id,
+-            ownerName: node._name
+-          });
+-          console.warn(message);
+-        }
+-      }
+-    }
+-  };
++  const node = createEffectNode(
++    compute,
++    effect,
++    error,
++    isUser ? EFFECT_USER : EFFECT_RENDER,
++    notifyEffectStatus,
++    options
++  );
+   recompute(node, true);
+   !options?.defer &&
+     (node._type === EFFECT_USER || options?.schedule
+-      ? node._queue.enqueue(node._type, runEffect.bind(node))
+-      : runEffect.call(node));
+-  initialized = true;
+-  cleanup(() => node._cleanup?.());
++      ? node._queue.enqueue(node._type, runEffect.bind(null, node))
++      : runEffect(node));
+   if (!node._parent) {
+     const message =
+       "[NO_OWNER_EFFECT] Effects created outside a reactive context will never be disposed";
+@@ -2216,32 +2394,76 @@ function effect(compute, effect, error, options) {
+     console.warn(message);
+   }
+ }
+-function runEffect() {
+-  if (!this._modified || this._flags & REACTIVE_DISPOSED) return;
++function notifyEffectStatus(status, error) {
++  const actualStatus = status !== undefined ? status : this._statusFlags;
++  const actualError = error !== undefined ? error : this._error;
++  if (actualStatus & STATUS_ERROR) {
++    let err = actualError;
++    this._queue.notify(this, STATUS_PENDING, 0);
++    if (this._type === EFFECT_USER) {
++      try {
++        return this._errorFn
++          ? this._errorFn(err, () => {
++              this._cleanup?.();
++              this._cleanup = undefined;
++            })
++          : console.error(err);
++      } catch (e) {
++        err = e;
++      }
++    }
++    if (!this._queue.notify(this, STATUS_ERROR, STATUS_ERROR)) throw err;
++  } else if (this._type === EFFECT_RENDER) {
++    this._queue.notify(this, STATUS_PENDING | STATUS_ERROR, actualStatus, actualError);
++    if (_hitUnhandledAsync) {
++      resetUnhandledAsync();
++      if (!this._queue.notify(this, STATUS_ERROR, STATUS_ERROR)) {
++        const message =
++          "[ASYNC_OUTSIDE_LOADING_BOUNDARY] An async value was read outside a Loading boundary. The root mount will be deferred until all pending async settles.";
++        emitDiagnostic({
++          code: "ASYNC_OUTSIDE_LOADING_BOUNDARY",
++          kind: "async",
++          severity: "warn",
++          message: message,
++          ownerId: this.id,
++          ownerName: this._name
++        });
++        console.warn(message);
++      }
++    }
++  }
++}
++function runEffect(node) {
++  if (!node._modified || node._flags & REACTIVE_DISPOSED) return;
+   let prevStrictRead = false;
+   {
+     prevStrictRead = setStrictRead("an effect callback");
+   }
+-  this._cleanup?.();
+-  this._cleanup = undefined;
++  node._cleanup?.();
++  node._cleanup = undefined;
+   try {
+-    const cleanup = this._effectFn(this._value, this._prevValue);
+-    if (true && cleanup !== undefined && typeof cleanup !== "function") {
++    const nextCleanup = node._effectFn(node._value, node._prevValue);
++    if (true && nextCleanup !== undefined && typeof nextCleanup !== "function") {
+       throw new Error(
+-        `${this._name || "effect"} callback returned an invalid cleanup value. Return a cleanup function or undefined.`
++        `${node._name || "effect"} callback returned an invalid cleanup value. Return a cleanup function or undefined.`
+       );
+     }
+-    this._cleanup = cleanup;
++    node._cleanup = nextCleanup;
++    if (node._cleanup && !node._cleanupRegistered) {
++      node._cleanupRegistered = true;
++      runWithOwner(node._parent, () => cleanup(() => node._cleanup?.()));
++    }
+   } catch (error) {
+-    this._error = new StatusError(this, error);
+-    this._statusFlags |= STATUS_ERROR;
+-    if (!this._queue.notify(this, STATUS_ERROR, STATUS_ERROR)) throw error;
++    node._error = new StatusError(node, error);
++    node._statusFlags |= STATUS_ERROR;
++    if (!node._queue.notify(node, STATUS_ERROR, STATUS_ERROR)) throw error;
+   } finally {
+     setStrictRead(prevStrictRead);
+-    this._prevValue = this._value;
+-    this._modified = false;
++    node._prevValue = node._value;
++    node._modified = false;
+   }
+ }
++GlobalQueue._runEffect = runEffect;
+ function trackedEffect(fn, options) {
+   const run = () => {
+     if (!node._modified || node._flags & REACTIVE_DISPOSED) return;
+@@ -2377,7 +2599,7 @@ function createSignal(first, second) {
+   if (typeof first === "function") {
+     const node = computed(first, second);
+     node._config &= ~CONFIG_AUTO_DISPOSE;
+-    return [accessor(node), setSignal.bind(null, node)];
++    return [accessor(node), setMemo.bind(null, node)];
+   }
+   const node = signal(first, second);
+   registerGraph(node, getOwner());
+@@ -2946,6 +3168,21 @@ const storeTraps = {
+     }
+     const nodes = getNodes(target, STORE_NODE);
+     const tracked = nodes[property];
++    const source = target[STORE_VALUE];
++    if (
++      !tracked &&
++      !target[STORE_OVERRIDE] &&
++      !target[STORE_OPTIMISTIC_OVERRIDE] &&
++      !target[STORE_CUSTOM_PROTO] &&
++      !target[STORE_OPTIMISTIC] &&
++      !target[STORE_SNAPSHOT_PROPS] &&
++      !source[$TARGET] &&
++      !(property in source) &&
++      getObserver() &&
++      !writeOnly(receiver)
++    ) {
++      return read(getNode(nodes, property, undefined, target[STORE_FIREWALL]));
++    }
+     const optOverridden =
+       target[STORE_OPTIMISTIC_OVERRIDE] && property in target[STORE_OPTIMISTIC_OVERRIDE];
+     const overridden =
+@@ -3220,7 +3457,12 @@ function createStore(first, second, options) {
+   const derived = typeof first === "function",
+     wrappedStore = derived ? createProjectionInternal(first, second, options).store : wrap(first);
+   registerGraph(wrappedStore, getOwner());
+-  return [wrappedStore, fn => storeSetter(wrappedStore, fn)];
++  return [
++    wrappedStore,
++    derived
++      ? fn => (storeSetter(wrappedStore, fn), suppressComputedRecompute(wrappedStore[$REFRESH]))
++      : fn => storeSetter(wrappedStore, fn)
++  ];
+ }
+ function createOptimisticStore(first, second, options) {
+   GlobalQueue._clearOptimisticStore ||= clearOptimisticStore;
+@@ -3478,8 +3720,9 @@ function merge(...sources) {
+     const s = sources[i];
+     proxy = proxy || (!!s && $PROXY in s);
+     const childSources = !!s && s[$SOURCES];
+-    if (childSources) flattened.push(...childSources);
+-    else flattened.push(typeof s === "function" ? ((proxy = true), createMemo(s)) : s);
++    if (childSources) {
++      for (let i = 0; i < childSources.length; i++) flattened.push(childSources[i]);
++    } else flattened.push(typeof s === "function" ? ((proxy = true), createMemo(s)) : s);
+   }
+   if (SUPPORTS_PROXY && proxy) {
+     return new Proxy(
+@@ -3498,10 +3741,12 @@ function merge(...sources) {
+           return false;
+         },
+         keys() {
+-          const keys = [];
+-          for (let i = 0; i < flattened.length; i++)
+-            keys.push(...Object.keys(resolveSource(flattened[i])));
+-          return [...new Set(keys)];
++          const keys = new Set();
++          for (let i = 0; i < flattened.length; i++) {
++            const sourceKeys = Object.keys(resolveSource(flattened[i]));
++            for (let j = 0; j < sourceKeys.length; j++) keys.add(sourceKeys[j]);
++          }
++          return [...keys];
+         }
+       },
+       propTraps
+@@ -3542,26 +3787,27 @@ function merge(...sources) {
+   return target;
+ }
+ function omit(props, ...keys) {
+-  const blocked = new Set(keys);
+   if (SUPPORTS_PROXY && $PROXY in props) {
+     return new Proxy(
+       {
+         get(property) {
+-          return blocked.has(property) ? undefined : props[property];
++          return keys.includes(property) ? undefined : props[property];
+         },
+         has(property) {
+-          return !blocked.has(property) && property in props;
++          return !keys.includes(property) && property in props;
+         },
+         keys() {
+-          return Object.keys(props).filter(k => !blocked.has(k));
++          return Object.keys(props).filter(k => !keys.includes(k));
+         }
+       },
+       propTraps
+     );
+   }
+   const result = {};
+-  for (const propName of Object.getOwnPropertyNames(props)) {
+-    if (!blocked.has(propName)) {
++  const propNames = Object.getOwnPropertyNames(props);
++  const blocked = keys.length > 4 && propNames.length > keys.length ? new Set(keys) : undefined;
++  for (const propName of propNames) {
++    if (blocked ? !blocked.has(propName) : !keys.includes(propName)) {
+       const desc = Object.getOwnPropertyDescriptor(props, propName);
+       !desc.get && !desc.set && desc.enumerable && desc.writable && desc.configurable
+         ? (result[propName] = desc.value)
+diff --git a/dist/node.cjs b/dist/node.cjs
+index a3e05cdaf12edbecfc102a6f598e4d570b7ebc4d..76602c620aa701185e9532648b680bf7941bfd25 100644
+--- a/dist/node.cjs
++++ b/dist/node.cjs
+@@ -34,24 +34,27 @@ const u = 1 << 6;
+ const f = 1 << 7;
+ const l = 1 << 8;
+ const c = 1 << 9;
+-const a = 1 << 0;
+-const d = 1 << 1;
+-const p = 1 << 2;
+-const h = 1 << 3;
++const a = 1 << 10;
++const d = 1 << 0;
++const p = 1 << 1;
++const h = 1 << 2;
++const g = 1 << 3;
+ const y = 1 << 4;
+-const g = 1 << 5;
+-const S = 1 << 0;
+-const w = 1 << 1;
+-const m = 1 << 2;
+-const b = 1;
+-const _ = 2;
+-const O = 3;
+-const v = {};
++const S = 1 << 5;
++const w = 1 << 6;
++const m = 1 << 0;
++const _ = 1 << 1;
++const b = 1 << 2;
++const O = 1;
++const v = 2;
++const P = 3;
+ const x = {};
+-const P = "sp";
+-const k = typeof Proxy === "function";
+ const C = {};
+-const E = Symbol("refresh");
++const N = "sp";
++const E = typeof Proxy === "function";
++const k = {};
++const j = Symbol("refresh");
++const R = undefined;
+ function actualInsertIntoHeap(e, t) {
+   const n = (e.i?.t ? e.i.u?.o : e.i?.o) ?? -1;
+   if (n >= e.o) e.o = n + 1;
+@@ -68,7 +71,7 @@ function actualInsertIntoHeap(e, t) {
+ }
+ function insertIntoHeap(e, o) {
+   let u = e.m;
+-  if (u & (i | r)) return;
++  if (u & (i | r | a)) return;
+   if (u & t) {
+     e.m = (u & -4) | n | i;
+   } else e.m = u | i;
+@@ -76,7 +79,7 @@ function insertIntoHeap(e, o) {
+ }
+ function insertIntoHeapHeight(e, t) {
+   let n = e.m;
+-  if (n & (i | r | s)) return;
++  if (n & (i | r | s | a)) return;
+   e.m = n | s;
+   actualInsertIntoHeap(e, t);
+ }
+@@ -111,24 +114,24 @@ function markNode(e, r = n) {
+   if ((i & (t | n)) >= r) return;
+   e.m = (i & -4) | r;
+   for (let n = e.O; n !== null; n = n.P) {
+-    markNode(n.k, t);
++    markNode(n.C, t);
+   }
+-  if (e.C !== null) {
+-    for (let n = e.C; n !== null; n = n.j) {
++  if (e.N !== null) {
++    for (let n = e.N; n !== null; n = n.k) {
+       for (let e = n.O; e !== null; e = e.P) {
+-        markNode(e.k, t);
++        markNode(e.C, t);
+       }
+     }
+   }
+ }
+ function runHeap(e, t) {
+   e._ = false;
+-  for (e.N = 0; e.N <= e.S; e.N++) {
+-    let n = e.l[e.N];
++  for (e.j = 0; e.j <= e.S; e.j++) {
++    let n = e.l[e.j];
+     while (n !== undefined) {
+       if (n.m & i) t(n);
+       else adjustHeight(n, e);
+-      n = e.l[e.N];
++      n = e.l[e.j];
+     }
+   }
+   e.S = 0;
+@@ -136,7 +139,7 @@ function runHeap(e, t) {
+ function adjustHeight(e, t) {
+   deleteFromHeap(e, t);
+   let n = e.o;
+-  for (let t = e.W; t; t = t.R) {
++  for (let t = e.R; t; t = t.W) {
+     const e = t.A;
+     const r = e.L || e;
+     if (r.I && r.o >= n) n = r.o + 1;
+@@ -144,131 +147,141 @@ function adjustHeight(e, t) {
+   if (e.o !== n) {
+     e.o = n;
+     for (let n = e.O; n !== null; n = n.P) {
+-      insertIntoHeapHeight(n.k, t);
++      insertIntoHeapHeight(n.C, t);
+     }
+   }
+ }
+-const j = undefined;
+-const N = new Set();
+-const W = { l: new Array(2e3).fill(undefined), _: false, N: 0, S: 0 };
+-const R = { l: new Array(2e3).fill(undefined), _: false, N: 0, S: 0 };
+-let A = 0;
+-let L = null;
+-let I = false;
+-let T = false;
+-let H = null;
+-const Q = new Set();
++const W = new Set();
++const A = { l: new Array(2e3).fill(undefined), _: false, j: 0, S: 0 };
++const L = { l: new Array(2e3).fill(undefined), _: false, j: 0, S: 0 };
++let I = 0;
++let T = null;
++let H = false;
++let q = 0;
++let Q = false;
++let F = null;
++const M = new Set();
+ function registerTransientStoreNode(e) {
+-  Q.add(e);
++  M.add(e);
++}
++function canUseSimpleSyncFlush(e) {
++  return (
++    W.size === 0 &&
++    B.size === 0 &&
++    e.T.length === 0 &&
++    e.H.length === 0 &&
++    e.q.size === 0 &&
++    M.size === 0
++  );
+ }
+ function sweepTransientStoreNodes() {
+-  if (Q.size === 0) return;
+-  for (const e of Q) {
++  if (M.size === 0) return;
++  for (const e of M) {
+     if (e.O !== null) {
+-      Q.delete(e);
++      M.delete(e);
+       continue;
+     }
+-    if (e.T !== v) continue;
+-    if (e.H !== undefined && e.H !== v) continue;
+-    Q.delete(e);
+-    e.q?.();
++    if (e.F !== x) continue;
++    if (e.M !== undefined && e.M !== x) continue;
++    M.delete(e);
++    e.V?.();
+   }
+ }
+ function enforceLoadingBoundary(e) {}
+ function shouldReadStashedOptimisticValue(e) {
+-  return !!H?.has(e);
++  return !!F?.has(e);
+ }
+ function runLaneEffects(e) {
+-  for (const t of V) {
+-    if (t.M || t.V.size > 0) continue;
+-    const n = t.D[e - 1];
++  for (const t of B) {
++    if (t.D || t.B.size > 0) continue;
++    const n = t.K[e - 1];
+     if (n.length) {
+-      t.D[e - 1] = [];
++      t.K[e - 1] = [];
+       runQueue(n, e);
+     }
+   }
+ }
+ function queueStashedOptimisticEffects(e) {
+   for (let t = e.O; t !== null; t = t.P) {
+-    const e = t.k;
+-    if (!e.F) continue;
+-    if (e.F === O) {
+-      if (!e.B) {
+-        e.B = true;
+-        e.K.enqueue(_, e.G);
++    const e = t.C;
++    if (!e.G) continue;
++    if (e.G === P) {
++      if (!e.U) {
++        e.U = true;
++        e.J.enqueue(v, e.X);
+       }
+       continue;
+     }
+-    const n = e.m & o ? R : W;
+-    if (n.N > e.o) n.N = e.o;
++    const n = e.m & o ? L : A;
++    if (n.j > e.o) n.j = e.o;
+     insertIntoHeap(e, n);
+   }
+ }
+ function setProjectionWriteActive(e) {
+-  T = e;
++  Q = e;
+ }
+ function mergeTransitionState(e, t) {
+-  t.U = e;
+-  e.J.push(...t.J);
+-  for (const n of V) if (n.X === t) n.X = e;
+-  e.Y.push(...t.Y);
+-  for (const n of t.Z) e.Z.add(n);
+-  for (const [n, r] of t.$) {
+-    let t = e.$.get(n);
+-    if (!t) e.$.set(n, (t = new Set()));
++  t.Y = e;
++  e.Z.push(...t.Z);
++  for (const n of B) if (n.$ === t) n.$ = e;
++  e.H.push(...t.H);
++  for (const n of t.q) e.q.add(n);
++  for (const [n, r] of t.ee) {
++    let t = e.ee.get(n);
++    if (!t) e.ee.set(n, (t = new Set()));
+     for (const e of r) t.add(e);
+   }
+-  for (const n of t.ee) e.ee.add(n);
++  for (const n of t.te) e.te.add(n);
+ }
+ function resolveOptimisticNodes(e) {
+   for (let t = 0; t < e.length; t++) {
+     const n = e[t];
+-    n.te = undefined;
+-    if (n.T !== v) {
+-      n.ne = n.T;
+-      n.T = v;
++    n.ne = undefined;
++    if (n.F !== x) {
++      n.re = n.F;
++      n.F = x;
+     }
+-    const r = n.H;
+-    n.H = v;
+-    if (r !== v && n.ne !== r) insertSubs(n, true);
+-    n.X = null;
++    const r = n.M;
++    n.M = x;
++    if (r !== x && n.re !== r) insertSubs(n, true);
++    n.$ = null;
+   }
+   e.length = 0;
+ }
+ function cleanupCompletedLanes(e) {
+-  for (const t of V) {
+-    const n = e ? t.X === e : !t.X;
++  for (const t of B) {
++    const n = e ? t.$ === e : !t.$;
+     if (!n) continue;
+-    if (!t.M) {
+-      if (t.D[0].length) runQueue(t.D[0], b);
+-      if (t.D[1].length) runQueue(t.D[1], _);
++    if (!t.D) {
++      if (t.K[0].length) runQueue(t.K[0], O);
++      if (t.K[1].length) runQueue(t.K[1], v);
+     }
+-    if (t.re.te === t) t.re.te = undefined;
+-    t.V.clear();
+-    t.D[0].length = 0;
+-    t.D[1].length = 0;
+-    V.delete(t);
+-    M.delete(t.re);
++    if (t.ie.ne === t) t.ie.ne = undefined;
++    t.B.clear();
++    t.K[0].length = 0;
++    t.K[1].length = 0;
++    B.delete(t);
++    D.delete(t.ie);
+   }
+ }
+ function schedule() {
+-  if (I) return;
+-  I = true;
+-  if (!q.ie && !T) queueMicrotask(flush);
++  if (H) return;
++  H = true;
++  if (!q && !V.se && !Q) queueMicrotask(flush);
+ }
+ class Queue {
+   i = null;
+-  se = [[], []];
+-  oe = [];
+-  created = A;
++  oe = [[], []];
++  T = [];
++  created = I;
+   addChild(e) {
+-    this.oe.push(e);
++    this.T.push(e);
+     e.i = this;
+   }
+   removeChild(e) {
+-    const t = this.oe.indexOf(e);
++    const t = this.T.indexOf(e);
+     if (t >= 0) {
+-      this.oe.splice(t, 1);
++      this.T.splice(t, 1);
+       e.i = null;
+     }
+   }
+@@ -277,122 +290,133 @@ class Queue {
+     return false;
+   }
+   run(e) {
+-    if (this.se[e - 1].length) {
+-      const t = this.se[e - 1];
+-      this.se[e - 1] = [];
++    if (this.oe[e - 1].length) {
++      const t = this.oe[e - 1];
++      this.oe[e - 1] = [];
+       runQueue(t, e);
+     }
+-    for (let t = 0; t < this.oe.length; t++) this.oe[t].run?.(e);
++    for (let t = 0; t < this.T.length; t++) this.T[t].run?.(e);
+   }
+   enqueue(e, t) {
+     if (e) {
+-      if (Y) {
+-        const n = findLane(Y);
+-        n.D[e - 1].push(t);
++      if (te) {
++        const n = findLane(te);
++        n.K[e - 1].push(t);
+       } else {
+-        this.se[e - 1].push(t);
++        this.oe[e - 1].push(t);
+       }
+     }
+     schedule();
+   }
+   stashQueues(e) {
+-    e.se[0].push(...this.se[0]);
+-    e.se[1].push(...this.se[1]);
+-    this.se = [[], []];
+-    for (let t = 0; t < this.oe.length; t++) {
+-      let n = this.oe[t];
+-      let r = e.oe[t];
++    e.oe[0].push(...this.oe[0]);
++    e.oe[1].push(...this.oe[1]);
++    this.oe = [[], []];
++    for (let t = 0; t < this.T.length; t++) {
++      let n = this.T[t];
++      let r = e.T[t];
+       if (!r) {
+-        r = { se: [[], []], oe: [] };
+-        e.oe[t] = r;
++        r = { oe: [[], []], T: [] };
++        e.T[t] = r;
+       }
+       n.stashQueues(r);
+     }
+   }
+   restoreQueues(e) {
+-    this.se[0].push(...e.se[0]);
+-    this.se[1].push(...e.se[1]);
+-    for (let t = 0; t < e.oe.length; t++) {
+-      const n = e.oe[t];
+-      let r = this.oe[t];
++    this.oe[0].push(...e.oe[0]);
++    this.oe[1].push(...e.oe[1]);
++    for (let t = 0; t < e.T.length; t++) {
++      const n = e.T[t];
++      let r = this.T[t];
+       if (r) r.restoreQueues(n);
+     }
+   }
+ }
+ class GlobalQueue extends Queue {
+-  ie = false;
+-  ue = [];
+-  Y = [];
+-  Z = new Set();
+-  static fe;
++  se = false;
++  ue = null;
++  fe = [];
++  H = [];
++  q = new Set();
+   static le;
+-  static ce = null;
++  static ce;
++  static ae;
++  static de = null;
+   flush() {
+-    if (this.ie) return;
+-    this.ie = true;
++    if (this.se) return;
++    this.se = true;
+     try {
+-      runHeap(W, GlobalQueue.fe);
+-      if (L) {
+-        const e = transitionComplete(L);
++      runHeap(A, GlobalQueue.le);
++      if (T) {
++        const e = transitionComplete(T);
+         if (!e) {
+-          const e = L;
+-          runHeap(R, GlobalQueue.fe);
+-          this.ue = [];
+-          this.Y = [];
+-          this.Z = new Set();
+-          runLaneEffects(b);
+-          runLaneEffects(_);
+-          this.stashQueues(e.ae);
+-          A++;
+-          I = W.S >= W.N;
+-          reassignPendingTransition(e.ue);
+-          L = null;
+-          if (!e.J.length && !e.$.size && e.Y.length) {
+-            H = new Set();
+-            for (let t = 0; t < e.Y.length; t++) {
+-              const n = e.Y[t];
+-              if (n.I || n.de & a) continue;
+-              H.add(n);
++          const e = T;
++          runHeap(L, GlobalQueue.le);
++          this.ue = null;
++          this.fe = [];
++          this.H = [];
++          this.q = new Set();
++          runLaneEffects(O);
++          runLaneEffects(v);
++          this.stashQueues(e.pe);
++          I++;
++          H = A.S >= A.j;
++          reassignPendingTransition(e.fe);
++          T = null;
++          if (!e.Z.length && !e.ee.size && e.H.length) {
++            F = new Set();
++            for (let t = 0; t < e.H.length; t++) {
++              const n = e.H[t];
++              if (n.I || n.he & d) continue;
++              F.add(n);
+               queueStashedOptimisticEffects(n);
+             }
+           }
+           try {
+             finalizePureQueue(null, true);
+           } finally {
+-            H = null;
++            F = null;
+           }
+           return;
+         }
+-        this.ue !== L.ue && this.ue.push(...L.ue);
+-        this.restoreQueues(L.ae);
+-        N.delete(L);
+-        const t = L;
+-        L = null;
+-        reassignPendingTransition(this.ue);
++        this.fe !== T.fe && this.fe.push(...T.fe);
++        this.restoreQueues(T.pe);
++        W.delete(T);
++        const t = T;
++        T = null;
++        reassignPendingTransition(this.fe);
+         finalizePureQueue(t);
+       } else {
+-        if (N.size) runHeap(R, GlobalQueue.fe);
+-        finalizePureQueue();
+-      }
+-      A++;
+-      I = W.S >= W.N;
+-      runLaneEffects(b);
+-      this.run(b);
+-      runLaneEffects(_);
+-      this.run(_);
++        if (canUseSimpleSyncFlush(this)) {
++          commitPendingNodes();
++          if (A.S >= A.j) {
++            runHeap(A, GlobalQueue.le);
++            commitPendingNodes();
++          }
++        } else {
++          if (W.size) runHeap(L, GlobalQueue.le);
++          finalizePureQueue();
++        }
++      }
++      I++;
++      H = A.S >= A.j;
++      B.size && runLaneEffects(O);
++      this.run(O);
++      B.size && runLaneEffects(v);
++      this.run(v);
+       if (false);
+     } finally {
+-      this.ie = false;
++      this.se = false;
+     }
+   }
+   notify(e, t, n, r) {
+-    if (t & S) {
+-      if (n & S) {
+-        const t = r !== undefined ? r : e.pe;
+-        if (L && t) {
++    if (t & m) {
++      if (n & m) {
++        const t = r !== undefined ? r : e.ge;
++        if (T && t) {
+           const n = t.source;
+-          let r = L.$.get(n);
+-          if (!r) L.$.set(n, (r = new Set()));
++          let r = T.ee.get(n);
++          if (!r) T.ee.set(n, (r = new Set()));
+           const i = r.size;
+           r.add(e);
+           if (r.size !== i) schedule();
+@@ -404,123 +428,159 @@ class GlobalQueue extends Queue {
+   }
+   initTransition(e) {
+     if (e) e = currentTransition(e);
+-    if (e && e === L) return;
+-    if (!e && L && L.he === A) return;
+-    if (!L) {
+-      L = e ?? {
+-        he: A,
+-        ue: [],
+-        $: new Map(),
+-        Y: [],
+-        Z: new Set(),
+-        J: [],
+-        ae: { se: [[], []], oe: [] },
+-        U: false,
+-        ee: new Set()
++    if (e && e === T) return;
++    if (!e && T && T.ye === I) return;
++    if (!T) {
++      T = e ?? {
++        ye: I,
++        fe: [],
++        ee: new Map(),
++        H: [],
++        q: new Set(),
++        Z: [],
++        pe: { oe: [[], []], T: [] },
++        Y: false,
++        te: new Set()
+       };
+     } else if (e) {
+-      const t = L;
++      const t = T;
+       mergeTransitionState(e, t);
+-      N.delete(t);
+-      L = e;
++      W.delete(t);
++      T = e;
++    }
++    W.add(T);
++    T.ye = I;
++    if (this.ue !== null) {
++      this.ue.$ = T;
++      T.fe.push(this.ue);
++      this.ue = null;
+     }
+-    N.add(L);
+-    L.he = A;
+-    if (this.ue !== L.ue) {
+-      for (let e = 0; e < this.ue.length; e++) {
+-        const t = this.ue[e];
+-        t.X = L;
+-        L.ue.push(t);
++    if (this.fe !== T.fe) {
++      for (let e = 0; e < this.fe.length; e++) {
++        const t = this.fe[e];
++        t.$ = T;
++        T.fe.push(t);
+       }
+-      this.ue = L.ue;
++      this.fe = T.fe;
+     }
+-    if (this.Y !== L.Y) {
+-      for (let e = 0; e < this.Y.length; e++) {
+-        const t = this.Y[e];
+-        t.X = L;
+-        L.Y.push(t);
++    if (this.H !== T.H) {
++      for (let e = 0; e < this.H.length; e++) {
++        const t = this.H[e];
++        t.$ = T;
++        T.H.push(t);
+       }
+-      this.Y = L.Y;
++      this.H = T.H;
+     }
+-    for (const e of V) {
+-      if (!e.X) e.X = L;
++    for (const e of B) {
++      if (!e.$) e.$ = T;
+     }
+-    if (this.Z !== L.Z) {
+-      for (const e of this.Z) L.Z.add(e);
+-      this.Z = L.Z;
++    if (this.q !== T.q) {
++      for (const e of this.q) T.q.add(e);
++      this.q = T.q;
+     }
+   }
+ }
++function queuePendingNode(e) {
++  if (T) {
++    V.fe.push(e);
++    return;
++  }
++  if (V.ue === null && V.fe.length === 0) {
++    V.ue = e;
++    return;
++  }
++  if (V.ue !== null) {
++    V.fe.push(V.ue);
++    V.ue = null;
++  }
++  V.fe.push(e);
++}
+ function insertSubs(e, t = false) {
+-  const n = e.te || Y;
+-  const r = e.ye !== undefined;
++  const n = e.ne || te;
++  const r = e.Se !== undefined;
+   for (let i = e.O; i !== null; i = i.P) {
+-    if (r && i.k.de & h) {
+-      i.k.m |= l;
++    if (r && i.C.he & g) {
++      i.C.m |= l;
+       continue;
+     }
+     if (t && n) {
+-      i.k.m |= f;
+-      assignOrMergeLane(i.k, n);
++      i.C.m |= f;
++      assignOrMergeLane(i.C, n);
+     } else if (t) {
+-      i.k.m |= f;
+-      i.k.te = undefined;
++      i.C.m |= f;
++      i.C.ne = undefined;
+     }
+-    const e = i.k;
+-    if (e.F === O) {
+-      if (!e.B) {
+-        e.B = true;
+-        e.K.enqueue(_, e.G);
++    const e = i.C;
++    if (e.G === P) {
++      if (!e.U) {
++        e.U = true;
++        e.J.enqueue(v, e.X);
+       }
+       continue;
+     }
+-    const s = i.k.m & o ? R : W;
+-    if (s.N > i.k.o) s.N = i.k.o;
+-    insertIntoHeap(i.k, s);
++    const s = i.C.m & o ? L : A;
++    if (s.j > i.C.o) s.j = i.C.o;
++    insertIntoHeap(i.C, s);
+   }
+ }
++function commitPendingNode(e) {
++  const t = e;
++  if (!t.I) {
++    if (e.F !== x) {
++      e.re = e.F;
++      e.F = x;
++    }
++    return;
++  }
++  if (e.F !== x) {
++    e.re = e.F;
++    e.F = x;
++    if (e.G && e.G !== P) e.U = true;
++  }
++  t.m &= ~a;
++  if (!(t.we & m)) t.we &= ~b;
++  if (t.me !== null || t._e !== null) GlobalQueue.ce(t, false, true);
++}
+ function commitPendingNodes() {
+-  const e = q.ue;
++  if (V.ue !== null) {
++    commitPendingNode(V.ue);
++    V.ue = null;
++  }
++  const e = V.fe;
+   for (let t = 0; t < e.length; t++) {
+-    const n = e[t];
+-    if (n.T !== v) {
+-      n.ne = n.T;
+-      n.T = v;
+-      if (n.F && n.F !== O) n.B = true;
+-    }
+-    if (!(n.ge & S)) n.ge &= ~m;
+-    if (n.I) GlobalQueue.le(n, false, true);
++    commitPendingNode(e[t]);
+   }
+   e.length = 0;
+ }
+ function finalizePureQueue(e = null, t = false) {
+   const n = !t;
+   if (n) commitPendingNodes();
+-  if (!t) checkBoundaryChildren(q);
+-  if (W.S >= W.N) runHeap(W, GlobalQueue.fe);
++  if (!t && V.T.length) checkBoundaryChildren(V);
++  const r = A.S >= A.j;
++  if (r) runHeap(A, GlobalQueue.le);
+   if (n) {
+-    commitPendingNodes();
+-    resolveOptimisticNodes(e ? e.Y : q.Y);
+-    if (e && e.ee.size) {
+-      for (const t of e.ee) {
++    if (r) commitPendingNodes();
++    resolveOptimisticNodes(e ? e.H : V.H);
++    if (e && e.te.size) {
++      for (const t of e.te) {
+         if (t.m & u) continue;
+-        if (t.F === O) {
+-          if (!t.B) {
+-            t.B = true;
+-            t.K.enqueue(_, t.G);
++        if (t.G === P) {
++          if (!t.U) {
++            t.U = true;
++            t.J.enqueue(v, t.X);
+           }
+           continue;
+         }
+-        const e = t.m & o ? R : W;
+-        if (e.N > t.o) e.N = t.o;
++        const e = t.m & o ? L : A;
++        if (e.j > t.o) e.j = t.o;
+         insertIntoHeap(t, e);
+       }
+-      e.ee.clear();
++      e.te.clear();
+     }
+-    const t = e ? e.Z : q.Z;
+-    if (GlobalQueue.ce && t.size) {
++    const t = e ? e.q : V.q;
++    if (GlobalQueue.de && t.size) {
+       for (const e of t) {
+-        GlobalQueue.ce(e);
++        GlobalQueue.de(e);
+       }
+       t.clear();
+       schedule();
+@@ -530,27 +590,36 @@ function finalizePureQueue(e = null, t = false) {
+   }
+ }
+ function checkBoundaryChildren(e) {
+-  for (const t of e.oe) {
++  for (const t of e.T) {
+     t.checkSources?.();
+     checkBoundaryChildren(t);
+   }
+ }
+ function trackOptimisticStore(e) {
+-  q.Z.add(e);
++  V.q.add(e);
+   schedule();
+ }
+ function reassignPendingTransition(e) {
+   for (let t = 0; t < e.length; t++) {
+-    e[t].X = L;
++    e[t].$ = T;
+   }
+ }
+-const q = new GlobalQueue();
+-function flush() {
+-  if (q.ie) {
++const V = new GlobalQueue();
++function flush(e) {
++  if (e) {
++    q++;
++    try {
++      return e();
++    } finally {
++      flush();
++      q--;
++    }
++  }
++  if (V.se) {
+     return;
+   }
+-  while (I || L) {
+-    q.flush();
++  while (H || T) {
++    V.flush();
+   }
+ }
+ function runQueue(e, t) {
+@@ -558,21 +627,21 @@ function runQueue(e, t) {
+ }
+ function reporterBlocksSource(e, t) {
+   if (e.m & (o | u)) return false;
+-  if (e.Se === t || e.we?.has(t)) return true;
+-  for (let n = e.W; n; n = n.R) {
++  if (e.be === t || e.Oe?.has(t)) return true;
++  for (let n = e.R; n; n = n.W) {
+     let e = n.A;
+     while (e) {
+       if (e === t || e.L === t) return true;
+-      e = e.me;
++      e = e.ve;
+     }
+   }
+-  return !!(e.ge & S && e.pe instanceof NotReadyError && e.pe.source === t);
++  return !!(e.we & m && e.ge instanceof NotReadyError && e.ge.source === t);
+ }
+ function transitionComplete(e) {
+-  if (e.U) return true;
+-  if (e.J.length) return false;
++  if (e.Y) return true;
++  if (e.Z.length) return false;
+   let t = true;
+-  for (const [n, r] of e.$) {
++  for (const [n, r] of e.ee) {
+     let i = false;
+     for (const e of r) {
+       if (reporterBlocksSource(e, n)) {
+@@ -581,222 +650,231 @@ function transitionComplete(e) {
+       }
+       r.delete(e);
+     }
+-    if (!i) e.$.delete(n);
+-    else if (n.ge & S && n.pe?.source === n) {
++    if (!i) e.ee.delete(n);
++    else if (n.we & m && n.ge?.source === n) {
+       t = false;
+       break;
+     }
+   }
+   if (t) {
+-    for (let n = 0; n < e.Y.length; n++) {
+-      const r = e.Y[n];
++    for (let n = 0; n < e.H.length; n++) {
++      const r = e.H[n];
+       if (
+         hasActiveOverride(r) &&
+-        "ge" in r &&
+-        r.ge & S &&
+-        r.pe instanceof NotReadyError &&
+-        r.pe.source !== r
++        "we" in r &&
++        r.we & m &&
++        r.ge instanceof NotReadyError &&
++        r.ge.source !== r
+       ) {
+         t = false;
+         break;
+       }
+     }
+   }
+-  t && (e.U = true);
++  t && (e.Y = true);
+   return t;
+ }
+ function currentTransition(e) {
+-  while (e.U && typeof e.U === "object") e = e.U;
++  while (e.Y && typeof e.Y === "object") e = e.Y;
+   return e;
+ }
+ function setActiveTransition(e) {
+-  L = e;
++  T = e;
+ }
+ function runInTransition(e, t) {
+-  const n = L;
++  const n = T;
+   try {
+-    L = currentTransition(e);
++    T = currentTransition(e);
+     return t();
+   } finally {
+-    L = n;
++    T = n;
+   }
+ }
+-const M = new WeakMap();
+-const V = new Set();
++const D = new WeakMap();
++const B = new Set();
+ function getOrCreateLane(e) {
+-  let t = M.get(e);
++  let t = D.get(e);
+   if (t) {
+     return findLane(t);
+   }
+-  const n = e.me;
+-  const r = n?.te ? findLane(n.te) : null;
+-  t = { re: e, V: new Set(), D: [[], []], M: null, X: L, be: r };
+-  M.set(e, t);
+-  V.add(t);
+-  e._e = false;
++  const n = e.ve;
++  const r = n?.ne ? findLane(n.ne) : null;
++  t = { ie: e, B: new Set(), K: [[], []], D: null, $: T, Pe: r };
++  D.set(e, t);
++  B.add(t);
++  e.xe = false;
+   return t;
+ }
+ function findLane(e) {
+-  while (e.M) e = e.M;
++  while (e.D) e = e.D;
+   return e;
+ }
+ function mergeLanes(e, t) {
+   e = findLane(e);
+   t = findLane(t);
+   if (e === t) return e;
+-  t.M = e;
+-  for (const n of t.V) e.V.add(n);
+-  e.D[0].push(...t.D[0]);
+-  e.D[1].push(...t.D[1]);
++  t.D = e;
++  for (const n of t.B) e.B.add(n);
++  e.K[0].push(...t.K[0]);
++  e.K[1].push(...t.K[1]);
+   return e;
+ }
+ function resolveLane(e) {
+-  const t = e.te;
++  const t = e.ne;
+   if (!t) return undefined;
+   const n = findLane(t);
+-  if (V.has(n)) return n;
+-  e.te = undefined;
++  if (B.has(n)) return n;
++  e.ne = undefined;
+   return undefined;
+ }
+ function resolveTransition(e) {
+-  return resolveLane(e)?.X ?? e.X;
++  return resolveLane(e)?.$ ?? e.$;
+ }
+ function hasActiveOverride(e) {
+-  return !!(e.H !== undefined && e.H !== v);
++  return !!(e.M !== undefined && e.M !== x);
+ }
+ function assignOrMergeLane(e, t) {
+   const n = findLane(t);
+-  const r = e.te;
++  const r = e.ne;
+   if (r) {
+-    if (r.M) {
+-      e.te = t;
++    if (r.D) {
++      e.ne = t;
+       return;
+     }
+     const i = findLane(r);
+-    if (V.has(i)) {
++    if (B.has(i)) {
+       if (i !== n && !hasActiveOverride(e)) {
+-        if (n.be && findLane(n.be) === i) {
+-          e.te = t;
+-        } else if (i.be && findLane(i.be) === n);
++        if (n.Pe && findLane(n.Pe) === i) {
++          e.ne = t;
++        } else if (i.Pe && findLane(i.Pe) === n);
+         else mergeLanes(n, i);
+       }
+       return;
+     }
+   }
+-  e.te = t;
++  e.ne = t;
+ }
+ function unlinkSubs(e) {
+   const t = e.A;
+-  const n = e.R;
++  const n = e.W;
+   const r = e.P;
+-  const i = e.Oe;
+-  if (r !== null) r.Oe = i;
+-  else t.ve = i;
++  const i = e.Ce;
++  if (r !== null) r.Ce = i;
++  else t.Ne = i;
+   if (i !== null) i.P = r;
+   else {
+     t.O = r;
+     if (r === null) {
+-      t.q?.();
++      t.V?.();
+       const e = t;
+-      e.I && e.de & g && !(e.m & o) && unobserved(e);
++      e.I && e.he & S && !(e.m & o) && unobserved(e);
+     }
+   }
+   return n;
+ }
+ function unobserved(e) {
+-  deleteFromHeap(e, e.m & o ? R : W);
+-  let t = e.W;
++  deleteFromHeap(e, e.m & o ? L : A);
++  let t = e.R;
+   while (t !== null) {
+     t = unlinkSubs(t);
+   }
+-  e.W = null;
+-  e.xe = null;
++  e.R = null;
++  e.Ee = null;
+   disposeChildren(e, true);
+ }
+ function link(e, t) {
+-  const n = t.xe;
++  const n = t.Ee;
+   if (n !== null && n.A === e) return;
+   let i = null;
+   const s = t.m & r;
+   if (s) {
+-    i = n !== null ? n.R : t.W;
++    i = n !== null ? n.W : t.R;
+     if (i !== null && i.A === e) {
+-      t.xe = i;
++      t.Ee = i;
+       return;
+     }
+   }
+-  const o = e.ve;
+-  if (o !== null && o.k === t && (!s || isValidLink(o, t))) return;
+-  const u = (t.xe = e.ve = { A: e, k: t, R: i, Oe: o, P: null });
+-  if (n !== null) n.R = u;
+-  else t.W = u;
++  const o = e.Ne;
++  if (o !== null && o.C === t && (!s || isValidLink(o, t))) return;
++  const u = (t.Ee = e.Ne = { A: e, C: t, W: i, Ce: o, P: null });
++  if (n !== null) n.W = u;
++  else t.R = u;
+   if (o !== null) o.P = u;
+   else e.O = u;
+ }
+ function isValidLink(e, t) {
+-  const n = t.xe;
++  const n = t.Ee;
+   if (n !== null) {
+-    let r = t.W;
++    let r = t.R;
+     do {
+       if (r === e) return true;
+       if (r === n) break;
+-      r = r.R;
++      r = r.W;
+     } while (r !== null);
+   }
+   return false;
+ }
+-const D = {};
++const K = {};
+ function markDisposal(e) {
+-  let t = e.Pe;
++  let t = e.ke;
+   while (t) {
+     t.m |= o;
+     if (t.m & i) {
+-      deleteFromHeap(t, W);
+-      insertIntoHeap(t, R);
++      deleteFromHeap(t, A);
++      insertIntoHeap(t, L);
+     }
+     markDisposal(t);
+-    t = t.ke;
++    t = t.je;
+   }
+ }
+ function dispose(e) {
+-  let t = e.W || null;
++  let t = e.R || null;
+   do {
+     t = unlinkSubs(t);
+   } while (t !== null);
+-  e.W = null;
+-  e.xe = null;
++  e.R = null;
++  e.Ee = null;
+   disposeChildren(e, true);
+ }
+ function disposeChildren(e, t = false, n) {
+-  if (e.m & u) return;
+-  if (t) e.m = u;
+-  if (t && e.I) e.Ce = null;
+-  let r = n ? e.Ee : e.Pe;
+-  while (r) {
+-    const e = r.ke;
+-    if (r.W) {
+-      const e = r;
+-      deleteFromHeap(e, e.m & o ? R : W);
+-      let t = e.W;
++  const r = e.m;
++  if (r & u) return;
++  if (t) e.m = r | u;
++  if (t && e.I) e.Re = null;
++  let i = n ? e.me : e.ke;
++  while (i) {
++    const e = i.je;
++    if (i.R) {
++      const e = i;
++      deleteFromHeap(e, e.m & o ? L : A);
++      let t = e.R;
+       do {
+         t = unlinkSubs(t);
+       } while (t !== null);
+-      e.W = null;
+-      e.xe = null;
++      e.R = null;
++      e.Ee = null;
+     }
+-    disposeChildren(r, true);
+-    r = e;
++    disposeChildren(i, true);
++    i = e;
+   }
+   if (n) {
+-    e.Ee = null;
++    e.me = null;
+   } else {
+-    e.Pe = null;
+-    e.je = 0;
++    e.ke = null;
++    e.We = 0;
++  }
++  if (t && !n && !(r & o) && e.i !== null && !(e.i.m & u)) {
++    const t = e.Ae;
++    const n = e.je;
++    if (t !== null) t.je = n;
++    else e.i.ke = n;
++    if (n !== null) n.Ae = t;
++    e.Ae = null;
+   }
+   runDisposal(e, n);
+ }
+ function runDisposal(e, t) {
+-  let n = t ? e.Ne : e.We;
++  let n = t ? e._e : e.Le;
+   if (!n) return;
+   if (Array.isArray(n)) {
+     for (let e = 0; e < n.length; e++) {
+@@ -806,12 +884,12 @@ function runDisposal(e, t) {
+   } else {
+     n.call(n);
+   }
+-  t ? (e.Ne = null) : (e.We = null);
++  t ? (e._e = null) : (e.Le = null);
+ }
+ function childId(e, t) {
+   let n = e;
+-  while (n.de & p && n.i) n = n.i;
+-  if (n.id != null) return formatId(n.id, t ? n.je++ : n.je);
++  while (n.he & h && n.i) n = n.i;
++  if (n.id != null) return formatId(n.id, t ? n.We++ : n.We);
+   throw new Error("Cannot get child id from owner without an id");
+ }
+ function getNextChildId(e) {
+@@ -826,110 +904,113 @@ function formatId(e, t) {
+   return e + (r ? String.fromCharCode(64 + r) : "") + n;
+ }
+ function getObserver() {
+-  if (z || J) return D;
+-  return B ? X : null;
++  if (Y || $) return K;
++  return z ? ee : null;
+ }
+ function getOwner() {
+-  return X;
++  return ee;
+ }
+ function cleanup(e) {
+-  if (!X) return e;
+-  if (!X.We) X.We = e;
+-  else if (Array.isArray(X.We)) X.We.push(e);
+-  else X.We = [X.We, e];
++  if (!ee) return e;
++  if (!ee.Le) ee.Le = e;
++  else if (Array.isArray(ee.Le)) ee.Le.push(e);
++  else ee.Le = [ee.Le, e];
+   return e;
+ }
+ function isDisposed(e) {
+   return !!(e.m & (u | o));
+ }
++function disposeRootSelf(e = true) {
++  disposeChildren(this, e);
++}
+ function createOwner(e) {
+-  const t = X;
++  const t = ee;
+   const n = e?.transparent ?? false;
+   const r = {
+     id: e?.id ?? (n ? t?.id : t?.id != null ? getNextChildId(t) : undefined),
+-    de: n ? p : 0,
++    he: n ? h : 0,
+     t: true,
+     u: t?.t ? t.u : t,
+-    Pe: null,
+     ke: null,
+-    We: null,
+-    K: t?.K ?? q,
+-    Re: t?.Re || C,
+-    je: 0,
+-    Ne: null,
+-    Ee: null,
++    je: null,
++    Ae: null,
++    Le: null,
++    J: t?.J ?? V,
++    Ie: t?.Ie || k,
++    We: 0,
++    _e: null,
++    me: null,
+     i: t,
+-    dispose(e = true) {
+-      disposeChildren(r, e);
+-    }
++    dispose: disposeRootSelf
+   };
+   if (t) {
+-    const e = t.Pe;
++    const e = t.ke;
+     if (e === null) {
+-      t.Pe = r;
++      t.ke = r;
+     } else {
+-      r.ke = e;
+-      t.Pe = r;
++      r.je = e;
++      e.Ae = r;
++      t.ke = r;
+     }
+   }
+   return r;
+ }
+ function createRoot(e, t) {
+   const n = createOwner(t);
+-  return runWithOwner(n, () => e(n.dispose));
++  return runWithOwner(n, () => e(() => n.dispose()));
+ }
+ function addPendingSource(e, t) {
+-  if (e.Se === t || e.we?.has(t)) return false;
+-  if (!e.Se) {
+-    e.Se = t;
++  if (e.be === t || e.Oe?.has(t)) return false;
++  if (!e.be) {
++    e.be = t;
+     return true;
+   }
+-  if (!e.we) {
+-    e.we = new Set([e.Se, t]);
++  if (!e.Oe) {
++    e.Oe = new Set([e.be, t]);
+   } else {
+-    e.we.add(t);
++    e.Oe.add(t);
+   }
+-  e.Se = undefined;
++  e.be = undefined;
+   return true;
+ }
+ function removePendingSource(e, t) {
+-  if (e.Se) {
+-    if (e.Se !== t) return false;
+-    e.Se = undefined;
++  if (e.be) {
++    if (e.be !== t) return false;
++    e.be = undefined;
+     return true;
+   }
+-  if (!e.we?.delete(t)) return false;
+-  if (e.we.size === 1) {
+-    e.Se = e.we.values().next().value;
+-    e.we = undefined;
+-  } else if (e.we.size === 0) {
+-    e.we = undefined;
++  if (!e.Oe?.delete(t)) return false;
++  if (e.Oe.size === 1) {
++    e.be = e.Oe.values().next().value;
++    e.Oe = undefined;
++  } else if (e.Oe.size === 0) {
++    e.Oe = undefined;
+   }
+   return true;
+ }
+ function clearPendingSources(e) {
+-  e.Se = undefined;
+-  e.we?.clear();
+-  e.we = undefined;
++  e.be = undefined;
++  e.Oe?.clear();
++  e.Oe = undefined;
+ }
+ function setPendingError(e, t, n) {
+   if (!t) {
+-    e.pe = null;
++    e.ge = null;
+     return;
+   }
+   if (n instanceof NotReadyError && n.source === t) {
+-    e.pe = n;
++    e.ge = n;
+     return;
+   }
+-  const r = e.pe;
++  const r = e.ge;
+   if (!(r instanceof NotReadyError) || r.source !== t) {
+-    e.pe = new NotReadyError(t);
++    e.ge = new NotReadyError(t);
+   }
+ }
+ function forEachDependent(e, t) {
+-  for (let n = e.O; n !== null; n = n.P) t(n.k);
+-  for (let n = e.C; n !== null; n = n.j) {
+-    for (let e = n.O; e !== null; e = e.P) t(e.k);
++  for (let n = e.O; n !== null; n = n.P) t(n.C);
++  for (let n = e.N; n !== null; n = n.k) {
++    for (let e = n.O; e !== null; e = e.P) t(e.C);
+   }
+ }
+ function settlePendingSource(e) {
+@@ -938,30 +1019,30 @@ function settlePendingSource(e) {
+   const settle = r => {
+     if (n.has(r) || !removePendingSource(r, e)) return;
+     n.add(r);
+-    r.he = A;
+-    const i = r.Se ?? r.we?.values().next().value;
++    r.ye = I;
++    const i = r.be ?? r.Oe?.values().next().value;
+     if (i) {
+       setPendingError(r, i);
+       updatePendingSignal(r);
+     } else {
+-      r.ge &= ~S;
++      r.we &= ~m;
+       setPendingError(r);
+       updatePendingSignal(r);
+-      if (r.Ae) {
+-        if (r.F === O) {
++      if (r.Te) {
++        if (r.G === P) {
+           const e = r;
+-          if (!e.B) {
+-            e.B = true;
+-            e.K.enqueue(_, e.G);
++          if (!e.U) {
++            e.U = true;
++            e.J.enqueue(v, e.X);
+           }
+         } else {
+-          const e = r.m & o ? R : W;
+-          if (e.N > r.o) e.N = r.o;
++          const e = r.m & o ? L : A;
++          if (e.j > r.o) e.j = r.o;
+           insertIntoHeap(r, e);
+         }
+         t = true;
+       }
+-      r.Ae = false;
++      r.Te = false;
+     }
+     forEachDependent(r, settle);
+   };
+@@ -969,46 +1050,51 @@ function settlePendingSource(e) {
+   if (t) schedule();
+ }
+ function handleAsync(e, t, r) {
+-  const i = typeof t === "object" && t !== null;
+-  const s = i && untrack(() => t[Symbol.asyncIterator]);
+-  const o = !s && i && untrack(() => typeof t.then === "function");
+-  if (!o && !s) {
+-    e.Ce = null;
++  let i = false;
++  let s = false;
++  if (typeof t === "object" && t !== null) {
++    untrack(() => {
++      i = t[Symbol.asyncIterator];
++      s = !i && typeof t.then === "function";
++    });
++  }
++  if (!s && !i) {
++    e.Re = null;
+     return t;
+   }
+-  e.Ce = t;
+-  let u;
++  e.Re = t;
++  let o;
+   const handleError = n => {
+-    if (e.Ce !== t) return;
+-    q.initTransition(resolveTransition(e));
+-    notifyStatus(e, n instanceof NotReadyError ? S : w, n);
+-    e.he = A;
++    if (e.Re !== t) return;
++    V.initTransition(resolveTransition(e));
++    notifyStatus(e, n instanceof NotReadyError ? m : _, n);
++    e.ye = I;
+   };
+   const asyncWrite = (i, s) => {
+-    if (e.Ce !== t) return;
++    if (e.Re !== t) return;
+     if (e.m & (n | f)) return;
+-    q.initTransition(resolveTransition(e));
+-    const o = !!(e.ge & m);
++    V.initTransition(resolveTransition(e));
++    const o = !!(e.we & b);
+     clearStatus(e);
+     const u = resolveLane(e);
+-    if (u) u.V.delete(e);
++    if (u) u.B.delete(e);
+     if (r) r(i);
+-    else if (e.H !== undefined) {
+-      if (e.H !== undefined && e.H !== v) e.T = i;
++    else if (e.M !== undefined) {
++      if (e.M !== undefined && e.M !== x) e.F = i;
+       else {
+-        e.ne = i;
++        e.re = i;
+         insertSubs(e);
+       }
+-      e.he = A;
++      e.ye = I;
+     } else if (u) {
+-      const t = e.F;
+-      const n = e.ne;
+-      const r = e.Le;
++      const t = e.G;
++      const n = e.re;
++      const r = e.He;
+       if ((!t && o) || !r || !r(i, n)) {
+-        e.ne = i;
+-        e.he = A;
+-        if (e.Ie) {
+-          setSignal(e.Ie, i);
++        e.re = i;
++        e.ye = I;
++        if (e.qe) {
++          setSignal(e.qe, i);
+         }
+         insertSubs(e, true);
+       }
+@@ -1020,13 +1106,13 @@ function handleAsync(e, t, r) {
+     flush();
+     s?.();
+   };
+-  if (o) {
++  if (s) {
+     let n = false,
+       r = true;
+     t.then(
+       e => {
+         if (r) {
+-          u = e;
++          o = e;
+           n = true;
+         } else asyncWrite(e);
+       },
+@@ -1036,11 +1122,11 @@ function handleAsync(e, t, r) {
+     );
+     r = false;
+     if (!n) {
+-      q.initTransition(resolveTransition(e));
+-      throw new NotReadyError(X);
++      V.initTransition(resolveTransition(e));
++      throw new NotReadyError(ee);
+     }
+   }
+-  if (s) {
++  if (i) {
+     const n = t[Symbol.asyncIterator]();
+     let r = false;
+     let i = false;
+@@ -1056,15 +1142,15 @@ function handleAsync(e, t, r) {
+     });
+     const iterate = () => {
+       let s,
+-        o = false,
++        u = false,
+         f = true;
+       n.next().then(
+         n => {
+           if (f) {
+             s = n;
+-            o = true;
++            u = true;
+             if (n.done) i = true;
+-          } else if (e.Ce !== t) {
++          } else if (e.Re !== t) {
+             return;
+           } else if (!n.done) asyncWrite(n.value, iterate);
+           else {
+@@ -1074,52 +1160,52 @@ function handleAsync(e, t, r) {
+           }
+         },
+         n => {
+-          if (!f && e.Ce === t) {
++          if (!f && e.Re === t) {
+             i = true;
+             handleError(n);
+           }
+         }
+       );
+       f = false;
+-      if (o && !s.done) {
+-        u = s.value;
++      if (u && !s.done) {
++        o = s.value;
+         r = true;
+         return iterate();
+       }
+-      return o && s.done;
++      return u && s.done;
+     };
+     const s = iterate();
+     if (!r && !s) {
+-      q.initTransition(resolveTransition(e));
+-      throw new NotReadyError(X);
++      V.initTransition(resolveTransition(e));
++      throw new NotReadyError(ee);
+     }
+   }
+-  return u;
++  return o;
+ }
+ function clearStatus(e, t = false) {
+-  clearPendingSources(e);
+-  e.Ae = false;
+-  e.ge = t ? 0 : e.ge & m;
+-  setPendingError(e);
+-  updatePendingSignal(e);
+-  e.Te?.();
++  if (e.be || e.Oe) clearPendingSources(e);
++  if (e.Te) e.Te = false;
++  e.we = t ? 0 : e.we & b;
++  if (e.ge) setPendingError(e);
++  if (e.Qe) updatePendingSignal(e);
++  if (e.Fe) e.Fe();
+ }
+ function notifyStatus(e, t, n, r, i) {
+-  if (t === w && !(n instanceof StatusError) && !(n instanceof NotReadyError))
++  if (t === _ && !(n instanceof StatusError) && !(n instanceof NotReadyError))
+     n = new StatusError(e, n);
+-  const s = t === S && n instanceof NotReadyError ? n.source : undefined;
++  const s = t === m && n instanceof NotReadyError ? n.source : undefined;
+   const o = s === e;
+-  const u = t === S && e.H !== undefined && !o;
++  const u = t === m && e.M !== undefined && !o;
+   const f = u && hasActiveOverride(e);
+   if (!r) {
+-    if (t === S && s) {
++    if (t === m && s) {
+       addPendingSource(e, s);
+-      e.ge = S | (e.ge & m);
++      e.we = m | (e.we & b);
+       setPendingError(e, s, n);
+     } else {
+       clearPendingSources(e);
+-      e.ge = t | (t !== w ? e.ge & m : 0);
+-      e.pe = n;
++      e.we = t | (t !== _ ? e.we & b : 0);
++      e.ge = n;
+     }
+     updatePendingSignal(e);
+   }
+@@ -1128,34 +1214,34 @@ function notifyStatus(e, t, n, r, i) {
+   }
+   const l = r || f;
+   const c = r || u ? undefined : i;
+-  if (e.Te) {
+-    if (r && t === S) {
++  if (e.Fe) {
++    if (r && t === m) {
+       return;
+     }
+     if (l) {
+-      e.Te(t, n);
++      e.Fe(t, n);
+     } else {
+-      e.Te();
++      e.Fe();
+     }
+     return;
+   }
+   forEachDependent(e, e => {
+-    e.he = A;
++    e.ye = I;
+     if (
+-      (t === S && s && e.Se !== s && !e.we?.has(s)) ||
+-      (t !== S && (e.pe !== n || e.Se || e.we))
++      (t === m && s && e.be !== s && !e.Oe?.has(s)) ||
++      (t !== m && (e.ge !== n || e.be || e.Oe))
+     ) {
+-      if (!l && !e.X) q.ue.push(e);
++      if (!l && !e.$) queuePendingNode(e);
+       notifyStatus(e, t, n, l, c);
+     }
+   });
+ }
+-let F = null;
++let G = null;
+ function enableExternalSource(e) {
+   const { factory: t, untrack: n = e => e() } = e;
+-  if (F) {
+-    const { factory: e, untrack: r } = F;
+-    F = {
++  if (G) {
++    const { factory: e, untrack: r } = G;
++    G = {
+       factory: (n, r) => {
+         const i = e(n, r);
+         const s = t(e => i.track(e), r);
+@@ -1170,112 +1256,113 @@ function enableExternalSource(e) {
+       untrack: e => r(() => n(e))
+     };
+   } else {
+-    F = { factory: t, untrack: n };
++    G = { factory: t, untrack: n };
+   }
+ }
+-GlobalQueue.fe = recompute;
+-GlobalQueue.le = disposeChildren;
+-let B = false;
+-let K = false;
+-let G = false;
++GlobalQueue.le = recompute;
++GlobalQueue.ce = disposeChildren;
+ let z = false;
+ let U = false;
+ let J = false;
+-let X = null;
+-let Y = null;
++let X = false;
++let Y = false;
+ let Z = false;
+-let $ = null;
++let $ = false;
++let ee = null;
++let te = null;
++let ne = false;
++let re = null;
+ function ownerInSnapshotScope(e) {
+   while (e) {
+-    if (e.He) return true;
++    if (e.Me) return true;
+     e = e.i;
+   }
+   return false;
+ }
+ function setSnapshotCapture(e) {
+-  Z = e;
+-  if (e && !$) $ = new Set();
++  ne = e;
++  if (e && !re) re = new Set();
+ }
+ function markSnapshotScope(e) {
+-  e.He = true;
++  e.Me = true;
+ }
+ function releaseSnapshotScope(e) {
+-  e.He = false;
++  e.Me = false;
+   releaseSubtree(e);
+   schedule();
+ }
+ function releaseSubtree(e) {
+-  let t = e.Pe;
++  let t = e.ke;
+   while (t) {
+-    if (t.He) {
+-      t = t.ke;
++    if (t.Me) {
++      t = t.je;
+       continue;
+     }
+     if (t.I) {
+       const e = t;
+-      e.de &= ~h;
++      e.he &= ~g;
+       if (e.m & l) {
+         e.m &= ~l;
+         e.m |= n;
+-        if (W.N > e.o) W.N = e.o;
+-        insertIntoHeap(e, W);
++        if (A.j > e.o) A.j = e.o;
++        insertIntoHeap(e, A);
+       }
+     }
+     releaseSubtree(t);
+-    t = t.ke;
++    t = t.je;
+   }
+ }
+ function clearSnapshots() {
+-  if ($) {
+-    for (const e of $) {
+-      delete e.ye;
+-      delete e[P];
++  if (re) {
++    for (const e of re) {
++      delete e.Se;
++      delete e[N];
+     }
+-    $ = null;
++    re = null;
+   }
+-  Z = false;
++  ne = false;
+ }
+ function recompute(t, n = false) {
+-  const i = t.F;
++  const i = t.G;
+   if (!n) {
+-    if (t.X && (!i || L) && L !== t.X) q.initTransition(t.X);
+-    deleteFromHeap(t, t.m & o ? R : W);
+-    t.Ce = null;
+-    if (t.X || i === O) disposeChildren(t);
+-    else {
++    if (t.$ && (!i || T) && T !== t.$) V.initTransition(t.$);
++    deleteFromHeap(t, t.m & o ? L : A);
++    t.Re = null;
++    if (t.$ || i === P) disposeChildren(t);
++    else if (t.ke !== null || t.Le !== null) {
+       markDisposal(t);
+-      t.Ne = t.We;
+-      t.Ee = t.Pe;
+-      t.We = null;
+-      t.Pe = null;
+-      t.je = 0;
+-    }
++      t._e = t.Le;
++      t.me = t.ke;
++      t.Le = null;
++      t.ke = null;
++      t.We = 0;
++    } else;
+   }
+   let s = !!(t.m & f);
+-  const u = t.H !== undefined && t.H !== v;
+-  const c = !!(t.ge & S);
+-  const a = !!(t.ge & m);
+-  const d = X;
+-  X = t;
+-  t.xe = null;
++  const u = t.M !== undefined && t.M !== x;
++  const c = !!(t.we & m);
++  const a = !!(t.we & b);
++  const d = ee;
++  ee = t;
++  t.Ee = null;
+   t.m = r;
+-  t.he = A;
+-  let p = t.T === v ? t.ne : t.T;
++  t.ye = I;
++  let p = t.F === x ? t.re : t.F;
+   let h = t.o;
+-  let y = B;
+-  let g = Y;
+-  B = true;
++  let g = z;
++  let y = te;
++  z = true;
+   if (s) {
+     const e = resolveLane(t);
+-    if (e) Y = e;
+-  } else if (L && !n && L.Y.length) {
+-    for (let e = t.W; e; e = e.R) {
++    if (e) te = e;
++  } else if (T && !n && T.H.length) {
++    for (let e = t.R; e; e = e.W) {
+       const n = e.A;
+       if (n.m & f) {
+         const e = resolveLane(n);
+         if (e) {
+           s = true;
+-          Y = e;
++          te = e;
+           t.m |= f;
+           assignOrMergeLane(t, e);
+           break;
+@@ -1283,76 +1370,95 @@ function recompute(t, n = false) {
+       }
+     }
+   }
++  const S = i && i !== v;
++  const O = U;
++  if (S) U = true;
+   try {
+-    const e = t.Ce;
+-    const r = t.I(p);
+-    p = t.Ce !== e ? r : handleAsync(t, r);
++    if (!false && t.he & w) {
++      p = t.I(p);
++      t.Re = null;
++    } else {
++      const e = t.Re;
++      const n = t.I(p);
++      const r = typeof n === "object" && n !== null;
++      const i = t.Re !== e;
++      p = i || !r ? n : handleAsync(t, n);
++      if (!i && !r) t.Re = null;
++    }
+     clearStatus(t, n);
+-    const i = resolveLane(t);
+-    if (i) {
+-      i.V.delete(t);
+-      updatePendingSignal(i.re);
++    if (t.ne) {
++      const e = resolveLane(t);
++      if (e) {
++        e.B.delete(t);
++        updatePendingSignal(e.ie);
++      }
+     }
+   } catch (e) {
+-    if (e instanceof NotReadyError && Y) {
+-      const e = findLane(Y);
+-      if (e.re !== t) {
+-        e.V.add(t);
+-        t.te = e;
+-        updatePendingSignal(e.re);
++    if (e instanceof NotReadyError && te) {
++      const e = findLane(te);
++      if (e.ie !== t) {
++        e.B.add(t);
++        t.ne = e;
++        updatePendingSignal(e.ie);
+       }
+     }
+-    if (e instanceof NotReadyError) t.Ae = true;
++    if (e instanceof NotReadyError) t.Te = true;
+     notifyStatus(
+       t,
+-      e instanceof NotReadyError ? S : w,
++      e instanceof NotReadyError ? m : _,
+       e,
+       undefined,
+-      e instanceof NotReadyError ? t.te : undefined
++      e instanceof NotReadyError ? t.ne : undefined
+     );
+   } finally {
+-    B = y;
++    z = g;
++    if (S) U = O;
+     t.m = e | (n ? t.m & l : 0);
+-    X = d;
++    ee = d;
+   }
+-  if (!t.pe) {
+-    const e = t.xe;
+-    let r = e !== null ? e.R : t.W;
++  if (!t.ge) {
++    const e = t.Ee;
++    let r = e !== null ? e.W : t.R;
+     if (r !== null) {
+       do {
+         r = unlinkSubs(r);
+       } while (r !== null);
+-      if (e !== null) e.R = null;
+-      else t.W = null;
++      if (e !== null) e.W = null;
++      else t.R = null;
++    }
++    const f = u ? t.M : t.F === x ? t.re : t.F;
++    const l = (!i && a) || !t.He || !t.He(f, p);
++    if (i && l) {
++      t.U = !t.ge;
++      if (!n) t.J.enqueue(i, GlobalQueue.ae.bind(null, t));
+     }
+-    const f = u ? t.H : t.T === v ? t.ne : t.T;
+-    const l = (!i && a) || !t.Le || !t.Le(f, p);
+     if (l) {
+-      const e = u ? t.H : undefined;
+-      if (n || (i && L !== t.X) || s) {
+-        t.ne = p;
++      const e = u ? t.M : undefined;
++      if (n || (i && T !== t.$) || s) {
++        t.re = p;
+         if (u && s) {
+-          t.H = p;
+-          t.T = p;
++          t.M = p;
++          t.F = p;
+         }
+-      } else t.T = p;
+-      if (u && !s && c && !t._e) t.H = p;
+-      if (!u || s || t.H !== e) insertSubs(t, s || u);
++      } else t.F = p;
++      if (u && !s && c && !t.xe) t.M = p;
++      if (!u || s || t.M !== e) insertSubs(t, s || u);
+     } else if (u) {
+-      t.T = p;
++      t.F = p;
+     } else if (t.o != h) {
+       for (let e = t.O; e !== null; e = e.P) {
+-        insertIntoHeapHeight(e.k, e.k.m & o ? R : W);
++        insertIntoHeapHeight(e.C, e.C.m & o ? L : A);
+       }
+     }
+   }
+-  Y = g;
+-  (!n || t.ge & S) && !t.X && !(L && u) && q.ue.push(t);
+-  t.X && i && L !== t.X && runInTransition(t.X, () => recompute(t));
++  te = y;
++  const C = t.F !== x || t.me !== null || t._e !== null || !!(t.we & (m | b));
++  C && (!n || t.we & m) && !t.$ && !(T && u) && queuePendingNode(t);
++  t.$ && i && T !== t.$ && runInTransition(t.$, () => recompute(t));
+ }
+ function updateIfNecessary(e) {
+   if (e.m & t) {
+-    for (let t = e.W; t; t = t.R) {
++    for (let t = e.R; t; t = t.W) {
+       const r = t.A;
+       const i = r.L || r;
+       if (i.I) {
+@@ -1363,7 +1469,7 @@ function updateIfNecessary(e) {
+       }
+     }
+   }
+-  if (e.m & (n | f) || (e.pe && e.he < A && !e.Ce)) {
++  if (e.m & (n | f) || (e.ge && e.ye < I && !e.Re)) {
+     recompute(e);
+   }
+   e.m = e.m & (l | i | s);
+@@ -1371,167 +1477,227 @@ function updateIfNecessary(e) {
+ function computed(t, n) {
+   const r = n?.transparent ?? false;
+   const i = {
+-    id: n?.id ?? (r ? X?.id : X?.id != null ? getNextChildId(X) : undefined),
+-    de:
+-      (r ? p : 0) |
+-      (n?.ownedWrite ? a : 0) |
+-      (!X || n?.lazy ? g : 0) |
+-      (Z && ownerInSnapshotScope(X) ? h : 0),
+-    Le: n?.equals != null ? n.equals : isEqual,
+-    q: n?.unobserved,
+-    We: null,
+-    K: X?.K ?? q,
+-    Re: X?.Re ?? C,
+-    je: 0,
++    id: n?.id ?? (r ? ee?.id : ee?.id != null ? getNextChildId(ee) : undefined),
++    he:
++      (r ? h : 0) |
++      (n?.ownedWrite ? d : 0) |
++      (!ee || n?.lazy ? S : 0) |
++      (n?.sync ? w : 0) |
++      (ne && ownerInSnapshotScope(ee) ? g : 0),
++    He: n?.equals != null ? n.equals : isEqual,
++    V: n?.unobserved,
++    Le: null,
++    J: ee?.J ?? V,
++    Ie: ee?.Ie ?? k,
++    We: 0,
+     I: t,
+-    ne: undefined,
++    re: undefined,
+     o: 0,
+-    C: null,
++    N: null,
+     h: undefined,
+     p: null,
+-    W: null,
+-    xe: null,
++    R: null,
++    Ee: null,
+     O: null,
+-    ve: null,
+-    i: X,
++    Ne: null,
++    i: ee,
++    je: null,
++    Ae: null,
+     ke: null,
+-    Pe: null,
+     m: n?.lazy ? c : e,
+-    ge: m,
+-    he: A,
+-    T: v,
+-    Ne: null,
++    we: b,
++    ye: I,
++    F: x,
++    _e: null,
++    me: null,
++    Re: null,
++    $: null
++  };
++  setupComputedNode(i, n);
++  return i;
++}
++function createEffectNode(e, t, n, r, i, s) {
++  const o = s?.transparent ?? false;
++  const u = {
++    id: s?.id ?? (o ? ee?.id : ee?.id != null ? getNextChildId(ee) : undefined),
++    he:
++      (o ? h : 0) |
++      (s?.ownedWrite ? d : 0) |
++      (s?.sync ? w : 0) |
++      (ne && ownerInSnapshotScope(ee) ? g : 0),
++    He: false,
++    V: s?.unobserved,
++    Le: null,
++    J: ee?.J ?? V,
++    Ie: ee?.Ie ?? k,
++    We: 0,
++    I: e,
++    re: undefined,
++    o: 0,
++    N: null,
++    h: undefined,
++    p: null,
++    R: null,
+     Ee: null,
+-    Ce: null,
+-    X: null
++    O: null,
++    Ne: null,
++    i: ee,
++    je: null,
++    Ae: null,
++    ke: null,
++    m: c,
++    we: b,
++    ye: I,
++    F: x,
++    _e: null,
++    me: null,
++    Re: null,
++    $: null,
++    U: false,
++    Ve: undefined,
++    De: t,
++    Be: n,
++    Ke: undefined,
++    Ge: false,
++    G: r,
++    Fe: i
+   };
+-  i.p = i;
+-  const s = X?.t ? X.u : X;
+-  if (X) {
+-    const e = X.Pe;
+-    if (e === null) {
+-      X.Pe = i;
++  setupComputedNode(u, ie);
++  return u;
++}
++const ie = { lazy: true };
++function setupComputedNode(e, t) {
++  e.p = e;
++  const n = ee?.t ? ee.u : ee;
++  if (ee) {
++    const t = ee.ke;
++    if (t === null) {
++      ee.ke = e;
+     } else {
+-      i.ke = e;
+-      X.Pe = i;
++      e.je = t;
++      t.Ae = e;
++      ee.ke = e;
+     }
+   }
+-  if (s) i.o = s.o + 1;
+-  if (F) {
+-    const e = signal(undefined, { equals: false, ownedWrite: true });
+-    const t = F.factory(i.I, () => {
+-      setSignal(e, undefined);
++  if (n) e.o = n.o + 1;
++  if (G) {
++    const t = signal(undefined, { equals: false, ownedWrite: true });
++    const n = G.factory(e.I, () => {
++      setSignal(t, undefined);
+     });
+-    cleanup(() => t.dispose());
+-    i.I = n => {
+-      read(e);
+-      return t.track(n);
++    cleanup(() => n.dispose());
++    e.I = e => {
++      read(t);
++      return n.track(e);
+     };
+   }
+-  !n?.lazy && recompute(i, true);
+-  if (Z && !n?.lazy) {
+-    if (!(i.ge & S)) {
+-      i.ye = i.ne === undefined ? x : i.ne;
+-      $.add(i);
++  !t?.lazy && recompute(e, true);
++  if (ne && !t?.lazy) {
++    if (!(e.we & m)) {
++      e.Se = e.re === undefined ? C : e.re;
++      re.add(e);
+     }
+   }
+-  return i;
+ }
+ function signal(e, t, n = null) {
+   const r = {
+-    Le: t?.equals != null ? t.equals : isEqual,
+-    de: (t?.ownedWrite ? a : 0) | (t?.Qe ? d : 0),
+-    q: t?.unobserved,
+-    ne: e,
++    He: t?.equals != null ? t.equals : isEqual,
++    he: (t?.ownedWrite ? d : 0) | (t?.ze ? p : 0),
++    V: t?.unobserved,
++    re: e,
+     O: null,
+-    ve: null,
+-    he: A,
++    Ne: null,
++    ye: I,
+     L: n,
+-    j: n?.C || null,
+-    T: v
++    k: n?.N || null,
++    F: x
+   };
+-  n && (n.C = r);
+-  if (Z && !(r.de & d) && !((n?.ge ?? 0) & S)) {
+-    r.ye = e === undefined ? x : e;
+-    $.add(r);
++  n && (n.N = r);
++  if (ne && !(r.he & p) && !((n?.we ?? 0) & m)) {
++    r.Se = e === undefined ? C : e;
++    re.add(r);
+   }
+   return r;
+ }
+ function optimisticSignal(e, t) {
+   const n = signal(e, t);
+-  n.H = v;
++  n.M = x;
+   return n;
+ }
+ function optimisticComputed(e, t) {
+   const n = computed(e, t);
+-  n.H = v;
++  n.M = x;
+   return n;
+ }
+ function isEqual(e, t) {
+   return e === t;
+ }
+ function untrack(e, t) {
+-  if (!F && !B && true) return e();
+-  const n = B;
+-  B = false;
++  if (!G && !z && true) return e();
++  const n = z;
++  z = false;
+   try {
+-    if (F) return F.untrack(e);
++    if (G) return G.untrack(e);
+     return e();
+   } finally {
+-    B = n;
++    z = n;
+   }
+ }
+ function read(e) {
+-  if (J) {
++  if ($) {
+     const t = getLatestValueComputed(e);
+-    const n = J;
+-    J = false;
+-    const r = e.H !== undefined && e.H !== v ? e.H : e.ne;
++    const n = $;
++    $ = false;
++    const r = e.M !== undefined && e.M !== x ? e.M : e.re;
+     let i;
+     try {
+       i = read(t);
+     } catch (e) {
+-      if (!X && e instanceof NotReadyError) return r;
++      if (!ee && e instanceof NotReadyError) return r;
+       throw e;
+     } finally {
+-      J = n;
++      $ = n;
+     }
+-    if (t.ge & S) return r;
+-    if (K && Y && t.te) {
+-      const e = findLane(t.te);
+-      const n = findLane(Y);
+-      if (e !== n && e.V.size > 0) {
++    if (t.we & m) return r;
++    if (U && te && t.ne) {
++      const e = findLane(t.ne);
++      const n = findLane(te);
++      if (e !== n && e.B.size > 0) {
+         return r;
+       }
+     }
+     return i;
+   }
+-  if (z) {
++  if (Y) {
+     const t = e.L;
+-    const n = z;
+-    z = false;
+-    if (t && e.H !== undefined) {
+-      if (e.H !== v && (t.Ce || !!(t.ge & S))) {
+-        U = true;
++    const n = Y;
++    Y = false;
++    if (t && e.M !== undefined) {
++      if (e.M !== x && (t.Re || !!(t.we & m))) {
++        Z = true;
+       }
+-      let n = X;
++      let n = ee;
+       if (n?.t) n = n.u;
+-      if (n && B) link(e, n);
++      if (n && z) link(e, n);
+       read(getPendingSignal(e));
+       read(getPendingSignal(t));
+     } else {
+-      if (read(getPendingSignal(e))) U = true;
+-      if (t && read(getPendingSignal(t))) U = true;
++      if (read(getPendingSignal(e))) Z = true;
++      if (t && read(getPendingSignal(t))) Z = true;
+     }
+-    z = n;
+-    return e.ne;
++    Y = n;
++    return e.re;
+   }
+-  let t = X;
++  let t = ee;
+   if (t?.t) t = t.u;
+   const n = e;
+   if (typeof n.I === "function") {
+     const t = e;
+-    if (G && !(t.m & u)) recompute(t);
++    if (X && !(t.m & u)) {
++      X = false;
++      recompute(t);
++      X = true;
++    }
+     if (t.m & c) {
+       t.m &= ~c;
+       recompute(t, true);
+@@ -1540,13 +1706,26 @@ function read(e) {
+     }
+   }
+   const r = e.L || e;
+-  if (t && B) {
++  if (
++    !n.I &&
++    r === e &&
++    e.M === undefined &&
++    e.Se === undefined &&
++    T === null &&
++    te === null &&
++    !ne &&
++    true
++  ) {
++    if (t && z) link(e, t);
++    return !t || e.F === x ? e.re : e.F;
++  }
++  if (t && z) {
+     link(e, t);
+     if (r.I) {
+       const n = e.m & o;
+-      if (r.o >= (n ? R.N : W.N)) {
++      if (r.o >= (n ? L.j : A.j)) {
+         markNode(t);
+-        markHeap(n ? R : W);
++        markHeap(n ? L : A);
+         updateIfNecessary(r);
+       }
+       const i = r.o;
+@@ -1555,68 +1734,68 @@ function read(e) {
+       }
+     }
+   }
+-  if (r.ge & S) {
+-    if (t && !(K && r.X && L !== r.X)) {
+-      if (Y) {
+-        const n = r.te;
+-        const i = findLane(Y);
++  if (r.we & m) {
++    if (t && !(U && r.$ && T !== r.$)) {
++      if (te) {
++        const n = r.ne;
++        const i = findLane(te);
+         if (n && findLane(n) === i && !hasActiveOverride(r)) {
+-          if (!B && e !== t) link(e, t);
+-          throw r.pe;
++          if (!z && e !== t) link(e, t);
++          throw r.ge;
+         }
+       } else {
+-        if (!B && e !== t) link(e, t);
+-        throw r.pe;
++        if (!z && e !== t) link(e, t);
++        throw r.ge;
+       }
+-    } else if (t && r !== e && r.ge & m) {
+-      if (!B && e !== t) link(e, t);
+-      throw r.pe;
+-    } else if (!t && r.ge & m) {
+-      throw r.pe;
++    } else if (t && r !== e && r.we & b) {
++      if (!z && e !== t) link(e, t);
++      throw r.ge;
++    } else if (!t && r.we & b) {
++      throw r.ge;
+     }
+   }
+-  if (e.I && e.ge & w) {
+-    if (e.he < A) {
++  if (e.I && e.we & _) {
++    if (e.ye < I) {
+       recompute(e);
+       return read(e);
+-    } else throw e.pe;
++    } else throw e.ge;
+   }
+-  if (Z && t && t.de & h) {
+-    const n = e.ye;
++  if (ne && t && t.he & g) {
++    const n = e.Se;
+     if (n !== undefined) {
+-      const r = n === x ? undefined : n;
+-      const i = e.T !== v ? e.T : e.ne;
++      const r = n === C ? undefined : n;
++      const i = e.F !== x ? e.F : e.re;
+       if (i !== r) t.m |= l;
+       return r;
+     }
+   }
+-  if (e.H !== undefined && e.H !== v) {
+-    if (t && K && shouldReadStashedOptimisticValue(e)) return e.ne;
+-    return e.H;
++  if (e.M !== undefined && e.M !== x) {
++    if (t && U && shouldReadStashedOptimisticValue(e)) return e.re;
++    return e.M;
+   }
+-  if (L !== null && Y !== null && !J && e.T !== v && r === e && !e.I && t) {
+-    L.ee.add(t);
+-    return e.ne;
++  if (T !== null && te !== null && !$ && e.F !== x && r === e && !e.I && t) {
++    T.te.add(t);
++    return e.re;
+   }
+   const i =
+     !t ||
+-    (Y !== null && (e.H !== undefined || e.te || (r === e && K) || !!(r.ge & S))) ||
+-    e.T === v ||
+-    (K && e.X && L !== e.X)
+-      ? e.ne
+-      : e.T;
+-  if (!t && r === e && typeof n.I === "function" && e.de & g && !(r.ge & S) && !e.O) {
++    (te !== null && (e.M !== undefined || e.ne || (r === e && U) || !!(r.we & m))) ||
++    e.F === x ||
++    (U && e.$ && T !== e.$)
++      ? e.re
++      : e.F;
++  if (!t && r === e && typeof n.I === "function" && e.he & S && !(r.we & m) && !e.O) {
+     unobserved(e);
+   }
+   return i;
+ }
+ function setSignal(e, t) {
+-  if (e.X && L !== e.X) q.initTransition(e.X);
+-  const n = e.H !== undefined && !T;
+-  const r = e.H !== undefined && e.H !== v;
+-  const i = n ? (r ? e.H : e.ne) : e.T === v ? e.ne : e.T;
++  if (e.$ && T !== e.$) V.initTransition(e.$);
++  const n = e.M !== undefined && !Q;
++  const r = e.M !== undefined && e.M !== x;
++  const i = n ? (r ? e.M : e.re) : e.F === x ? e.re : e.F;
+   if (typeof t === "function") t = t(i);
+-  const s = !e.Le || !e.Le(i, t) || !!(e.ge & m);
++  const s = !e.He || !e.He(i, t) || !!(e.we & b);
+   if (!s) {
+     if (n && r && e.I) {
+       insertSubs(e, true);
+@@ -1625,156 +1804,170 @@ function setSignal(e, t) {
+     return t;
+   }
+   if (n) {
+-    const n = e.H === v;
+-    if (!n) q.initTransition(resolveTransition(e));
++    const n = e.M === x;
++    if (!n) V.initTransition(resolveTransition(e));
+     if (n) {
+-      e.T = e.ne;
+-      q.Y.push(e);
++      e.F = e.re;
++      V.H.push(e);
+     }
+-    e._e = true;
++    e.xe = true;
+     const r = getOrCreateLane(e);
+-    e.te = r;
+-    e.H = t;
++    e.ne = r;
++    e.M = t;
+   } else {
+-    if (e.T === v) q.ue.push(e);
+-    e.T = t;
++    if (e.F === x) queuePendingNode(e);
++    e.F = t;
+   }
+-  updatePendingSignal(e);
+-  if (e.Ie) {
+-    setSignal(e.Ie, t);
++  if (e.Qe) updatePendingSignal(e);
++  if (e.qe) {
++    setSignal(e.qe, t);
+   }
+-  e.he = A;
++  e.ye = I;
+   insertSubs(e, n);
+   schedule();
+   return t;
+ }
++function suppressComputedRecompute(e) {
++  deleteFromHeap(e, e.m & o ? L : A);
++  if (!(e.m & a) && e.F === x) queuePendingNode(e);
++  e.m = (e.m & -4) | a;
++}
++function setMemo(e, t) {
++  const n = setSignal(e, t);
++  suppressComputedRecompute(e);
++  return n;
++}
+ function runWithOwner(e, t) {
+-  const n = X;
+-  const r = B;
+-  X = e;
+-  B = false;
++  const n = ee;
++  const r = z;
++  ee = e;
++  z = false;
+   try {
+     return t();
+   } finally {
+-    X = n;
+-    B = r;
++    ee = n;
++    z = r;
+   }
+ }
+ function getPendingSignal(e) {
+-  if (!e.qe) {
+-    e.qe = optimisticSignal(false, { ownedWrite: true });
+-    if (e.me) {
+-      e.qe.me = e;
++  if (!e.Qe) {
++    e.Qe = optimisticSignal(false, { ownedWrite: true });
++    if (e.ve) {
++      e.Qe.ve = e;
+     }
+-    if (computePendingState(e)) setSignal(e.qe, true);
++    if (computePendingState(e)) setSignal(e.Qe, true);
+   }
+-  return e.qe;
++  return e.Qe;
+ }
+ function computePendingState(e) {
+   const t = e;
+   const n = e.L;
+-  if (n && e.T !== v) {
+-    return !n.Ce && !(n.ge & S);
++  if (n && e.F !== x) {
++    return !n.Re && !(n.we & m);
+   }
+-  if (e.H !== undefined && e.H !== v) {
+-    if (t.ge & S && !(t.ge & m)) return true;
+-    if (e.me) {
+-      const t = e.te ? findLane(e.te) : null;
+-      return !!(t && t.V.size > 0);
++  if (e.M !== undefined && e.M !== x) {
++    if (t.we & m && !(t.we & b)) return true;
++    if (e.ve) {
++      const t = e.ne ? findLane(e.ne) : null;
++      return !!(t && t.B.size > 0);
+     }
+     return true;
+   }
+-  if (e.H !== undefined && e.H === v && !e.me) {
++  if (e.M !== undefined && e.M === x && !e.ve) {
+     return false;
+   }
+-  if (e.T !== v && !(t.ge & m)) return true;
+-  return !!(t.ge & S && !(t.ge & m));
++  if (e.F !== x && !(t.we & b)) return true;
++  return !!(t.we & m && !(t.we & b));
+ }
+ function updatePendingSignal(e) {
+-  if (e.qe) {
++  if (e.Qe) {
+     const t = computePendingState(e);
+-    const n = e.qe;
++    const n = e.Qe;
+     setSignal(n, t);
+-    if (!t && n.te) {
++    if (!t && n.ne) {
+       const t = resolveLane(e);
+-      if (t && t.V.size > 0) {
+-        const e = findLane(n.te);
++      if (t && t.B.size > 0) {
++        const e = findLane(n.ne);
+         if (e !== t) {
+           mergeLanes(t, e);
+         }
+       }
+-      M.delete(n);
+-      n.te = undefined;
++      D.delete(n);
++      n.ne = undefined;
+     }
+   }
+ }
+ function getLatestValueComputed(e) {
+-  if (!e.Ie) {
+-    const t = J;
+-    J = false;
+-    const n = z;
+-    z = false;
+-    const r = X;
+-    X = null;
+-    e.Ie = optimisticComputed(() => read(e));
+-    e.Ie.me = e;
+-    X = r;
+-    z = n;
+-    J = t;
++  if (!e.qe) {
++    const t = $;
++    $ = false;
++    const n = Y;
++    Y = false;
++    const r = ee;
++    ee = null;
++    e.qe = optimisticComputed(() => read(e));
++    e.qe.ve = e;
++    ee = r;
++    Y = n;
++    $ = t;
+   }
+-  return e.Ie;
++  return e.qe;
+ }
+ function staleValues(e, t = true) {
+-  const n = K;
+-  K = t;
++  const n = U;
++  U = t;
+   try {
+     return e();
+   } finally {
+-    K = n;
++    U = n;
+   }
+ }
+ function latest(e) {
+-  const t = J;
+-  J = true;
++  const t = $;
++  $ = true;
+   try {
+     return e();
+   } finally {
+-    J = t;
++    $ = t;
+   }
+ }
+ function isPending(e) {
+-  const t = z;
+-  const n = U;
+-  z = true;
+-  U = false;
++  const t = Y;
++  const n = Z;
++  Y = true;
++  Z = false;
+   try {
+     e();
+-    return U;
++    return Z;
+   } catch {
+-    return U;
++    return Z;
+   } finally {
+-    z = t;
+-    U = n;
++    Y = t;
++    Z = n;
+   }
+ }
+ function refresh(e) {
+-  let t = G;
+-  G = true;
++  let t = J;
++  let n = X;
++  J = true;
++  X = true;
+   try {
+     if (typeof e !== "function") {
+-      recompute(e[E]);
++      X = false;
++      recompute(e[j]);
+       return e;
+     }
+     return untrack(e);
+   } finally {
+-    G = t;
++    J = t;
++    X = n;
+     if (!t) {
+       schedule();
+     }
+   }
+ }
+ function isRefreshing() {
+-  return G;
++  return J;
+ }
+ function createContext(e, t) {
+   return { id: Symbol(t), defaultValue: e };
+@@ -1783,7 +1976,7 @@ function getContext(e, t = getOwner()) {
+   if (!t) {
+     throw new NoOwnerError();
+   }
+-  const n = hasContext(e, t) ? t.Re[e.id] : e.defaultValue;
++  const n = hasContext(e, t) ? t.Ie[e.id] : e.defaultValue;
+   if (isUndefined(n)) {
+     throw new ContextNotFoundError();
+   }
+@@ -1793,113 +1986,102 @@ function setContext(e, t, n = getOwner()) {
+   if (!n) {
+     throw new NoOwnerError();
+   }
+-  n.Re = { ...n.Re, [e.id]: isUndefined(t) ? e.defaultValue : t };
++  n.Ie = { ...n.Ie, [e.id]: isUndefined(t) ? e.defaultValue : t };
+ }
+ function hasContext(e, t) {
+-  return !isUndefined(t?.Re[e.id]);
++  return !isUndefined(t?.Ie[e.id]);
+ }
+ function isUndefined(e) {
+   return typeof e === "undefined";
+ }
+ function effect(e, t, n, r) {
+-  let i = false;
+-  const s = !!r?.user;
+-  const o = computed(s ? e : t => staleValues(() => e(t)), {
+-    ...r,
+-    equals: () => {
+-      o.B = !o.pe;
+-      if (i) o.K.enqueue(o.F, runEffect.bind(o));
+-      return false;
+-    },
+-    lazy: true
+-  });
+-  o.de &= ~g;
+-  o.Me = undefined;
+-  o.Ve = t;
+-  o.De = n;
+-  o.Fe = undefined;
+-  o.F = s ? _ : b;
+-  o.Te = (e, t) => {
+-    const n = e !== undefined ? e : o.ge;
+-    const r = t !== undefined ? t : o.pe;
+-    if (n & w) {
+-      let e = r;
+-      o.K.notify(o, S, 0);
+-      if (o.F === _) {
+-        try {
+-          return o.De
+-            ? o.De(e, () => {
+-                o.Fe?.();
+-                o.Fe = undefined;
+-              })
+-            : console.error(e);
+-        } catch (t) {
+-          e = t;
+-        }
++  const i = !!r?.user;
++  const s = createEffectNode(e, t, n, i ? v : O, notifyEffectStatus, r);
++  recompute(s, true);
++  !r?.defer &&
++    (s.G === v || r?.schedule ? s.J.enqueue(s.G, runEffect.bind(null, s)) : runEffect(s));
++}
++function notifyEffectStatus(e, t) {
++  const n = e !== undefined ? e : this.we;
++  const r = t !== undefined ? t : this.ge;
++  if (n & _) {
++    let e = r;
++    this.J.notify(this, m, 0);
++    if (this.G === v) {
++      try {
++        return this.Be
++          ? this.Be(e, () => {
++              this.Ke?.();
++              this.Ke = undefined;
++            })
++          : console.error(e);
++      } catch (t) {
++        e = t;
+       }
+-      if (!o.K.notify(o, w, w)) throw e;
+-    } else if (o.F === b) {
+-      o.K.notify(o, S | w, n, r);
+     }
+-  };
+-  recompute(o, true);
+-  !r?.defer && (o.F === _ || r?.schedule ? o.K.enqueue(o.F, runEffect.bind(o)) : runEffect.call(o));
+-  i = true;
+-  cleanup(() => o.Fe?.());
+-}
+-function runEffect() {
+-  if (!this.B || this.m & u) return;
+-  this.Fe?.();
+-  this.Fe = undefined;
++    if (!this.J.notify(this, _, _)) throw e;
++  } else if (this.G === O) {
++    this.J.notify(this, m | _, n, r);
++  }
++}
++function runEffect(e) {
++  if (!e.U || e.m & u) return;
++  e.Ke?.();
++  e.Ke = undefined;
+   try {
+-    const e = this.Ve(this.ne, this.Me);
+-    if (false && e !== undefined && typeof e !== "function");
+-    this.Fe = e;
+-  } catch (e) {
+-    this.pe = new StatusError(this, e);
+-    this.ge |= w;
+-    if (!this.K.notify(this, w, w)) throw e;
++    const t = e.De(e.re, e.Ve);
++    if (false && t !== undefined && typeof t !== "function");
++    e.Ke = t;
++    if (e.Ke && !e.Ge) {
++      e.Ge = true;
++      runWithOwner(e.i, () => cleanup(() => e.Ke?.()));
++    }
++  } catch (t) {
++    e.ge = new StatusError(e, t);
++    e.we |= _;
++    if (!e.J.notify(e, _, _)) throw t;
+   } finally {
+-    this.Me = this.ne;
+-    this.B = false;
++    e.Ve = e.re;
++    e.U = false;
+   }
+ }
++GlobalQueue.ae = runEffect;
+ function trackedEffect(e, t) {
+   const run = () => {
+-    if (!n.B || n.m & u) return;
++    if (!n.U || n.m & u) return;
+     try {
+-      n.B = false;
++      n.U = false;
+       recompute(n);
+     } finally {
+     }
+   };
+   const n = computed(
+     () => {
+-      n.Fe?.();
+-      n.Fe = undefined;
++      n.Ke?.();
++      n.Ke = undefined;
+       const t = staleValues(e);
+-      n.Fe = t;
++      n.Ke = t;
+     },
+     { ...t, lazy: true }
+   );
+-  n.Fe = undefined;
+-  n.de = (n.de & ~g) | y;
+-  n.B = true;
+-  n.F = O;
+-  n.Te = (e, t) => {
+-    const r = e !== undefined ? e : n.ge;
+-    if (r & w) {
+-      n.K.notify(n, S, 0);
+-      const e = t !== undefined ? t : n.pe;
+-      if (!n.K.notify(n, w, w)) throw e;
++  n.Ke = undefined;
++  n.he = (n.he & ~S) | y;
++  n.U = true;
++  n.G = P;
++  n.Fe = (e, t) => {
++    const r = e !== undefined ? e : n.we;
++    if (r & _) {
++      n.J.notify(n, m, 0);
++      const e = t !== undefined ? t : n.ge;
++      if (!n.J.notify(n, _, _)) throw e;
+     }
+   };
+-  n.G = run;
+-  n.K.enqueue(_, run);
+-  cleanup(() => n.Fe?.());
++  n.X = run;
++  n.J.enqueue(v, run);
++  cleanup(() => n.Ke?.());
+ }
+ function restoreTransition(e, t) {
+-  q.initTransition(e);
++  V.initTransition(e);
+   const n = t();
+   flush();
+   return n;
+@@ -1908,13 +2090,13 @@ function action(e) {
+   return (...t) =>
+     new Promise((n, r) => {
+       const i = e(...t);
+-      q.initTransition();
+-      let s = L;
+-      s.J.push(i);
++      V.initTransition();
++      let s = T;
++      s.Z.push(i);
+       const done = (e, t) => {
+         s = currentTransition(s);
+-        const o = s.J.indexOf(i);
+-        if (o >= 0) s.J.splice(o, 1);
++        const o = s.Z.indexOf(i);
++        if (o >= 0) s.Z.splice(o, 1);
+         setActiveTransition(s);
+         schedule();
+         t ? r(t) : n(e);
+@@ -1951,8 +2133,8 @@ function accessor(e) {
+ function createSignal(e, t) {
+   if (typeof e === "function") {
+     const n = computed(e, t);
+-    n.de &= ~g;
+-    return [accessor(n), setSignal.bind(null, n)];
++    n.he &= ~S;
++    return [accessor(n), setMemo.bind(null, n)];
+   }
+   const n = signal(e, t);
+   return [accessor(n), setSignal.bind(null, n)];
+@@ -2008,7 +2190,7 @@ function resolve(e) {
+ function createOptimistic(e, t) {
+   if (typeof e === "function") {
+     const n = optimisticComputed(e, t);
+-    n.de &= ~g;
++    n.he &= ~S;
+     return [accessor(n), setSignal.bind(null, n)];
+   }
+   const n = optimisticSignal(e, t);
+@@ -2016,15 +2198,15 @@ function createOptimistic(e, t) {
+ }
+ function onSettled(e) {
+   const t = getOwner();
+-  t && !(t.de & y)
++  t && !(t.he & y)
+     ? createTrackedEffect(() => untrack(e), undefined)
+-    : q.enqueue(_, () => {
++    : V.enqueue(v, () => {
+         const t = e();
+         t?.();
+       });
+ }
+ function unwrap(e) {
+-  return e?.[te]?.[ue] ?? e;
++  return e?.[oe]?.[de] ?? e;
+ }
+ function getOverrideValue(e, t, n, r, i) {
+   if (i && r in i) return i[r];
+@@ -2036,21 +2218,21 @@ function getAllKeys(e, t, n) {
+   return Array.from(new Set([...r, ...i]));
+ }
+ function applyState(e, t, n) {
+-  const r = t?.[te];
++  const r = t?.[oe];
+   if (!r) return;
+-  const i = r[ie];
+-  const s = r[se];
+-  const o = r[oe];
+-  let u = r[ue];
++  const i = r[le];
++  const s = r[ce];
++  const o = r[ae];
++  let u = r[de];
+   if (e === i && !s && !o) return;
+-  (r[ae] || he).set(e, r[ne]);
+-  r[ie] = e;
+-  r[se] = undefined;
++  (r[ye] || me).set(e, r[ue]);
++  r[le] = e;
++  r[ce] = undefined;
+   if (Array.isArray(i)) {
+     let t = false;
+     const f = getOverrideValue(i, s, u, "length", o);
+     if (e.length && f && e[0] && n(e[0]) != null) {
+-      let l, c, a, d, p, h, y, g;
++      let l, c, a, d, p, h, g, y;
+       for (
+         a = 0, d = Math.min(f, e.length);
+         a < d &&
+@@ -2073,59 +2255,59 @@ function applyState(e, t, n) {
+       if (a > p || a > d) {
+         for (c = a; c <= p; c++) {
+           t = true;
+-          r[ue][c] && setSignal(r[ue][c], wrap(e[c], r));
++          r[de][c] && setSignal(r[de][c], wrap(e[c], r));
+         }
+         for (; c < e.length; c++) {
+           t = true;
+           const i = wrap(S[c], r);
+-          r[ue][c] && setSignal(r[ue][c], i);
++          r[de][c] && setSignal(r[de][c], i);
+           applyState(e[c], i, n);
+         }
+-        t && r[ue][ee] && setSignal(r[ue][ee], void 0);
+-        f !== e.length && r[ue].length && setSignal(r[ue].length, e.length);
++        t && r[de][se] && setSignal(r[de][se], void 0);
++        f !== e.length && r[de].length && setSignal(r[de].length, e.length);
+         return;
+       }
+-      y = new Array(p + 1);
++      g = new Array(p + 1);
+       for (c = p; c >= a; c--) {
+         h = e[c];
+-        g = h ? n(h) : h;
+-        l = w.get(g);
+-        y[c] = l === undefined ? -1 : l;
+-        w.set(g, c);
++        y = h ? n(h) : h;
++        l = w.get(y);
++        g[c] = l === undefined ? -1 : l;
++        w.set(y, c);
+       }
+       for (l = a; l <= d; l++) {
+         h = getOverrideValue(i, s, u, l, o);
+-        g = h ? n(h) : h;
+-        c = w.get(g);
++        y = h ? n(h) : h;
++        c = w.get(y);
+         if (c !== undefined && c !== -1) {
+           S[c] = h;
+-          c = y[c];
+-          w.set(g, c);
++          c = g[c];
++          w.set(y, c);
+         }
+       }
+       for (c = a; c < e.length; c++) {
+         if (c in S) {
+           const t = wrap(S[c], r);
+-          r[ue][c] && setSignal(r[ue][c], t);
++          r[de][c] && setSignal(r[de][c], t);
+           applyState(e[c], t, n);
+-        } else r[ue][c] && setSignal(r[ue][c], wrap(e[c], r));
++        } else r[de][c] && setSignal(r[de][c], wrap(e[c], r));
+       }
+       if (a < e.length) t = true;
+     } else if (e.length) {
+       for (let t = 0, f = e.length; t < f; t++) {
+         const f = getOverrideValue(i, s, u, t, o);
+-        isWrappable(f) ? applyState(e[t], wrap(f, r), n) : r[ue][t] && setSignal(r[ue][t], e[t]);
++        isWrappable(f) ? applyState(e[t], wrap(f, r), n) : r[de][t] && setSignal(r[de][t], e[t]);
+       }
+     }
+     if (f !== e.length) {
+       t = true;
+-      r[ue].length && setSignal(r[ue].length, e.length);
++      r[de].length && setSignal(r[de].length, e.length);
+     }
+-    t && r[ue][ee] && setSignal(r[ue][ee], void 0);
++    t && r[de][se] && setSignal(r[de][se], void 0);
+     return;
+   }
+   if (u) {
+-    const t = u[ee];
++    const t = u[se];
+     const f = t ? getAllKeys(i, s, e) : Object.keys(u);
+     for (let l = 0, c = f.length; l < c; l++) {
+       const c = f[l];
+@@ -2139,7 +2321,7 @@ function applyState(e, t, n) {
+       } else applyState(p, wrap(d, r), n);
+     }
+   }
+-  if ((u = r[fe])) {
++  if ((u = r[pe])) {
+     const t = Object.keys(u);
+     for (let n = 0, r = t.length; n < r; n++) {
+       const r = t[n];
+@@ -2161,9 +2343,9 @@ function createProjectionInternal(e, t, n) {
+   let r;
+   const i = new WeakMap();
+   const wrapper = e => {
+-    e[ce] = wrapProjection;
+-    e[ae] = i;
+-    Object.defineProperty(e, de, {
++    e[ge] = wrapProjection;
++    e[ye] = i;
++    Object.defineProperty(e, Se, {
+       get() {
+         return r;
+       },
+@@ -2172,8 +2354,8 @@ function createProjectionInternal(e, t, n) {
+   };
+   const wrapProjection = e => {
+     if (i.has(e)) return i.get(e);
+-    if (e[te]?.[ce] === wrapProjection) return e;
+-    const t = createStoreProxy(e, Se, wrapper);
++    if (e[oe]?.[ge] === wrapProjection) return e;
++    const t = createStoreProxy(e, Oe, wrapper);
+     i.set(e, t);
+     return t;
+   };
+@@ -2182,7 +2364,7 @@ function createProjectionInternal(e, t, n) {
+     if (!r) r = getOwner();
+     runProjectionComputed(s, e, n?.key || "id");
+   }, undefined);
+-  r.de &= ~g;
++  r.he &= ~S;
+   return { store: s, node: r };
+ }
+ function createProjection(e, t, n) {
+@@ -2194,7 +2376,7 @@ function runProjectionComputed(e, t, n, r) {
+   let o;
+   const u = new Proxy(
+     e,
+-    createWriteTraps(() => !s || i.Ce === o)
++    createWriteTraps(() => !s || i.Re === o)
+   );
+   storeSetter(u, u => {
+     o = t(u);
+@@ -2261,35 +2443,35 @@ function createWriteTraps(e) {
+   };
+   return t;
+ }
+-const ee = Symbol(0),
+-  te = Symbol(0),
+-  ne = Symbol(0),
+-  re = Symbol(0);
+-const ie = "v",
+-  se = "o",
+-  oe = "x",
+-  ue = "n",
+-  fe = "h",
+-  le = "c",
+-  ce = "w",
+-  ae = "l",
+-  de = "f",
+-  pe = "p";
+-function createStoreProxy(e, t = Se, n) {
++const se = Symbol(0),
++  oe = Symbol(0),
++  ue = Symbol(0),
++  fe = Symbol(0);
++const le = "v",
++  ce = "o",
++  ae = "x",
++  de = "n",
++  pe = "h",
++  he = "c",
++  ge = "w",
++  ye = "l",
++  Se = "f",
++  we = "p";
++function createStoreProxy(e, t = Oe, n) {
+   let r;
+   if (Array.isArray(e)) {
+     r = [];
+     r.v = e;
+   } else r = { v: e };
+-  r[le] = hasCustomPrototype(unwrapStoreValue(e));
++  r[he] = hasCustomPrototype(unwrapStoreValue(e));
+   n && n(r);
+-  return (r[ne] = new Proxy(r, t));
++  return (r[ue] = new Proxy(r, t));
+ }
+-const he = new WeakMap();
++const me = new WeakMap();
+ function wrap(e, t) {
+-  if (t?.[ce]) return t[ce](e, t);
+-  let n = e[ne] || he.get(e);
+-  if (!n) he.set(e, (n = createStoreProxy(e)));
++  if (t?.[ge]) return t[ge](e, t);
++  let n = e[ue] || me.get(e);
++  if (!n) me.set(e, (n = createStoreProxy(e)));
+   return n;
+ }
+ function isWrappable(e) {
+@@ -2300,15 +2482,15 @@ function isWrappable(e) {
+     !(typeof Node !== "undefined" && e instanceof Node)
+   );
+ }
+-let ye = false;
++let _e = false;
+ function setWriteOverride(e) {
+-  ye = e;
++  _e = e;
+ }
+ function writeOnly(e) {
+-  return ye || !!ge?.has(e);
++  return _e || !!be?.has(e);
+ }
+ function unwrapStoreValue(e) {
+-  return e?.[te]?.[ie] ?? e;
++  return e?.[oe]?.[le] ?? e;
+ }
+ function hasCustomPrototype(e) {
+   if (Array.isArray(e)) return false;
+@@ -2342,17 +2524,17 @@ function getNode(e, t, n, r, i = isEqual, s, o) {
+     r
+   );
+   if (s) {
+-    u.H = v;
++    u.M = x;
+   }
+   if (o && t in o) {
+     const e = o[t];
+-    u.ye = e === undefined ? x : e;
+-    $?.add(u);
++    u.Se = e === undefined ? C : e;
++    re?.add(u);
+   }
+   return (e[t] = u);
+ }
+-function trackSelf(e, t = ee) {
+-  getObserver() && read(getNode(getNodes(e, ue), t, undefined, e[de], false, e[pe]));
++function trackSelf(e, t = se) {
++  getObserver() && read(getNode(getNodes(e, de), t, undefined, e[Se], false, e[we]));
+ }
+ function getKeys(e, t, n = true) {
+   const r = untrack(() => (n ? Object.keys(e) : Reflect.ownKeys(e)));
+@@ -2360,65 +2542,65 @@ function getKeys(e, t, n = true) {
+   const i = new Set(r);
+   const s = Reflect.ownKeys(t);
+   for (const e of s) {
+-    if (t[e] !== re) i.add(e);
++    if (t[e] !== fe) i.add(e);
+     else i.delete(e);
+   }
+   return Array.from(i);
+ }
+ function getPropertyDescriptor(e, t, n) {
+   if (t && n in t) {
+-    if (t[n] === re) return void 0;
++    if (t[n] === fe) return void 0;
+     const r = Reflect.getOwnPropertyDescriptor(t, n);
+     if (r?.get || r?.set || !(n in e)) return r;
+   }
+   return Reflect.getOwnPropertyDescriptor(e, n);
+ }
+ function prepareStoreWrite(e, t, n) {
+-  if (e[pe]) {
+-    const t = e[de];
+-    if (t?.X) {
+-      q.initTransition(t.X);
++  if (e[we]) {
++    const t = e[Se];
++    if (t?.$) {
++      V.initTransition(t.$);
+     }
+   }
+-  const r = e[ie];
++  const r = e[le];
+   const i = r[n];
+-  if (Z && typeof n !== "symbol" && !((e[de]?.ge ?? 0) & S)) {
+-    if (!e[P]) {
+-      e[P] = Object.create(null);
+-      $?.add(e);
++  if (ne && typeof n !== "symbol" && !((e[Se]?.we ?? 0) & m)) {
++    if (!e[N]) {
++      e[N] = Object.create(null);
++      re?.add(e);
+     }
+-    if (!(n in e[P])) {
+-      e[P][n] = i;
++    if (!(n in e[N])) {
++      e[N][n] = i;
+     }
+   }
+-  const s = e[pe] && !T;
+-  const o = s ? oe : se;
++  const s = e[we] && !Q;
++  const o = s ? ae : ce;
+   if (s) trackOptimisticStore(t);
+   return { base: i, overrideKey: o, state: r };
+ }
+ function upsertStoreNode(e, t, n, r, i) {
+   if (t[n]) return t[n];
+   const s = isWrappable(r) ? wrap(r, e) : r;
+-  const o = getNode(t, n, s, e[de], isEqual, e[pe], i);
++  const o = getNode(t, n, s, e[Se], isEqual, e[we], i);
+   registerTransientStoreNode(o);
+   return o;
+ }
+ function notifyStoreProperty(e, t, n, r, i, s) {
+-  const o = T || e[pe];
++  const o = Q || e[we];
+   const u = n !== "delete";
+-  const f = e[fe]?.[t];
++  const f = e[pe]?.[t];
+   if (f) {
+     setSignal(f, u);
+   } else if (!o && n !== "invalidate" && s !== u) {
+-    const n = upsertStoreNode(e, getNodes(e, fe), t, s);
++    const n = upsertStoreNode(e, getNodes(e, pe), t, s);
+     setSignal(n, u);
+   }
+-  const l = getNodes(e, ue);
++  const l = getNodes(e, de);
+   if (n === "set") {
+     if (l[t]) {
+       setSignal(l[t], () => (isWrappable(r) ? wrap(r, e) : r));
+     } else if (!o) {
+-      const n = upsertStoreNode(e, l, t, i, e[P]);
++      const n = upsertStoreNode(e, l, t, i, e[N]);
+       setSignal(n, () => (isWrappable(r) ? wrap(r, e) : r));
+     }
+   } else if (n === "invalidate") {
+@@ -2430,94 +2612,109 @@ function notifyStoreProperty(e, t, n, r, i, s) {
+     if (l[t]) {
+       setSignal(l[t], undefined);
+     } else if (!o) {
+-      const n = upsertStoreNode(e, l, t, i, e[P]);
++      const n = upsertStoreNode(e, l, t, i, e[N]);
+       setSignal(n, undefined);
+     }
+   }
+-  l[ee] && setSignal(l[ee], undefined);
++  l[se] && setSignal(l[se], undefined);
+ }
+-let ge = null;
+-const Se = {
++let be = null;
++const Oe = {
+   get(e, t, n) {
+-    if (t === te) return e;
+-    if (t === ne) return n;
+-    if (t === E) return e[de];
+-    if (t === ee) {
++    if (t === oe) return e;
++    if (t === ue) return n;
++    if (t === j) return e[Se];
++    if (t === se) {
+       trackSelf(e);
+       return n;
+     }
+-    const r = getNodes(e, ue);
++    const r = getNodes(e, de);
+     const i = r[t];
+-    const s = e[oe] && t in e[oe];
+-    const o = s || (e[se] && t in e[se]);
+-    const u = !!e[ie][te];
+-    const f = s ? e[oe] : e[se] && t in e[se] ? e[se] : e[ie];
++    const s = e[le];
++    if (
++      !i &&
++      !e[ce] &&
++      !e[ae] &&
++      !e[he] &&
++      !e[we] &&
++      !e[N] &&
++      !s[oe] &&
++      !(t in s) &&
++      getObserver() &&
++      !writeOnly(n)
++    ) {
++      return read(getNode(r, t, undefined, e[Se]));
++    }
++    const o = e[ae] && t in e[ae];
++    const u = o || (e[ce] && t in e[ce]);
++    const f = !!e[le][oe];
++    const l = o ? e[ae] : e[ce] && t in e[ce] ? e[ce] : e[le];
+     if (!i) {
+-      const r = Object.getOwnPropertyDescriptor(f, t);
++      const r = Object.getOwnPropertyDescriptor(l, t);
+       if (r && r.get) return r.get.call(n);
+-      if (!r && !o && e[le]) {
+-        const e = unwrapStoreValue(f);
++      if (!r && !u && e[he]) {
++        const e = unwrapStoreValue(l);
+         if (hasInheritedAccessor(e, t)) {
+-          return Reflect.get(f, t, n);
++          return Reflect.get(l, t, n);
+         }
+       }
+     }
+     if (writeOnly(n)) {
+       let n =
+-        i && (o || !u) ? (i.H !== undefined && i.H !== v ? i.H : i.T !== v ? i.T : i.ne) : f[t];
+-      n === re && (n = undefined);
++        i && (u || !f) ? (i.M !== undefined && i.M !== x ? i.M : i.F !== x ? i.F : i.re) : l[t];
++      n === fe && (n = undefined);
+       if (!isWrappable(n)) return n;
+       const r = wrap(n, e);
+-      ge?.add(r);
++      be?.add(r);
+       return r;
+     }
+-    let l = i ? (o || !u ? read(r[t]) : (read(r[t]), f[t])) : f[t];
+-    l === re && (l = undefined);
++    let c = i ? (u || !f ? read(r[t]) : (read(r[t]), l[t])) : l[t];
++    c === fe && (c = undefined);
+     if (!i) {
+-      if (!o && typeof l === "function" && !f.hasOwnProperty(t)) {
++      if (!u && typeof c === "function" && !l.hasOwnProperty(t)) {
+         let t;
+-        return !Array.isArray(e[ie]) && (t = Object.getPrototypeOf(e[ie])) && t !== Object.prototype
+-          ? l.bind(f)
+-          : l;
++        return !Array.isArray(e[le]) && (t = Object.getPrototypeOf(e[le])) && t !== Object.prototype
++          ? c.bind(l)
++          : c;
+       } else if (getObserver()) {
+-        return read(getNode(r, t, isWrappable(l) ? wrap(l, e) : l, e[de], isEqual, e[pe], e[P]));
++        return read(getNode(r, t, isWrappable(c) ? wrap(c, e) : c, e[Se], isEqual, e[we], e[N]));
+       }
+     }
+-    return isWrappable(l) ? wrap(l, e) : l;
++    return isWrappable(c) ? wrap(c, e) : c;
+   },
+   has(e, t) {
+-    if (t === ne || t === ee || t === "__proto__") return true;
++    if (t === ue || t === se || t === "__proto__") return true;
+     const n =
+-      e[oe] && t in e[oe] ? e[oe][t] !== re : e[se] && t in e[se] ? e[se][t] !== re : t in e[ie];
+-    if (writeOnly(e[ne])) return n;
+-    const r = getNodes(e, fe);
++      e[ae] && t in e[ae] ? e[ae][t] !== fe : e[ce] && t in e[ce] ? e[ce][t] !== fe : t in e[le];
++    if (writeOnly(e[ue])) return n;
++    const r = getNodes(e, pe);
+     if (r[t]) return read(r[t]);
+     if (getObserver()) {
+-      return read(getNode(r, t, n, e[de], isEqual, e[pe]));
++      return read(getNode(r, t, n, e[Se], isEqual, e[we]));
+     }
+     return n;
+   },
+   set(e, t, n) {
+-    const r = e[ne];
++    const r = e[ue];
+     if (writeOnly(r)) {
+       untrack(() => {
+         const { base: i, overrideKey: s, state: o } = prepareStoreWrite(e, r, t);
+-        const u = e[oe] && t in e[oe] ? e[oe][t] : e[se] && t in e[se] ? e[se][t] : i;
++        const u = e[ae] && t in e[ae] ? e[ae][t] : e[ce] && t in e[ce] ? e[ce][t] : i;
+         const f =
+-          e[oe] && t in e[oe]
+-            ? e[oe][t] !== re
+-            : e[se] && t in e[se]
+-              ? e[se][t] !== re
+-              : t in e[ie];
++          e[ae] && t in e[ae]
++            ? e[ae][t] !== fe
++            : e[ce] && t in e[ce]
++              ? e[ce][t] !== fe
++              : t in e[le];
+         const l = unwrapStoreValue(n);
+         const c = Array.isArray(o) && t !== "length";
+         const a = c ? parseInt(t) + 1 : 0;
+         const d =
+           c &&
+-          (e[oe] && "length" in e[oe]
+-            ? e[oe].length
+-            : e[se] && "length" in e[se]
+-              ? e[se].length
++          (e[ae] && "length" in e[ae]
++            ? e[ae].length
++            : e[ce] && "length" in e[ce]
++              ? e[ce].length
+               : o.length);
+         const p = c && a > d ? a : undefined;
+         if (u === l && p === undefined) return true;
+@@ -2529,11 +2726,11 @@ const Se = {
+         }
+         notifyStoreProperty(e, t, "set", l, u, f);
+         if (Array.isArray(o) && t !== "length" && p !== undefined) {
+-          const t = getNodes(e, ue);
++          const t = getNodes(e, de);
+           if (t.length) {
+             setSignal(t.length, p);
+-          } else if (!T && !e[pe]) {
+-            const n = upsertStoreNode(e, t, "length", d, e[P]);
++          } else if (!Q && !e[we]) {
++            const n = upsertStoreNode(e, t, "length", d, e[N]);
+             setSignal(n, p);
+           }
+         }
+@@ -2543,7 +2740,7 @@ const Se = {
+     return true;
+   },
+   defineProperty(e, t, n) {
+-    const r = e[ne];
++    const r = e[ue];
+     if (writeOnly(r)) {
+       untrack(() => {
+         const { base: i, overrideKey: s } = prepareStoreWrite(e, r, t);
+@@ -2556,16 +2753,16 @@ const Se = {
+     return true;
+   },
+   deleteProperty(e, t) {
+-    const n = e[oe]?.[t] === re;
+-    const r = e[se]?.[t] === re;
+-    if (writeOnly(e[ne]) && !n && !r) {
++    const n = e[ae]?.[t] === fe;
++    const r = e[ce]?.[t] === fe;
++    if (writeOnly(e[ue]) && !n && !r) {
+       untrack(() => {
+-        const n = e[pe] && !T;
+-        const r = n ? oe : se;
+-        if (n) trackOptimisticStore(e[ne]);
+-        const i = e[oe] && t in e[oe] ? e[oe][t] : e[se] && t in e[se] ? e[se][t] : e[ie][t];
+-        if (t in e[ie] || (e[se] && t in e[se])) {
+-          (e[r] || (e[r] = Object.create(null)))[t] = re;
++        const n = e[we] && !Q;
++        const r = n ? ae : ce;
++        if (n) trackOptimisticStore(e[ue]);
++        const i = e[ae] && t in e[ae] ? e[ae][t] : e[ce] && t in e[ce] ? e[ce][t] : e[le][t];
++        if (t in e[le] || (e[ce] && t in e[ce])) {
++          (e[r] || (e[r] = Object.create(null)))[t] = fe;
+         } else if (e[r] && t in e[r]) {
+           delete e[r][t];
+         } else return true;
+@@ -2576,11 +2773,11 @@ const Se = {
+   },
+   ownKeys(e) {
+     trackSelf(e);
+-    let t = getKeys(e[ie], e[se], false);
+-    if (e[oe]) {
++    let t = getKeys(e[le], e[ce], false);
++    if (e[ae]) {
+       const n = new Set(t);
+-      for (const t of Reflect.ownKeys(e[oe])) {
+-        if (e[oe][t] !== re) n.add(t);
++      for (const t of Reflect.ownKeys(e[ae])) {
++        if (e[ae][t] !== fe) n.add(t);
+         else n.delete(t);
+       }
+       t = Array.from(n);
+@@ -2588,27 +2785,27 @@ const Se = {
+     return t;
+   },
+   getOwnPropertyDescriptor(e, t) {
+-    if (t === ne) return { value: e[ne], writable: true, configurable: true };
+-    if (e[oe] && t in e[oe]) {
+-      if (e[oe][t] === re) return undefined;
+-      const n = Reflect.getOwnPropertyDescriptor(e[oe], t);
+-      if (n?.get || n?.set || !(t in e[ie])) return n;
+-      const r = getPropertyDescriptor(e[ie], e[se], t);
++    if (t === ue) return { value: e[ue], writable: true, configurable: true };
++    if (e[ae] && t in e[ae]) {
++      if (e[ae][t] === fe) return undefined;
++      const n = Reflect.getOwnPropertyDescriptor(e[ae], t);
++      if (n?.get || n?.set || !(t in e[le])) return n;
++      const r = getPropertyDescriptor(e[le], e[ce], t);
+       if (r) {
+-        return { ...r, value: e[oe][t] };
++        return { ...r, value: e[ae][t] };
+       }
+-      return { value: e[oe][t], writable: true, enumerable: true, configurable: true };
++      return { value: e[ae][t], writable: true, enumerable: true, configurable: true };
+     }
+-    return getPropertyDescriptor(e[ie], e[se], t);
++    return getPropertyDescriptor(e[le], e[ce], t);
+   },
+   getPrototypeOf(e) {
+-    return Object.getPrototypeOf(e[ie]);
++    return Object.getPrototypeOf(e[le]);
+   }
+ };
+ function storeSetter(e, t) {
+-  const n = ge;
+-  ge = new Set();
+-  ge.add(e);
++  const n = be;
++  be = new Set();
++  be.add(e);
+   try {
+     const n = t(e);
+     if (n !== e && n !== undefined) {
+@@ -2624,17 +2821,20 @@ function storeSetter(e, t) {
+       }
+     }
+   } finally {
+-    ge.clear();
+-    ge = n;
++    be.clear();
++    be = n;
+   }
+ }
+ function createStore(e, t, n) {
+   const r = typeof e === "function",
+     i = r ? createProjectionInternal(e, t, n).store : wrap(e);
+-  return [i, e => storeSetter(i, e)];
++  return [
++    i,
++    r ? e => (storeSetter(i, e), suppressComputedRecompute(i[j])) : e => storeSetter(i, e)
++  ];
+ }
+ function createOptimisticStore(e, t, n) {
+-  GlobalQueue.ce ||= clearOptimisticStore;
++  GlobalQueue.de ||= clearOptimisticStore;
+   const r = typeof e === "function";
+   const i = r ? t : e;
+   const s = r ? e : undefined;
+@@ -2642,39 +2842,39 @@ function createOptimisticStore(e, t, n) {
+   return [o, e => storeSetter(o, e)];
+ }
+ function clearOptimisticStore(e) {
+-  const t = e[te];
+-  if (!t || !t[oe]) return;
+-  const n = t[oe];
+-  const r = t[ue];
++  const t = e[oe];
++  if (!t || !t[ae]) return;
++  const n = t[ae];
++  const r = t[de];
+   setProjectionWriteActive(true);
+   try {
+     if (r) {
+       for (const e of Reflect.ownKeys(n)) {
+         if (r[e]) {
+-          r[e].te = undefined;
+-          const n = t[se] && e in t[se] ? t[se][e] : t[ie][e];
+-          const i = n === re ? undefined : n;
++          r[e].ne = undefined;
++          const n = t[ce] && e in t[ce] ? t[ce][e] : t[le][e];
++          const i = n === fe ? undefined : n;
+           setSignal(r[e], isWrappable(i) ? wrap(i, t) : i);
+         }
+       }
+-      if (r[ee]) {
+-        r[ee].te = undefined;
+-        setSignal(r[ee], undefined);
++      if (r[se]) {
++        r[se].ne = undefined;
++        setSignal(r[se], undefined);
+       }
+     }
+   } finally {
+     setProjectionWriteActive(false);
+   }
+-  delete t[oe];
++  delete t[ae];
+ }
+ function createOptimisticProjectionInternal(e, t, n) {
+   let r;
+   const i = new WeakMap();
+   const wrapper = e => {
+-    e[ce] = wrapProjection;
+-    e[ae] = i;
+-    e[pe] = true;
+-    Object.defineProperty(e, de, {
++    e[ge] = wrapProjection;
++    e[ye] = i;
++    e[we] = true;
++    Object.defineProperty(e, Se, {
+       get() {
+         return r;
+       },
+@@ -2683,8 +2883,8 @@ function createOptimisticProjectionInternal(e, t, n) {
+   };
+   const wrapProjection = e => {
+     if (i.has(e)) return i.get(e);
+-    if (e[te]?.[ce] === wrapProjection) return e;
+-    const t = createStoreProxy(e, Se, wrapper);
++    if (e[oe]?.[ge] === wrapProjection) return e;
++    const t = createStoreProxy(e, Oe, wrapper);
+     i.set(e, t);
+     return t;
+   };
+@@ -2706,11 +2906,11 @@ function createOptimisticProjectionInternal(e, t, n) {
+         setProjectionWriteActive(false);
+       }
+     }, undefined);
+-    r.de &= ~g;
++    r.he &= ~S;
+   }
+   return { store: s, node: r };
+ }
+-const we = Symbol(0);
++const ve = Symbol(0);
+ function isPrototypePollutionKey(e) {
+   return e === "__proto__" || e === "constructor" || e === "prototype";
+ }
+@@ -2758,7 +2958,7 @@ function updatePath(e, t, n = 0) {
+     if (s === i) return;
+   }
+   if (r === undefined && s == undefined) return;
+-  if (s === we) {
++  if (s === ve) {
+     delete e[r];
+   } else if (r === undefined || (isWrappable(i) && isWrappable(s) && !Array.isArray(s))) {
+     const t = r !== undefined ? e[r] : e;
+@@ -2774,26 +2974,26 @@ function updatePath(e, t, n = 0) {
+     e[r] = s;
+   }
+ }
+-const me = Object.assign(
++const Pe = Object.assign(
+   function storePath(...e) {
+     return t => {
+       updatePath(t, e);
+     };
+   },
+-  { DELETE: we }
++  { DELETE: ve }
+ );
+ function snapshotImpl(e, t, n, r) {
+   let i, s, o, u, f, l;
+   if (!isWrappable(e)) return e;
+   if (n && n.has(e)) return n.get(e);
+   if (!n) n = new Map();
+-  if ((i = e[te] || r?.get(e)?.[te])) {
+-    if (t) trackSelf(i, ee);
+-    o = i[se];
+-    s = Array.isArray(i[ie]);
+-    n.set(e, o ? (u = s ? [] : Object.create(Object.getPrototypeOf(i[ie]))) : i[ie]);
+-    e = i[ie];
+-    r = he;
++  if ((i = e[oe] || r?.get(e)?.[oe])) {
++    if (t) trackSelf(i, se);
++    o = i[ce];
++    s = Array.isArray(i[le]);
++    n.set(e, o ? (u = s ? [] : Object.create(Object.getPrototypeOf(i[le]))) : i[le]);
++    e = i[le];
++    r = me;
+   } else {
+     s = Array.isArray(e);
+     n.set(e, e);
+@@ -2802,7 +3002,7 @@ function snapshotImpl(e, t, n, r) {
+     const s = o?.length || e.length;
+     for (let c = 0; c < s; c++) {
+       l = o && c in o ? o[c] : e[c];
+-      if (l === re) continue;
++      if (l === fe) continue;
+       if (t && isWrappable(l)) wrap(l, i);
+       if ((f = snapshotImpl(l, t, n, r)) !== l || u) {
+         if (!u) n.set(e, (u = [...e]));
+@@ -2837,13 +3037,13 @@ function deep(e) {
+ function trueFn() {
+   return true;
+ }
+-const be = {
++const xe = {
+   get(e, t, n) {
+-    if (t === ne) return n;
++    if (t === ue) return n;
+     return e.get(t);
+   },
+   has(e, t) {
+-    if (t === ne) return true;
++    if (t === ue) return true;
+     return e.has(t);
+   },
+   set: trueFn,
+@@ -2866,23 +3066,24 @@ const be = {
+ function resolveSource(e) {
+   return !(e = typeof e === "function" ? e() : e) ? {} : e;
+ }
+-const _e = Symbol(0);
++const Ce = Symbol(0);
+ function merge(...e) {
+   if (e.length === 1 && typeof e[0] !== "function") return e[0];
+   let t = false;
+   const n = [];
+   for (let r = 0; r < e.length; r++) {
+     const i = e[r];
+-    t = t || (!!i && ne in i);
+-    const s = !!i && i[_e];
+-    if (s) n.push(...s);
+-    else n.push(typeof i === "function" ? ((t = true), createMemo(i)) : i);
++    t = t || (!!i && ue in i);
++    const s = !!i && i[Ce];
++    if (s) {
++      for (let e = 0; e < s.length; e++) n.push(s[e]);
++    } else n.push(typeof i === "function" ? ((t = true), createMemo(i)) : i);
+   }
+-  if (k && t) {
++  if (E && t) {
+     return new Proxy(
+       {
+         get(e) {
+-          if (e === _e) return n;
++          if (e === Ce) return n;
+           for (let t = n.length - 1; t >= 0; t--) {
+             const r = resolveSource(n[t]);
+             if (e in r) return r[e];
+@@ -2895,12 +3096,15 @@ function merge(...e) {
+           return false;
+         },
+         keys() {
+-          const e = [];
+-          for (let t = 0; t < n.length; t++) e.push(...Object.keys(resolveSource(n[t])));
+-          return [...new Set(e)];
++          const e = new Set();
++          for (let t = 0; t < n.length; t++) {
++            const r = Object.keys(resolveSource(n[t]));
++            for (let t = 0; t < r.length; t++) e.add(r[t]);
++          }
++          return [...e];
+         }
+       },
+-      be
++      xe
+     );
+   }
+   const r = Object.create(null);
+@@ -2932,105 +3136,106 @@ function merge(...e) {
+     if (n.get) Object.defineProperty(o, t, n);
+     else o[t] = n.value;
+   }
+-  o[_e] = n;
++  o[Ce] = n;
+   return o;
+ }
+ function omit(e, ...t) {
+-  const n = new Set(t);
+-  if (k && ne in e) {
++  if (E && ue in e) {
+     return new Proxy(
+       {
+-        get(t) {
+-          return n.has(t) ? undefined : e[t];
++        get(n) {
++          return t.includes(n) ? undefined : e[n];
+         },
+-        has(t) {
+-          return !n.has(t) && t in e;
++        has(n) {
++          return !t.includes(n) && n in e;
+         },
+         keys() {
+-          return Object.keys(e).filter(e => !n.has(e));
++          return Object.keys(e).filter(e => !t.includes(e));
+         }
+       },
+-      be
++      xe
+     );
+   }
+-  const r = {};
+-  for (const t of Object.getOwnPropertyNames(e)) {
+-    if (!n.has(t)) {
+-      const n = Object.getOwnPropertyDescriptor(e, t);
+-      !n.get && !n.set && n.enumerable && n.writable && n.configurable
+-        ? (r[t] = n.value)
+-        : Object.defineProperty(r, t, n);
++  const n = {};
++  const r = Object.getOwnPropertyNames(e);
++  const i = t.length > 4 && r.length > t.length ? new Set(t) : undefined;
++  for (const s of r) {
++    if (i ? !i.has(s) : !t.includes(s)) {
++      const t = Object.getOwnPropertyDescriptor(e, s);
++      !t.get && !t.set && t.enumerable && t.writable && t.configurable
++        ? (n[s] = t.value)
++        : Object.defineProperty(n, s, t);
+     }
+   }
+-  return r;
++  return n;
+ }
+ function mapArray(e, t, n) {
+   const r = typeof n?.keyed === "function" ? n.keyed : undefined;
+   const i = t.length > 1;
+   const s = t;
+   const o = {
+-    Be: createOwner(),
+-    Ke: 0,
+-    Ge: e,
+-    ze: [],
+-    Ue: s,
+-    Je: [],
+-    Xe: [],
+-    Ye: r,
+-    Ze: r || n?.keyed === false ? [] : undefined,
+-    $e: i ? [] : undefined,
+-    et: n?.fallback
++    Ue: createOwner(),
++    Je: 0,
++    Xe: e,
++    Ye: [],
++    Ze: s,
++    $e: [],
++    et: [],
++    tt: r,
++    nt: r || n?.keyed === false ? [] : undefined,
++    rt: i ? [] : undefined,
++    it: n?.fallback
+   };
+   const u = computed(updateKeyedMap.bind(o));
+-  o.Be.u = u;
+-  u.de &= ~g;
++  o.Ue.u = u;
++  u.he &= ~S;
+   return accessor(u);
+ }
+-const Oe = { ownedWrite: true };
++const Ne = { ownedWrite: true };
+ function updateKeyedMap() {
+-  const e = this.Ge() || [],
++  const e = this.Xe() || [],
+     t = e.length;
+-  e[ee];
+-  runWithOwner(this.Be, () => {
++  e[se];
++  runWithOwner(this.Ue, () => {
+     let n,
+       r,
+-      i = this.Ze
++      i = this.nt
+         ? () => {
+-            this.Ze[r] = signal(e[r], Oe);
+-            this.$e && (this.$e[r] = signal(r, Oe));
+-            return this.Ue(accessor(this.Ze[r]), this.$e ? accessor(this.$e[r]) : undefined);
++            this.nt[r] = signal(e[r], Ne);
++            this.rt && (this.rt[r] = signal(r, Ne));
++            return this.Ze(accessor(this.nt[r]), this.rt ? accessor(this.rt[r]) : undefined);
+           }
+-        : this.$e
++        : this.rt
+           ? () => {
+               const t = e[r];
+-              this.$e[r] = signal(r, Oe);
+-              return this.Ue(() => t, accessor(this.$e[r]));
++              this.rt[r] = signal(r, Ne);
++              return this.Ze(() => t, accessor(this.rt[r]));
+             }
+           : () => {
+               const t = e[r];
+-              return this.Ue(() => t);
++              return this.Ze(() => t);
+             };
+     if (t === 0) {
+-      if (this.Ke !== 0) {
+-        this.Be.dispose(false);
+-        this.Xe = [];
+-        this.ze = [];
+-        this.Je = [];
+-        this.Ke = 0;
+-        this.Ze && (this.Ze = []);
+-        this.$e && (this.$e = []);
+-      }
+-      if (this.et && !this.Je[0]) {
+-        this.Je[0] = runWithOwner((this.Xe[0] = createOwner()), this.et);
+-      }
+-    } else if (this.Ke === 0) {
+-      if (this.Xe[0]) this.Xe[0].dispose();
+-      this.Je = new Array(t);
++      if (this.Je !== 0) {
++        this.Ue.dispose(false);
++        this.et = [];
++        this.Ye = [];
++        this.$e = [];
++        this.Je = 0;
++        this.nt && (this.nt = []);
++        this.rt && (this.rt = []);
++      }
++      if (this.it && !this.$e[0]) {
++        this.$e[0] = runWithOwner((this.et[0] = createOwner()), this.it);
++      }
++    } else if (this.Je === 0) {
++      if (this.et[0]) this.et[0].dispose();
++      this.$e = new Array(t);
+       for (r = 0; r < t; r++) {
+-        this.ze[r] = e[r];
+-        this.Je[r] = runWithOwner((this.Xe[r] = createOwner()), i);
++        this.Ye[r] = e[r];
++        this.$e[r] = runWithOwner((this.et[r] = createOwner()), i);
+       }
+-      this.Ke = t;
++      this.Je = t;
+     } else {
+       let s,
+         o,
+@@ -3041,216 +3246,216 @@ function updateKeyedMap() {
+         a,
+         d = new Array(t),
+         p = new Array(t),
+-        h = this.Ze ? new Array(t) : undefined,
+-        y = this.$e ? new Array(t) : undefined;
++        h = this.nt ? new Array(t) : undefined,
++        g = this.rt ? new Array(t) : undefined;
+       for (
+-        s = 0, o = Math.min(this.Ke, t);
+-        s < o && (this.ze[s] === e[s] || (this.Ze && compare(this.Ye, this.ze[s], e[s])));
++        s = 0, o = Math.min(this.Je, t);
++        s < o && (this.Ye[s] === e[s] || (this.nt && compare(this.tt, this.Ye[s], e[s])));
+         s++
+       ) {
+-        if (this.Ze) setSignal(this.Ze[s], e[s]);
++        if (this.nt) setSignal(this.nt[s], e[s]);
+       }
+       for (
+-        o = this.Ke - 1, u = t - 1;
++        o = this.Je - 1, u = t - 1;
+         o >= s &&
+         u >= s &&
+-        (this.ze[o] === e[u] || (this.Ze && compare(this.Ye, this.ze[o], e[u])));
++        (this.Ye[o] === e[u] || (this.nt && compare(this.tt, this.Ye[o], e[u])));
+         o--, u--
+       ) {
+-        d[u] = this.Je[o];
+-        p[u] = this.Xe[o];
+-        h && (h[u] = this.Ze[o]);
+-        y && (y[u] = this.$e[o]);
++        d[u] = this.$e[o];
++        p[u] = this.et[o];
++        h && (h[u] = this.nt[o]);
++        g && (g[u] = this.rt[o]);
+       }
+       c = new Map();
+       a = new Array(u + 1);
+       for (r = u; r >= s; r--) {
+         f = e[r];
+-        l = this.Ye ? this.Ye(f) : f;
++        l = this.tt ? this.tt(f) : f;
+         n = c.get(l);
+         a[r] = n === undefined ? -1 : n;
+         c.set(l, r);
+       }
+       for (n = s; n <= o; n++) {
+-        f = this.ze[n];
+-        l = this.Ye ? this.Ye(f) : f;
++        f = this.Ye[n];
++        l = this.tt ? this.tt(f) : f;
+         r = c.get(l);
+         if (r !== undefined && r !== -1) {
+-          d[r] = this.Je[n];
+-          p[r] = this.Xe[n];
+-          h && (h[r] = this.Ze[n]);
+-          y && (y[r] = this.$e[n]);
++          d[r] = this.$e[n];
++          p[r] = this.et[n];
++          h && (h[r] = this.nt[n]);
++          g && (g[r] = this.rt[n]);
+           r = a[r];
+           c.set(l, r);
+-        } else this.Xe[n].dispose();
++        } else this.et[n].dispose();
+       }
+       for (r = s; r < t; r++) {
+         if (r in d) {
+-          this.Je[r] = d[r];
+-          this.Xe[r] = p[r];
++          this.$e[r] = d[r];
++          this.et[r] = p[r];
+           if (h) {
+-            this.Ze[r] = h[r];
+-            setSignal(this.Ze[r], e[r]);
++            this.nt[r] = h[r];
++            setSignal(this.nt[r], e[r]);
+           }
+-          if (y) {
+-            this.$e[r] = y[r];
+-            setSignal(this.$e[r], r);
++          if (g) {
++            this.rt[r] = g[r];
++            setSignal(this.rt[r], r);
+           }
+         } else {
+-          this.Je[r] = runWithOwner((this.Xe[r] = createOwner()), i);
++          this.$e[r] = runWithOwner((this.et[r] = createOwner()), i);
+         }
+       }
+-      this.Je = this.Je.slice(0, (this.Ke = t));
+-      this.ze = e.slice(0);
++      this.$e = this.$e.slice(0, (this.Je = t));
++      this.Ye = e.slice(0);
+     }
+   });
+-  return this.Je;
++  return this.$e;
+ }
+ function repeat(e, t, n) {
+   const r = t;
+   const i = computed(
+     updateRepeat.bind({
+-      Be: createOwner(),
+-      Ke: 0,
+-      tt: 0,
+-      nt: e,
+-      Ue: r,
+-      Xe: [],
+-      Je: [],
+-      rt: n?.from,
+-      et: n?.fallback
++      Ue: createOwner(),
++      Je: 0,
++      st: 0,
++      ot: e,
++      Ze: r,
++      et: [],
++      $e: [],
++      ut: n?.from,
++      it: n?.fallback
+     })
+   );
+-  i.de &= ~g;
++  i.he &= ~S;
+   return accessor(i);
+ }
+ function updateRepeat() {
+-  const e = this.nt();
+-  const t = this.rt?.() || 0;
+-  runWithOwner(this.Be, () => {
++  const e = this.ot();
++  const t = this.ut?.() || 0;
++  runWithOwner(this.Ue, () => {
+     if (e === 0) {
+-      if (this.Ke !== 0) {
+-        this.Be.dispose(false);
+-        this.Xe = [];
+-        this.Je = [];
+-        this.Ke = 0;
++      if (this.Je !== 0) {
++        this.Ue.dispose(false);
++        this.et = [];
++        this.$e = [];
++        this.Je = 0;
+       }
+-      if (this.et && !this.Je[0]) {
+-        this.Je[0] = runWithOwner((this.Xe[0] = createOwner()), this.et);
++      if (this.it && !this.$e[0]) {
++        this.$e[0] = runWithOwner((this.et[0] = createOwner()), this.it);
+       }
+       return;
+     }
+     const n = t + e;
+-    const r = this.tt + this.Ke;
+-    if (this.Ke === 0 && this.Xe[0]) this.Xe[0].dispose();
+-    for (let e = n; e < r; e++) this.Xe[e - this.tt].dispose();
+-    if (this.tt < t) {
+-      let e = this.tt;
+-      while (e < t && e < this.Ke) this.Xe[e++].dispose();
+-      this.Xe.splice(0, t - this.tt);
+-      this.Je.splice(0, t - this.tt);
+-    } else if (this.tt > t) {
+-      let n = r - this.tt - 1;
+-      let i = this.tt - t;
+-      this.Xe.length = this.Je.length = e;
++    const r = this.st + this.Je;
++    if (this.Je === 0 && this.et[0]) this.et[0].dispose();
++    for (let e = n; e < r; e++) this.et[e - this.st].dispose();
++    if (this.st < t) {
++      let e = this.st;
++      while (e < t && e < this.Je) this.et[e++].dispose();
++      this.et.splice(0, t - this.st);
++      this.$e.splice(0, t - this.st);
++    } else if (this.st > t) {
++      let n = r - this.st - 1;
++      let i = this.st - t;
++      this.et.length = this.$e.length = e;
+       while (n >= i) {
+-        this.Xe[n] = this.Xe[n - i];
+-        this.Je[n] = this.Je[n - i];
++        this.et[n] = this.et[n - i];
++        this.$e[n] = this.$e[n - i];
+         n--;
+       }
+       for (let e = 0; e < i; e++) {
+-        this.Je[e] = runWithOwner((this.Xe[e] = createOwner()), () => this.Ue(e + t));
++        this.$e[e] = runWithOwner((this.et[e] = createOwner()), () => this.Ze(e + t));
+       }
+     }
+     for (let e = r; e < n; e++) {
+-      this.Je[e - t] = runWithOwner((this.Xe[e - t] = createOwner()), () => this.Ue(e));
++      this.$e[e - t] = runWithOwner((this.et[e - t] = createOwner()), () => this.Ze(e));
+     }
+-    this.Je = this.Je.slice(0, e);
+-    this.tt = t;
+-    this.Ke = e;
++    this.$e = this.$e.slice(0, e);
++    this.st = t;
++    this.Je = e;
+   });
+-  return this.Je;
++  return this.$e;
+ }
+ function compare(e, t, n) {
+   return e ? e(t) === e(n) : true;
+ }
+ function boundaryComputed(e, t) {
+   const n = computed(e, { lazy: true });
+-  n.Te = (e, t) => {
+-    const r = e !== undefined ? e : n.ge;
+-    const i = t !== undefined ? t : n.pe;
+-    n.ge &= ~n.it;
+-    n.K.notify(n, n.it, r, i);
++  n.Fe = (e, t) => {
++    const r = e !== undefined ? e : n.we;
++    const i = t !== undefined ? t : n.ge;
++    n.we &= ~n.ft;
++    n.J.notify(n, n.ft, r, i);
+   };
+-  n.it = t;
+-  n.de &= ~g;
++  n.ft = t;
++  n.he &= ~S;
+   recompute(n, true);
+   return n;
+ }
+ function createBoundChildren(e, t, n, r) {
+-  const i = e.K;
+-  i.addChild((e.K = n));
+-  cleanup(() => i.removeChild(e.K));
++  const i = e.J;
++  i.addChild((e.J = n));
++  cleanup(() => i.removeChild(e.J));
+   return runWithOwner(e, () => {
+     const e = computed(t);
+     return boundaryComputed(() => staleValues(() => flatten(read(e))), r);
+   });
+ }
+-const ve = Symbol();
+-const xe = createContext(null);
+-let Pe = false;
++const Ee = Symbol();
++const ke = createContext(null);
++let je = false;
+ const FALSE_ACCESSOR = () => false;
+ const SEQUENTIAL_ACCESSOR = () => "sequential";
+ function isRevealController(e) {
+   return e instanceof RevealController;
+ }
+ function isSlotReady(e) {
+-  return isRevealController(e) ? e.isReady() : e.st.size === 0 && !e.ot;
++  return isRevealController(e) ? e.isReady() : e.lt.size === 0 && !e.ct;
+ }
+ function isSlotMinimallyReady(e) {
+   return isRevealController(e) ? e.isMinimallyReady() : isSlotReady(e);
+ }
+ function setSlotState(e, t, n, r) {
+-  setSignal(e.ut, n);
+-  setSignal(e.ft, r);
++  setSignal(e.dt, n);
++  setSignal(e.ht, r);
+   if (isRevealController(e)) {
+-    if (!n && e.lt === t) e.lt = undefined;
++    if (!n && e.gt === t) e.gt = undefined;
+     return e.evaluate(n, r);
+   }
+-  if (!n && e.ct === t && e.dt) e.ct = undefined;
++  if (!n && e.yt === t && e.St) e.yt = undefined;
+ }
+ class RevealController {
+-  ht;
+-  yt;
+-  gt = [];
+-  lt;
+-  ut = signal(false, { ownedWrite: true, Qe: true });
+-  ft = signal(false, { ownedWrite: true, Qe: true });
+-  St = true;
+-  wt = true;
+-  bt = false;
++  wt;
++  _t;
++  bt = [];
++  gt;
++  dt = signal(false, { ownedWrite: true, ze: true });
++  ht = signal(false, { ownedWrite: true, ze: true });
++  Ot = true;
++  vt = true;
++  Pt = false;
+   constructor(e, t) {
+-    this.ht = e;
+-    this.yt = t;
++    this.wt = e;
++    this._t = t;
+   }
+-  _t(e) {
+-    for (let t = 0; t < this.gt.length; t++) {
+-      const n = this.gt[t];
+-      if ((isRevealController(n) ? n.lt : n.ct) !== this) continue;
++  xt(e) {
++    for (let t = 0; t < this.bt.length; t++) {
++      const n = this.bt[t];
++      if ((isRevealController(n) ? n.gt : n.yt) !== this) continue;
+       if (e(n) === false) return false;
+     }
+     return true;
+   }
+   isReady() {
+-    return this._t(isSlotReady);
++    return this.xt(isSlotReady);
+   }
+   isMinimallyReady() {
+-    const e = untrack(this.ht);
++    const e = untrack(this.wt);
+     if (e === "together") return this.isReady();
+     if (e === "natural") {
+       let e = false;
+       let t = false;
+-      this._t(n => {
++      this.xt(n => {
+         e = true;
+         if (isSlotMinimallyReady(n)) {
+           t = true;
+@@ -3260,58 +3465,58 @@ class RevealController {
+       return !e || t;
+     }
+     let t = true;
+-    this._t(e => {
++    this.xt(e => {
+       t = isSlotMinimallyReady(e);
+       return false;
+     });
+     return t;
+   }
+   register(e) {
+-    if (this.gt.includes(e)) return;
+-    this.gt.push(e);
+-    const t = untrack(this.ht);
+-    (setSignal(e.ut, true), setSignal(e.ft, t === "sequential" ? !!untrack(this.yt) : false));
++    if (this.bt.includes(e)) return;
++    this.bt.push(e);
++    const t = untrack(this.wt);
++    (setSignal(e.dt, true), setSignal(e.ht, t === "sequential" ? !!untrack(this._t) : false));
+     untrack(() => this.evaluate());
+   }
+   unregister(e) {
+-    const t = this.gt.indexOf(e);
+-    if (t >= 0) this.gt.splice(t, 1);
++    const t = this.bt.indexOf(e);
++    if (t >= 0) this.bt.splice(t, 1);
+     untrack(() => this.evaluate());
+   }
+   evaluate(e, t) {
+-    if (this.bt) return;
+-    this.bt = true;
+-    const n = this.St;
+-    const r = this.wt;
++    if (this.Pt) return;
++    this.Pt = true;
++    const n = this.Ot;
++    const r = this.vt;
+     try {
+-      const n = e ?? read(this.ut),
+-        r = untrack(this.ht),
+-        i = r === "sequential" && !!untrack(this.yt),
++      const n = e ?? read(this.dt),
++        r = untrack(this.wt),
++        i = r === "sequential" && !!untrack(this._t),
+         s = t ?? i;
+       if (n) {
+-        this._t(e => setSlotState(e, this, true, s));
++        this.xt(e => setSlotState(e, this, true, s));
+       } else if (r === "natural") {
+-        this._t(e => {
++        this.xt(e => {
+           if (isRevealController(e)) {
+-            setSignal(e.ft, false);
+-            setSignal(e.ut, false);
++            setSignal(e.ht, false);
++            setSignal(e.dt, false);
+             e.evaluate(false, false);
+           } else {
+             setSlotState(e, this, !isSlotReady(e), false);
+           }
+         });
+       } else if (r === "together") {
+-        const e = this._t(isSlotMinimallyReady);
+-        this._t(t => setSlotState(t, this, !e, false));
++        const e = this.xt(isSlotMinimallyReady);
++        this.xt(t => setSlotState(t, this, !e, false));
+       } else {
+         let e = false;
+-        this._t(t => {
++        this.xt(t => {
+           if (e) return setSlotState(t, this, true, i);
+           if (isSlotReady(t)) return setSlotState(t, this, false, false);
+           e = true;
+           if (isRevealController(t)) {
+-            setSignal(t.ft, false);
+-            setSignal(t.ut, false);
++            setSignal(t.ht, false);
++            setSignal(t.dt, false);
+             t.evaluate(false, false);
+           } else {
+             setSlotState(t, this, true, false);
+@@ -3319,92 +3524,92 @@ class RevealController {
+         });
+       }
+     } finally {
+-      this.St = this.isReady();
+-      this.wt = this.isMinimallyReady();
+-      this.bt = false;
++      this.Ot = this.isReady();
++      this.vt = this.isMinimallyReady();
++      this.Pt = false;
+     }
+-    if (this.lt && (n !== this.St || r !== this.wt)) this.lt.evaluate();
++    if (this.gt && (n !== this.Ot || r !== this.vt)) this.gt.evaluate();
+   }
+ }
+ class CollectionQueue extends Queue {
+-  Ot;
+-  st = new Set();
+-  vt;
+-  ot = true;
+-  ut = signal(false, { ownedWrite: true, Qe: true });
+-  ft = signal(false, { ownedWrite: true, Qe: true });
+-  ct;
+-  dt = false;
+-  xt;
+-  Pt = ve;
++  Ct;
++  lt = new Set();
++  Nt;
++  ct = true;
++  dt = signal(false, { ownedWrite: true, ze: true });
++  ht = signal(false, { ownedWrite: true, ze: true });
++  yt;
++  St = false;
++  Et;
++  kt = Ee;
+   constructor(e) {
+     super();
+-    this.Ot = e;
++    this.Ct = e;
+   }
+   run(e) {
+-    if (!e || (read(this.ut) && (!Pe || read(this.ft)))) return;
++    if (!e || (read(this.dt) && (!je || read(this.ht)))) return;
+     return super.run(e);
+   }
+   notify(e, t, n, r) {
+-    if (!(t & this.Ot)) return super.notify(e, t, n, r);
+-    if (this.dt && this.xt) {
++    if (!(t & this.Ct)) return super.notify(e, t, n, r);
++    if (this.St && this.Et) {
+       const e = untrack(() => {
+         try {
+-          return this.xt();
++          return this.Et();
+         } catch {
+-          return ve;
++          return Ee;
+         }
+       });
+-      if (e !== this.Pt) {
+-        this.Pt = e;
+-        this.dt = false;
+-        this.st.clear();
++      if (e !== this.kt) {
++        this.kt = e;
++        this.St = false;
++        this.lt.clear();
+       }
+     }
+-    if (this.Ot & S && this.dt) return super.notify(e, t, n, r);
+-    if (this.Ot & S && n & w) {
+-      return super.notify(e, w, n, r);
++    if (this.Ct & m && this.St) return super.notify(e, t, n, r);
++    if (this.Ct & m && n & _) {
++      return super.notify(e, _, n, r);
+     }
+-    if (n & this.Ot) {
+-      this.ot = true;
+-      const t = r?.source || e.pe?.source;
++    if (n & this.Ct) {
++      this.ct = true;
++      const t = r?.source || e.ge?.source;
+       if (t) {
+-        const e = this.st.size === 0;
+-        this.st.add(t);
+-        if (e) setSignal(this.ut, true);
++        const e = this.lt.size === 0;
++        this.lt.add(t);
++        if (e) setSignal(this.dt, true);
+       }
+     }
+-    t &= ~this.Ot;
++    t &= ~this.Ct;
+     return t ? super.notify(e, t, n, r) : true;
+   }
+   checkSources() {
+-    for (const e of this.st) {
+-      if (e.m & u || (!(e.ge & this.Ot) && !(this.Ot & w && e.ge & S))) this.st.delete(e);
++    for (const e of this.lt) {
++      if (e.m & u || (!(e.we & this.Ct) && !(this.Ct & _ && e.we & m))) this.lt.delete(e);
+     }
+-    if (!this.st.size) {
+-      if (this.Ot & S && this.ot && !this.dt && this.vt) {
+-        this.ot = !!(this.vt.ge & this.Ot);
++    if (!this.lt.size) {
++      if (this.Ct & m && this.ct && !this.St && this.Nt) {
++        this.ct = !!(this.Nt.we & this.Ct);
+       } else {
+-        this.ot = false;
++        this.ct = false;
+       }
+-      if (!this.ot) {
+-        setSignal(this.ut, false);
+-        if (this.xt) {
++      if (!this.ct) {
++        setSignal(this.dt, false);
++        if (this.Et) {
+           try {
+-            this.Pt = untrack(() => this.xt());
++            this.kt = untrack(() => this.Et());
+           } catch {}
+         }
+       }
+     }
+-    if (Pe) this.ct?.evaluate();
++    if (je) this.yt?.evaluate();
+   }
+ }
+ function createCollectionBoundary(e, t, n, r) {
+   const i = createOwner();
+-  if (Pe) setContext(xe, null, i);
++  if (je) setContext(ke, null, i);
+   const s = new CollectionQueue(e);
+-  if (r) s.xt = r;
+-  const o = (s.vt = createBoundChildren(i, t, s, e));
++  if (r) s.Et = r;
++  const o = (s.Nt = createBoundChildren(i, t, s, e));
+   untrack(() => {
+     let t = false;
+     try {
+@@ -3413,46 +3618,46 @@ function createCollectionBoundary(e, t, n, r) {
+       if (e instanceof NotReadyError) t = true;
+       else throw e;
+     }
+-    s.ot = t || !!(o.ge & e) || o.pe instanceof NotReadyError;
++    s.ct = t || !!(o.we & e) || o.ge instanceof NotReadyError;
+   });
+-  const u = Pe && e === S ? getContext(xe) : null;
++  const u = je && e === m ? getContext(ke) : null;
+   if (u) {
+-    s.ct = u;
++    s.yt = u;
+     u.register(s);
+     cleanup(() => u.unregister(s));
+   }
+   return accessor(
+     computed(() => {
+-      if (!read(s.ut)) {
++      if (!read(s.dt)) {
+         const e = read(o);
+-        if (!untrack(() => read(s.ut))) return ((s.dt = true), e);
++        if (!untrack(() => read(s.dt))) return ((s.St = true), e);
+       }
+-      if (Pe && read(s.ft)) return undefined;
++      if (je && read(s.ht)) return undefined;
+       return n(s);
+     })
+   );
+ }
+ function createLoadingBoundary(e, t, n) {
+-  return createCollectionBoundary(S, e, () => t(), n?.on);
++  return createCollectionBoundary(m, e, () => t(), n?.on);
+ }
+ function createErrorBoundary(e, t) {
+-  return createCollectionBoundary(w, e, e => {
+-    let n = e.st.values().next().value;
+-    const r = n.pe?.cause ?? n.pe;
++  return createCollectionBoundary(_, e, e => {
++    let n = e.lt.values().next().value;
++    const r = n.ge?.cause ?? n.ge;
+     return t(r, () => {
+-      for (const t of e.st) recompute(t);
++      for (const t of e.lt) recompute(t);
+       schedule();
+     });
+   });
+ }
+ function createRevealOrder(e, t) {
+-  Pe = true;
++  je = true;
+   const n = createOwner();
+-  const r = getContext(xe);
++  const r = getContext(ke);
+   const i = t?.order || SEQUENTIAL_ACCESSOR,
+     s = t?.collapsed || FALSE_ACCESSOR;
+   const o = new RevealController(i, s);
+-  setContext(xe, o, n);
++  setContext(ke, o, n);
+   return runWithOwner(n, () => {
+     const t = e();
+     computed(() => {
+@@ -3461,7 +3666,7 @@ function createRevealOrder(e, t) {
+       o.evaluate();
+     });
+     if (r) {
+-      o.lt = r;
++      o.gt = r;
+       r.register(o);
+       cleanup(() => r.unregister(o));
+     }
+@@ -3517,16 +3722,16 @@ function flattenArray(e, t = [], n) {
+   if (r) throw r;
+   return i;
+ }
+-const ke = undefined;
+-exports.$PROXY = ne;
+-exports.$REFRESH = E;
+-exports.$TARGET = te;
+-exports.$TRACK = ee;
++const Re = undefined;
++exports.$PROXY = ue;
++exports.$REFRESH = j;
++exports.$TARGET = oe;
++exports.$TRACK = se;
+ exports.ContextNotFoundError = ContextNotFoundError;
+-exports.DEV = ke;
++exports.DEV = Re;
+ exports.NoOwnerError = NoOwnerError;
+ exports.NotReadyError = NotReadyError;
+-exports.SUPPORTS_PROXY = k;
++exports.SUPPORTS_PROXY = E;
+ exports.action = action;
+ exports.clearSnapshots = clearSnapshots;
+ exports.createContext = createContext;
+@@ -3576,5 +3781,5 @@ exports.runWithOwner = runWithOwner;
+ exports.setContext = setContext;
+ exports.setSnapshotCapture = setSnapshotCapture;
+ exports.snapshot = snapshot;
+-exports.storePath = me;
++exports.storePath = Pe;
+ exports.untrack = untrack;
+diff --git a/dist/prod.js b/dist/prod.js
+index 65752b822deaf7c92e3b70ba77b8a20b66e3d2ae..e9c0d0ce700eea7b5dcaba07e5a3b30dfbce6064 100644
+--- a/dist/prod.js
++++ b/dist/prod.js
+@@ -33,12 +33,14 @@ const REACTIVE_DISPOSED = 1 << 6;
+ const REACTIVE_OPTIMISTIC_DIRTY = 1 << 7;
+ const REACTIVE_SNAPSHOT_STALE = 1 << 8;
+ const REACTIVE_LAZY = 1 << 9;
++const REACTIVE_MANUAL_WRITE = 1 << 10;
+ const CONFIG_OWNED_WRITE = 1 << 0;
+ const CONFIG_NO_SNAPSHOT = 1 << 1;
+ const CONFIG_TRANSPARENT = 1 << 2;
+ const CONFIG_IN_SNAPSHOT_SCOPE = 1 << 3;
+ const CONFIG_CHILDREN_FORBIDDEN = 1 << 4;
+ const CONFIG_AUTO_DISPOSE = 1 << 5;
++const CONFIG_SYNC = 1 << 6;
+ const STATUS_PENDING = 1 << 0;
+ const STATUS_ERROR = 1 << 1;
+ const STATUS_UNINITIALIZED = 1 << 2;
+@@ -51,6 +53,7 @@ const STORE_SNAPSHOT_PROPS = "sp";
+ const SUPPORTS_PROXY = typeof Proxy === "function";
+ const defaultContext = {};
+ const $REFRESH = Symbol("refresh");
++const DEV$1 = undefined;
+ function actualInsertIntoHeap(e, t) {
+   const n = (e.i?.t ? e.i.u?.o : e.i?.o) ?? -1;
+   if (n >= e.o) e.o = n + 1;
+@@ -63,26 +66,30 @@ function actualInsertIntoHeap(e, t) {
+     e.T = t;
+     r.T = e;
+   }
+-  if (i > t.O) t.O = i;
++  if (i > t._) t._ = i;
+ }
+ function insertIntoHeap(e, t) {
+-  let n = e.R;
+-  if (n & (REACTIVE_IN_HEAP | REACTIVE_RECOMPUTING_DEPS)) return;
++  let n = e.O;
++  if (n & (REACTIVE_IN_HEAP | REACTIVE_RECOMPUTING_DEPS | REACTIVE_MANUAL_WRITE)) return;
+   if (n & REACTIVE_CHECK) {
+-    e.R = (n & -4) | REACTIVE_DIRTY | REACTIVE_IN_HEAP;
+-  } else e.R = n | REACTIVE_IN_HEAP;
++    e.O = (n & -4) | REACTIVE_DIRTY | REACTIVE_IN_HEAP;
++  } else e.O = n | REACTIVE_IN_HEAP;
+   if (!(n & REACTIVE_IN_HEAP_HEIGHT)) actualInsertIntoHeap(e, t);
+ }
+ function insertIntoHeapHeight(e, t) {
+-  let n = e.R;
+-  if (n & (REACTIVE_IN_HEAP | REACTIVE_RECOMPUTING_DEPS | REACTIVE_IN_HEAP_HEIGHT)) return;
+-  e.R = n | REACTIVE_IN_HEAP_HEIGHT;
++  let n = e.O;
++  if (
++    n &
++    (REACTIVE_IN_HEAP | REACTIVE_RECOMPUTING_DEPS | REACTIVE_IN_HEAP_HEIGHT | REACTIVE_MANUAL_WRITE)
++  )
++    return;
++  e.O = n | REACTIVE_IN_HEAP_HEIGHT;
+   actualInsertIntoHeap(e, t);
+ }
+ function deleteFromHeap(e, t) {
+-  const n = e.R;
++  const n = e.O;
+   if (!(n & (REACTIVE_IN_HEAP | REACTIVE_IN_HEAP_HEIGHT))) return;
+-  e.R = n & -25;
++  e.O = n & -25;
+   const i = e.o;
+   if (e.T === e) t.l[i] = undefined;
+   else {
+@@ -97,40 +104,40 @@ function deleteFromHeap(e, t) {
+   e.S = undefined;
+ }
+ function markHeap(e) {
+-  if (e._) return;
+-  e._ = true;
+-  for (let t = 0; t <= e.O; t++) {
++  if (e.R) return;
++  e.R = true;
++  for (let t = 0; t <= e._; t++) {
+     for (let n = e.l[t]; n !== undefined; n = n.S) {
+-      if (n.R & REACTIVE_IN_HEAP) markNode(n);
++      if (n.O & REACTIVE_IN_HEAP) markNode(n);
+     }
+   }
+ }
+ function markNode(e, t = REACTIVE_DIRTY) {
+-  const n = e.R;
++  const n = e.O;
+   if ((n & (REACTIVE_CHECK | REACTIVE_DIRTY)) >= t) return;
+-  e.R = (n & -4) | t;
+-  for (let t = e.I; t !== null; t = t.h) {
+-    markNode(t.p, REACTIVE_CHECK);
++  e.O = (n & -4) | t;
++  for (let t = e.I; t !== null; t = t.p) {
++    markNode(t.h, REACTIVE_CHECK);
+   }
+   if (e.N !== null) {
+     for (let t = e.N; t !== null; t = t.A) {
+-      for (let e = t.I; e !== null; e = e.h) {
+-        markNode(e.p, REACTIVE_CHECK);
++      for (let e = t.I; e !== null; e = e.p) {
++        markNode(e.h, REACTIVE_CHECK);
+       }
+     }
+   }
+ }
+ function runHeap(e, t) {
+-  e._ = false;
+-  for (e.P = 0; e.P <= e.O; e.P++) {
++  e.R = false;
++  for (e.P = 0; e.P <= e._; e.P++) {
+     let n = e.l[e.P];
+     while (n !== undefined) {
+-      if (n.R & REACTIVE_IN_HEAP) t(n);
++      if (n.O & REACTIVE_IN_HEAP) t(n);
+       else adjustHeight(n, e);
+       n = e.l[e.P];
+     }
+   }
+-  e.O = 0;
++  e._ = 0;
+ }
+ function adjustHeight(e, t) {
+   deleteFromHeap(e, t);
+@@ -142,24 +149,34 @@ function adjustHeight(e, t) {
+   }
+   if (e.o !== n) {
+     e.o = n;
+-    for (let n = e.I; n !== null; n = n.h) {
+-      insertIntoHeapHeight(n.p, t);
++    for (let n = e.I; n !== null; n = n.p) {
++      insertIntoHeapHeight(n.h, t);
+     }
+   }
+ }
+-const DEV$1 = undefined;
+ const transitions = new Set();
+-const dirtyQueue = { l: new Array(2e3).fill(undefined), _: false, P: 0, O: 0 };
+-const zombieQueue = { l: new Array(2e3).fill(undefined), _: false, P: 0, O: 0 };
++const dirtyQueue = { l: new Array(2e3).fill(undefined), R: false, P: 0, _: 0 };
++const zombieQueue = { l: new Array(2e3).fill(undefined), R: false, P: 0, _: 0 };
+ let clock = 0;
+ let activeTransition = null;
+ let scheduled = false;
++let syncDepth = 0;
+ let projectionWriteActive = false;
+ let stashedOptimisticReads = null;
+ const transientStoreNodes = new Set();
+ function registerTransientStoreNode(e) {
+   transientStoreNodes.add(e);
+ }
++function canUseSimpleSyncFlush(e) {
++  return (
++    transitions.size === 0 &&
++    activeLanes.size === 0 &&
++    e.U.length === 0 &&
++    e.G.length === 0 &&
++    e.F.size === 0 &&
++    transientStoreNodes.size === 0
++  );
++}
+ function sweepTransientStoreNodes() {
+   if (transientStoreNodes.size === 0) return;
+   for (const e of transientStoreNodes) {
+@@ -167,10 +184,10 @@ function sweepTransientStoreNodes() {
+       transientStoreNodes.delete(e);
+       continue;
+     }
+-    if (e.U !== NOT_PENDING) continue;
+-    if (e.G !== undefined && e.G !== NOT_PENDING) continue;
++    if (e.k !== NOT_PENDING) continue;
++    if (e.W !== undefined && e.W !== NOT_PENDING) continue;
+     transientStoreNodes.delete(e);
+-    e.k?.();
++    e.H?.();
+   }
+ }
+ function enforceLoadingBoundary(e) {}
+@@ -179,26 +196,26 @@ function shouldReadStashedOptimisticValue(e) {
+ }
+ function runLaneEffects(e) {
+   for (const t of activeLanes) {
+-    if (t.F || t.W.size > 0) continue;
+-    const n = t.H[e - 1];
++    if (t.M || t.j.size > 0) continue;
++    const n = t.$[e - 1];
+     if (n.length) {
+-      t.H[e - 1] = [];
++      t.$[e - 1] = [];
+       runQueue(n, e);
+     }
+   }
+ }
+ function queueStashedOptimisticEffects(e) {
+-  for (let t = e.I; t !== null; t = t.h) {
+-    const e = t.p;
+-    if (!e.M) continue;
+-    if (e.M === EFFECT_TRACKED) {
+-      if (!e.j) {
+-        e.j = true;
+-        e.$.enqueue(EFFECT_USER, e.K);
++  for (let t = e.I; t !== null; t = t.p) {
++    const e = t.h;
++    if (!e.K) continue;
++    if (e.K === EFFECT_TRACKED) {
++      if (!e.Y) {
++        e.Y = true;
++        e.Z.enqueue(EFFECT_USER, e.B);
+       }
+       continue;
+     }
+-    const n = e.R & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue;
++    const n = e.O & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue;
+     if (n.P > e.o) n.P = e.o;
+     insertIntoHeap(e, n);
+   }
+@@ -207,67 +224,67 @@ function setProjectionWriteActive(e) {
+   projectionWriteActive = e;
+ }
+ function mergeTransitionState(e, t) {
+-  t.Y = e;
+-  e.B.push(...t.B);
+-  for (const n of activeLanes) if (n.Z === t) n.Z = e;
+-  e.q.push(...t.q);
+-  for (const n of t.X) e.X.add(n);
+-  for (const [n, i] of t.J) {
+-    let t = e.J.get(n);
+-    if (!t) e.J.set(n, (t = new Set()));
++  t.q = e;
++  e.X.push(...t.X);
++  for (const n of activeLanes) if (n.J === t) n.J = e;
++  e.G.push(...t.G);
++  for (const n of t.F) e.F.add(n);
++  for (const [n, i] of t.ee) {
++    let t = e.ee.get(n);
++    if (!t) e.ee.set(n, (t = new Set()));
+     for (const e of i) t.add(e);
+   }
+-  for (const n of t.ee) e.ee.add(n);
++  for (const n of t.te) e.te.add(n);
+ }
+ function resolveOptimisticNodes(e) {
+   for (let t = 0; t < e.length; t++) {
+     const n = e[t];
+-    n.te = undefined;
+-    if (n.U !== NOT_PENDING) {
+-      n.ne = n.U;
+-      n.U = NOT_PENDING;
++    n.ne = undefined;
++    if (n.k !== NOT_PENDING) {
++      n.ie = n.k;
++      n.k = NOT_PENDING;
+     }
+-    const i = n.G;
+-    n.G = NOT_PENDING;
+-    if (i !== NOT_PENDING && n.ne !== i) insertSubs(n, true);
+-    n.Z = null;
++    const i = n.W;
++    n.W = NOT_PENDING;
++    if (i !== NOT_PENDING && n.ie !== i) insertSubs(n, true);
++    n.J = null;
+   }
+   e.length = 0;
+ }
+ function cleanupCompletedLanes(e) {
+   for (const t of activeLanes) {
+-    const n = e ? t.Z === e : !t.Z;
++    const n = e ? t.J === e : !t.J;
+     if (!n) continue;
+-    if (!t.F) {
+-      if (t.H[0].length) runQueue(t.H[0], EFFECT_RENDER);
+-      if (t.H[1].length) runQueue(t.H[1], EFFECT_USER);
+-    }
+-    if (t.ie.te === t) t.ie.te = undefined;
+-    t.W.clear();
+-    t.H[0].length = 0;
+-    t.H[1].length = 0;
++    if (!t.M) {
++      if (t.$[0].length) runQueue(t.$[0], EFFECT_RENDER);
++      if (t.$[1].length) runQueue(t.$[1], EFFECT_USER);
++    }
++    if (t.re.ne === t) t.re.ne = undefined;
++    t.j.clear();
++    t.$[0].length = 0;
++    t.$[1].length = 0;
+     activeLanes.delete(t);
+-    signalLanes.delete(t.ie);
++    signalLanes.delete(t.re);
+   }
+ }
+ function schedule() {
+   if (scheduled) return;
+   scheduled = true;
+-  if (!globalQueue.re && !projectionWriteActive) queueMicrotask(flush);
++  if (!syncDepth && !globalQueue.se && !projectionWriteActive) queueMicrotask(flush);
+ }
+ class Queue {
+   i = null;
+-  se = [[], []];
+-  oe = [];
++  oe = [[], []];
++  U = [];
+   created = clock;
+   addChild(e) {
+-    this.oe.push(e);
++    this.U.push(e);
+     e.i = this;
+   }
+   removeChild(e) {
+-    const t = this.oe.indexOf(e);
++    const t = this.U.indexOf(e);
+     if (t >= 0) {
+-      this.oe.splice(t, 1);
++      this.U.splice(t, 1);
+       e.i = null;
+     }
+   }
+@@ -276,81 +293,84 @@ class Queue {
+     return false;
+   }
+   run(e) {
+-    if (this.se[e - 1].length) {
+-      const t = this.se[e - 1];
+-      this.se[e - 1] = [];
++    if (this.oe[e - 1].length) {
++      const t = this.oe[e - 1];
++      this.oe[e - 1] = [];
+       runQueue(t, e);
+     }
+-    for (let t = 0; t < this.oe.length; t++) this.oe[t].run?.(e);
++    for (let t = 0; t < this.U.length; t++) this.U[t].run?.(e);
+   }
+   enqueue(e, t) {
+     if (e) {
+       if (currentOptimisticLane) {
+         const n = findLane(currentOptimisticLane);
+-        n.H[e - 1].push(t);
++        n.$[e - 1].push(t);
+       } else {
+-        this.se[e - 1].push(t);
++        this.oe[e - 1].push(t);
+       }
+     }
+     schedule();
+   }
+   stashQueues(e) {
+-    e.se[0].push(...this.se[0]);
+-    e.se[1].push(...this.se[1]);
+-    this.se = [[], []];
+-    for (let t = 0; t < this.oe.length; t++) {
+-      let n = this.oe[t];
+-      let i = e.oe[t];
++    e.oe[0].push(...this.oe[0]);
++    e.oe[1].push(...this.oe[1]);
++    this.oe = [[], []];
++    for (let t = 0; t < this.U.length; t++) {
++      let n = this.U[t];
++      let i = e.U[t];
+       if (!i) {
+-        i = { se: [[], []], oe: [] };
+-        e.oe[t] = i;
++        i = { oe: [[], []], U: [] };
++        e.U[t] = i;
+       }
+       n.stashQueues(i);
+     }
+   }
+   restoreQueues(e) {
+-    this.se[0].push(...e.se[0]);
+-    this.se[1].push(...e.se[1]);
+-    for (let t = 0; t < e.oe.length; t++) {
+-      const n = e.oe[t];
+-      let i = this.oe[t];
++    this.oe[0].push(...e.oe[0]);
++    this.oe[1].push(...e.oe[1]);
++    for (let t = 0; t < e.U.length; t++) {
++      const n = e.U[t];
++      let i = this.U[t];
+       if (i) i.restoreQueues(n);
+     }
+   }
+ }
+ class GlobalQueue extends Queue {
+-  re = false;
+-  ue = [];
+-  q = [];
+-  X = new Set();
+-  static ce;
++  se = false;
++  ue = null;
++  ce = [];
++  G = [];
++  F = new Set();
++  static le;
+   static ae;
+-  static le = null;
++  static fe;
++  static Ee = null;
+   flush() {
+-    if (this.re) return;
+-    this.re = true;
++    if (this.se) return;
++    this.se = true;
+     try {
+-      runHeap(dirtyQueue, GlobalQueue.ce);
++      runHeap(dirtyQueue, GlobalQueue.le);
+       if (activeTransition) {
+         const e = transitionComplete(activeTransition);
+         if (!e) {
+           const e = activeTransition;
+-          runHeap(zombieQueue, GlobalQueue.ce);
+-          this.ue = [];
+-          this.q = [];
+-          this.X = new Set();
++          runHeap(zombieQueue, GlobalQueue.le);
++          this.ue = null;
++          this.ce = [];
++          this.G = [];
++          this.F = new Set();
+           runLaneEffects(EFFECT_RENDER);
+           runLaneEffects(EFFECT_USER);
+-          this.stashQueues(e.fe);
++          this.stashQueues(e.Te);
+           clock++;
+-          scheduled = dirtyQueue.O >= dirtyQueue.P;
+-          reassignPendingTransition(e.ue);
++          scheduled = dirtyQueue._ >= dirtyQueue.P;
++          reassignPendingTransition(e.ce);
+           activeTransition = null;
+-          if (!e.B.length && !e.J.size && e.q.length) {
++          if (!e.X.length && !e.ee.size && e.G.length) {
+             stashedOptimisticReads = new Set();
+-            for (let t = 0; t < e.q.length; t++) {
+-              const n = e.q[t];
+-              if (n.L || n.Ee & CONFIG_OWNED_WRITE) continue;
++            for (let t = 0; t < e.G.length; t++) {
++              const n = e.G[t];
++              if (n.L || n.de & CONFIG_OWNED_WRITE) continue;
+               stashedOptimisticReads.add(n);
+               queueStashedOptimisticEffects(n);
+             }
+@@ -362,36 +382,44 @@ class GlobalQueue extends Queue {
+           }
+           return;
+         }
+-        this.ue !== activeTransition.ue && this.ue.push(...activeTransition.ue);
+-        this.restoreQueues(activeTransition.fe);
++        this.ce !== activeTransition.ce && this.ce.push(...activeTransition.ce);
++        this.restoreQueues(activeTransition.Te);
+         transitions.delete(activeTransition);
+         const t = activeTransition;
+         activeTransition = null;
+-        reassignPendingTransition(this.ue);
++        reassignPendingTransition(this.ce);
+         finalizePureQueue(t);
+       } else {
+-        if (transitions.size) runHeap(zombieQueue, GlobalQueue.ce);
+-        finalizePureQueue();
++        if (canUseSimpleSyncFlush(this)) {
++          commitPendingNodes();
++          if (dirtyQueue._ >= dirtyQueue.P) {
++            runHeap(dirtyQueue, GlobalQueue.le);
++            commitPendingNodes();
++          }
++        } else {
++          if (transitions.size) runHeap(zombieQueue, GlobalQueue.le);
++          finalizePureQueue();
++        }
+       }
+       clock++;
+-      scheduled = dirtyQueue.O >= dirtyQueue.P;
+-      runLaneEffects(EFFECT_RENDER);
++      scheduled = dirtyQueue._ >= dirtyQueue.P;
++      activeLanes.size && runLaneEffects(EFFECT_RENDER);
+       this.run(EFFECT_RENDER);
+-      runLaneEffects(EFFECT_USER);
++      activeLanes.size && runLaneEffects(EFFECT_USER);
+       this.run(EFFECT_USER);
+       if (false);
+     } finally {
+-      this.re = false;
++      this.se = false;
+     }
+   }
+   notify(e, t, n, i) {
+     if (t & STATUS_PENDING) {
+       if (n & STATUS_PENDING) {
+-        const t = i !== undefined ? i : e.Te;
++        const t = i !== undefined ? i : e.Se;
+         if (activeTransition && t) {
+           const n = t.source;
+-          let i = activeTransition.J.get(n);
+-          if (!i) activeTransition.J.set(n, (i = new Set()));
++          let i = activeTransition.ee.get(n);
++          if (!i) activeTransition.ee.set(n, (i = new Set()));
+           const r = i.size;
+           i.add(e);
+           if (i.size !== r) schedule();
+@@ -404,18 +432,18 @@ class GlobalQueue extends Queue {
+   initTransition(e) {
+     if (e) e = currentTransition(e);
+     if (e && e === activeTransition) return;
+-    if (!e && activeTransition && activeTransition.Se === clock) return;
++    if (!e && activeTransition && activeTransition._e === clock) return;
+     if (!activeTransition) {
+       activeTransition = e ?? {
+-        Se: clock,
+-        ue: [],
+-        J: new Map(),
+-        q: [],
+-        X: new Set(),
+-        B: [],
+-        fe: { se: [[], []], oe: [] },
+-        Y: false,
+-        ee: new Set()
++        _e: clock,
++        ce: [],
++        ee: new Map(),
++        G: [],
++        F: new Set(),
++        X: [],
++        Te: { oe: [[], []], U: [] },
++        q: false,
++        te: new Set()
+       };
+     } else if (e) {
+       const t = activeTransition;
+@@ -424,102 +452,138 @@ class GlobalQueue extends Queue {
+       activeTransition = e;
+     }
+     transitions.add(activeTransition);
+-    activeTransition.Se = clock;
+-    if (this.ue !== activeTransition.ue) {
+-      for (let e = 0; e < this.ue.length; e++) {
+-        const t = this.ue[e];
+-        t.Z = activeTransition;
+-        activeTransition.ue.push(t);
++    activeTransition._e = clock;
++    if (this.ue !== null) {
++      this.ue.J = activeTransition;
++      activeTransition.ce.push(this.ue);
++      this.ue = null;
++    }
++    if (this.ce !== activeTransition.ce) {
++      for (let e = 0; e < this.ce.length; e++) {
++        const t = this.ce[e];
++        t.J = activeTransition;
++        activeTransition.ce.push(t);
+       }
+-      this.ue = activeTransition.ue;
++      this.ce = activeTransition.ce;
+     }
+-    if (this.q !== activeTransition.q) {
+-      for (let e = 0; e < this.q.length; e++) {
+-        const t = this.q[e];
+-        t.Z = activeTransition;
+-        activeTransition.q.push(t);
++    if (this.G !== activeTransition.G) {
++      for (let e = 0; e < this.G.length; e++) {
++        const t = this.G[e];
++        t.J = activeTransition;
++        activeTransition.G.push(t);
+       }
+-      this.q = activeTransition.q;
++      this.G = activeTransition.G;
+     }
+     for (const e of activeLanes) {
+-      if (!e.Z) e.Z = activeTransition;
++      if (!e.J) e.J = activeTransition;
+     }
+-    if (this.X !== activeTransition.X) {
+-      for (const e of this.X) activeTransition.X.add(e);
+-      this.X = activeTransition.X;
++    if (this.F !== activeTransition.F) {
++      for (const e of this.F) activeTransition.F.add(e);
++      this.F = activeTransition.F;
+     }
+   }
+ }
++function queuePendingNode(e) {
++  if (activeTransition) {
++    globalQueue.ce.push(e);
++    return;
++  }
++  if (globalQueue.ue === null && globalQueue.ce.length === 0) {
++    globalQueue.ue = e;
++    return;
++  }
++  if (globalQueue.ue !== null) {
++    globalQueue.ce.push(globalQueue.ue);
++    globalQueue.ue = null;
++  }
++  globalQueue.ce.push(e);
++}
+ function insertSubs(e, t = false) {
+-  const n = e.te || currentOptimisticLane;
+-  const i = e.de !== undefined;
+-  for (let r = e.I; r !== null; r = r.h) {
+-    if (i && r.p.Ee & CONFIG_IN_SNAPSHOT_SCOPE) {
+-      r.p.R |= REACTIVE_SNAPSHOT_STALE;
++  const n = e.ne || currentOptimisticLane;
++  const i = e.Oe !== undefined;
++  for (let r = e.I; r !== null; r = r.p) {
++    if (i && r.h.de & CONFIG_IN_SNAPSHOT_SCOPE) {
++      r.h.O |= REACTIVE_SNAPSHOT_STALE;
+       continue;
+     }
+     if (t && n) {
+-      r.p.R |= REACTIVE_OPTIMISTIC_DIRTY;
+-      assignOrMergeLane(r.p, n);
++      r.h.O |= REACTIVE_OPTIMISTIC_DIRTY;
++      assignOrMergeLane(r.h, n);
+     } else if (t) {
+-      r.p.R |= REACTIVE_OPTIMISTIC_DIRTY;
+-      r.p.te = undefined;
++      r.h.O |= REACTIVE_OPTIMISTIC_DIRTY;
++      r.h.ne = undefined;
+     }
+-    const e = r.p;
+-    if (e.M === EFFECT_TRACKED) {
+-      if (!e.j) {
+-        e.j = true;
+-        e.$.enqueue(EFFECT_USER, e.K);
++    const e = r.h;
++    if (e.K === EFFECT_TRACKED) {
++      if (!e.Y) {
++        e.Y = true;
++        e.Z.enqueue(EFFECT_USER, e.B);
+       }
+       continue;
+     }
+-    const s = r.p.R & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue;
+-    if (s.P > r.p.o) s.P = r.p.o;
+-    insertIntoHeap(r.p, s);
++    const s = r.h.O & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue;
++    if (s.P > r.h.o) s.P = r.h.o;
++    insertIntoHeap(r.h, s);
++  }
++}
++function commitPendingNode(e) {
++  const t = e;
++  if (!t.L) {
++    if (e.k !== NOT_PENDING) {
++      e.ie = e.k;
++      e.k = NOT_PENDING;
++    }
++    return;
++  }
++  if (e.k !== NOT_PENDING) {
++    e.ie = e.k;
++    e.k = NOT_PENDING;
++    if (e.K && e.K !== EFFECT_TRACKED) e.Y = true;
+   }
++  t.O &= ~REACTIVE_MANUAL_WRITE;
++  if (!(t.Re & STATUS_PENDING)) t.Re &= ~STATUS_UNINITIALIZED;
++  if (t.Ie !== null || t.pe !== null) GlobalQueue.ae(t, false, true);
+ }
+ function commitPendingNodes() {
+-  const e = globalQueue.ue;
++  if (globalQueue.ue !== null) {
++    commitPendingNode(globalQueue.ue);
++    globalQueue.ue = null;
++  }
++  const e = globalQueue.ce;
+   for (let t = 0; t < e.length; t++) {
+-    const n = e[t];
+-    if (n.U !== NOT_PENDING) {
+-      n.ne = n.U;
+-      n.U = NOT_PENDING;
+-      if (n.M && n.M !== EFFECT_TRACKED) n.j = true;
+-    }
+-    if (!(n.Oe & STATUS_PENDING)) n.Oe &= ~STATUS_UNINITIALIZED;
+-    if (n.L) GlobalQueue.ae(n, false, true);
++    commitPendingNode(e[t]);
+   }
+   e.length = 0;
+ }
+ function finalizePureQueue(e = null, t = false) {
+   const n = !t;
+   if (n) commitPendingNodes();
+-  if (!t) checkBoundaryChildren(globalQueue);
+-  if (dirtyQueue.O >= dirtyQueue.P) runHeap(dirtyQueue, GlobalQueue.ce);
++  if (!t && globalQueue.U.length) checkBoundaryChildren(globalQueue);
++  const i = dirtyQueue._ >= dirtyQueue.P;
++  if (i) runHeap(dirtyQueue, GlobalQueue.le);
+   if (n) {
+-    commitPendingNodes();
+-    resolveOptimisticNodes(e ? e.q : globalQueue.q);
+-    if (e && e.ee.size) {
+-      for (const t of e.ee) {
+-        if (t.R & REACTIVE_DISPOSED) continue;
+-        if (t.M === EFFECT_TRACKED) {
+-          if (!t.j) {
+-            t.j = true;
+-            t.$.enqueue(EFFECT_USER, t.K);
++    if (i) commitPendingNodes();
++    resolveOptimisticNodes(e ? e.G : globalQueue.G);
++    if (e && e.te.size) {
++      for (const t of e.te) {
++        if (t.O & REACTIVE_DISPOSED) continue;
++        if (t.K === EFFECT_TRACKED) {
++          if (!t.Y) {
++            t.Y = true;
++            t.Z.enqueue(EFFECT_USER, t.B);
+           }
+           continue;
+         }
+-        const e = t.R & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue;
++        const e = t.O & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue;
+         if (e.P > t.o) e.P = t.o;
+         insertIntoHeap(t, e);
+       }
+-      e.ee.clear();
++      e.te.clear();
+     }
+-    const t = e ? e.X : globalQueue.X;
+-    if (GlobalQueue.le && t.size) {
++    const t = e ? e.F : globalQueue.F;
++    if (GlobalQueue.Ee && t.size) {
+       for (const e of t) {
+-        GlobalQueue.le(e);
++        GlobalQueue.Ee(e);
+       }
+       t.clear();
+       schedule();
+@@ -529,23 +593,32 @@ function finalizePureQueue(e = null, t = false) {
+   }
+ }
+ function checkBoundaryChildren(e) {
+-  for (const t of e.oe) {
++  for (const t of e.U) {
+     t.checkSources?.();
+     checkBoundaryChildren(t);
+   }
+ }
+ function trackOptimisticStore(e) {
+-  globalQueue.X.add(e);
++  globalQueue.F.add(e);
+   schedule();
+ }
+ function reassignPendingTransition(e) {
+   for (let t = 0; t < e.length; t++) {
+-    e[t].Z = activeTransition;
++    e[t].J = activeTransition;
+   }
+ }
+ const globalQueue = new GlobalQueue();
+-function flush() {
+-  if (globalQueue.re) {
++function flush(e) {
++  if (e) {
++    syncDepth++;
++    try {
++      return e();
++    } finally {
++      flush();
++      syncDepth--;
++    }
++  }
++  if (globalQueue.se) {
+     return;
+   }
+   while (scheduled || activeTransition) {
+@@ -556,22 +629,22 @@ function runQueue(e, t) {
+   for (let n = 0; n < e.length; n++) e[n](t);
+ }
+ function reporterBlocksSource(e, t) {
+-  if (e.R & (REACTIVE_ZOMBIE | REACTIVE_DISPOSED)) return false;
+-  if (e.Re === t || e._e?.has(t)) return true;
++  if (e.O & (REACTIVE_ZOMBIE | REACTIVE_DISPOSED)) return false;
++  if (e.he === t || e.Ne?.has(t)) return true;
+   for (let n = e.C; n; n = n.D) {
+     let e = n.m;
+     while (e) {
+       if (e === t || e.V === t) return true;
+-      e = e.Ie;
++      e = e.Ae;
+     }
+   }
+-  return !!(e.Oe & STATUS_PENDING && e.Te instanceof NotReadyError && e.Te.source === t);
++  return !!(e.Re & STATUS_PENDING && e.Se instanceof NotReadyError && e.Se.source === t);
+ }
+ function transitionComplete(e) {
+-  if (e.Y) return true;
+-  if (e.B.length) return false;
++  if (e.q) return true;
++  if (e.X.length) return false;
+   let t = true;
+-  for (const [n, i] of e.J) {
++  for (const [n, i] of e.ee) {
+     let r = false;
+     for (const e of i) {
+       if (reporterBlocksSource(e, n)) {
+@@ -580,32 +653,32 @@ function transitionComplete(e) {
+       }
+       i.delete(e);
+     }
+-    if (!r) e.J.delete(n);
+-    else if (n.Oe & STATUS_PENDING && n.Te?.source === n) {
++    if (!r) e.ee.delete(n);
++    else if (n.Re & STATUS_PENDING && n.Se?.source === n) {
+       t = false;
+       break;
+     }
+   }
+   if (t) {
+-    for (let n = 0; n < e.q.length; n++) {
+-      const i = e.q[n];
++    for (let n = 0; n < e.G.length; n++) {
++      const i = e.G[n];
+       if (
+         hasActiveOverride(i) &&
+-        "Oe" in i &&
+-        i.Oe & STATUS_PENDING &&
+-        i.Te instanceof NotReadyError &&
+-        i.Te.source !== i
++        "Re" in i &&
++        i.Re & STATUS_PENDING &&
++        i.Se instanceof NotReadyError &&
++        i.Se.source !== i
+       ) {
+         t = false;
+         break;
+       }
+     }
+   }
+-  t && (e.Y = true);
++  t && (e.q = true);
+   return t;
+ }
+ function currentTransition(e) {
+-  while (e.Y && typeof e.Y === "object") e = e.Y;
++  while (e.q && typeof e.q === "object") e = e.q;
+   return e;
+ }
+ function setActiveTransition(e) {
+@@ -627,113 +700,113 @@ function getOrCreateLane(e) {
+   if (t) {
+     return findLane(t);
+   }
+-  const n = e.Ie;
+-  const i = n?.te ? findLane(n.te) : null;
+-  t = { ie: e, W: new Set(), H: [[], []], F: null, Z: activeTransition, he: i };
++  const n = e.Ae;
++  const i = n?.ne ? findLane(n.ne) : null;
++  t = { re: e, j: new Set(), $: [[], []], M: null, J: activeTransition, Pe: i };
+   signalLanes.set(e, t);
+   activeLanes.add(t);
+-  e.pe = false;
++  e.Ce = false;
+   return t;
+ }
+ function findLane(e) {
+-  while (e.F) e = e.F;
++  while (e.M) e = e.M;
+   return e;
+ }
+ function mergeLanes(e, t) {
+   e = findLane(e);
+   t = findLane(t);
+   if (e === t) return e;
+-  t.F = e;
+-  for (const n of t.W) e.W.add(n);
+-  e.H[0].push(...t.H[0]);
+-  e.H[1].push(...t.H[1]);
++  t.M = e;
++  for (const n of t.j) e.j.add(n);
++  e.$[0].push(...t.$[0]);
++  e.$[1].push(...t.$[1]);
+   return e;
+ }
+ function resolveLane(e) {
+-  const t = e.te;
++  const t = e.ne;
+   if (!t) return undefined;
+   const n = findLane(t);
+   if (activeLanes.has(n)) return n;
+-  e.te = undefined;
++  e.ne = undefined;
+   return undefined;
+ }
+ function resolveTransition(e) {
+-  return resolveLane(e)?.Z ?? e.Z;
++  return resolveLane(e)?.J ?? e.J;
+ }
+ function hasActiveOverride(e) {
+-  return !!(e.G !== undefined && e.G !== NOT_PENDING);
++  return !!(e.W !== undefined && e.W !== NOT_PENDING);
+ }
+ function assignOrMergeLane(e, t) {
+   const n = findLane(t);
+-  const i = e.te;
++  const i = e.ne;
+   if (i) {
+-    if (i.F) {
+-      e.te = t;
++    if (i.M) {
++      e.ne = t;
+       return;
+     }
+     const r = findLane(i);
+     if (activeLanes.has(r)) {
+       if (r !== n && !hasActiveOverride(e)) {
+-        if (n.he && findLane(n.he) === r) {
+-          e.te = t;
+-        } else if (r.he && findLane(r.he) === n);
++        if (n.Pe && findLane(n.Pe) === r) {
++          e.ne = t;
++        } else if (r.Pe && findLane(r.Pe) === n);
+         else mergeLanes(n, r);
+       }
+       return;
+     }
+   }
+-  e.te = t;
++  e.ne = t;
+ }
+ function unlinkSubs(e) {
+   const t = e.m;
+   const n = e.D;
+-  const i = e.h;
+-  const r = e.Ne;
+-  if (i !== null) i.Ne = r;
+-  else t.Ae = r;
+-  if (r !== null) r.h = i;
++  const i = e.p;
++  const r = e.ge;
++  if (i !== null) i.ge = r;
++  else t.De = r;
++  if (r !== null) r.p = i;
+   else {
+     t.I = i;
+     if (i === null) {
+-      t.k?.();
++      t.H?.();
+       const e = t;
+-      e.L && e.Ee & CONFIG_AUTO_DISPOSE && !(e.R & REACTIVE_ZOMBIE) && unobserved(e);
++      e.L && e.de & CONFIG_AUTO_DISPOSE && !(e.O & REACTIVE_ZOMBIE) && unobserved(e);
+     }
+   }
+   return n;
+ }
+ function unobserved(e) {
+-  deleteFromHeap(e, e.R & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
++  deleteFromHeap(e, e.O & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
+   let t = e.C;
+   while (t !== null) {
+     t = unlinkSubs(t);
+   }
+   e.C = null;
+-  e.Pe = null;
++  e.ye = null;
+   disposeChildren(e, true);
+ }
+ function link(e, t) {
+-  const n = t.Pe;
++  const n = t.ye;
+   if (n !== null && n.m === e) return;
+   let i = null;
+-  const r = t.R & REACTIVE_RECOMPUTING_DEPS;
++  const r = t.O & REACTIVE_RECOMPUTING_DEPS;
+   if (r) {
+     i = n !== null ? n.D : t.C;
+     if (i !== null && i.m === e) {
+-      t.Pe = i;
++      t.ye = i;
+       return;
+     }
+   }
+-  const s = e.Ae;
+-  if (s !== null && s.p === t && (!r || isValidLink(s, t))) return;
+-  const o = (t.Pe = e.Ae = { m: e, p: t, D: i, Ne: s, h: null });
++  const s = e.De;
++  if (s !== null && s.h === t && (!r || isValidLink(s, t))) return;
++  const o = (t.ye = e.De = { m: e, h: t, D: i, ge: s, p: null });
+   if (n !== null) n.D = o;
+   else t.C = o;
+-  if (s !== null) s.h = o;
++  if (s !== null) s.p = o;
+   else e.I = o;
+ }
+ function isValidLink(e, t) {
+-  const n = t.Pe;
++  const n = t.ye;
+   if (n !== null) {
+     let i = t.C;
+     do {
+@@ -746,15 +819,15 @@ function isValidLink(e, t) {
+ }
+ const PENDING_OWNER = {};
+ function markDisposal(e) {
+-  let t = e.Ce;
++  let t = e.ve;
+   while (t) {
+-    t.R |= REACTIVE_ZOMBIE;
+-    if (t.R & REACTIVE_IN_HEAP) {
++    t.O |= REACTIVE_ZOMBIE;
++    if (t.O & REACTIVE_IN_HEAP) {
+       deleteFromHeap(t, dirtyQueue);
+       insertIntoHeap(t, zombieQueue);
+     }
+     markDisposal(t);
+-    t = t.ge;
++    t = t.me;
+   }
+ }
+ function dispose(e) {
+@@ -763,39 +836,48 @@ function dispose(e) {
+     t = unlinkSubs(t);
+   } while (t !== null);
+   e.C = null;
+-  e.Pe = null;
++  e.ye = null;
+   disposeChildren(e, true);
+ }
+ function disposeChildren(e, t = false, n) {
+-  if (e.R & REACTIVE_DISPOSED) return;
+-  if (t) e.R = REACTIVE_DISPOSED;
+-  if (t && e.L) e.De = null;
+-  let i = n ? e.ye : e.Ce;
+-  while (i) {
+-    const e = i.ge;
+-    if (i.C) {
+-      const e = i;
+-      deleteFromHeap(e, e.R & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
++  const i = e.O;
++  if (i & REACTIVE_DISPOSED) return;
++  if (t) e.O = i | REACTIVE_DISPOSED;
++  if (t && e.L) e.be = null;
++  let r = n ? e.Ie : e.ve;
++  while (r) {
++    const e = r.me;
++    if (r.C) {
++      const e = r;
++      deleteFromHeap(e, e.O & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
+       let t = e.C;
+       do {
+         t = unlinkSubs(t);
+       } while (t !== null);
+       e.C = null;
+-      e.Pe = null;
++      e.ye = null;
+     }
+-    disposeChildren(i, true);
+-    i = e;
++    disposeChildren(r, true);
++    r = e;
+   }
+   if (n) {
+-    e.ye = null;
++    e.Ie = null;
+   } else {
+-    e.Ce = null;
+-    e.ve = 0;
++    e.ve = null;
++    e.Ve = 0;
++  }
++  if (t && !n && !(i & REACTIVE_ZOMBIE) && e.i !== null && !(e.i.O & REACTIVE_DISPOSED)) {
++    const t = e.we;
++    const n = e.me;
++    if (t !== null) t.me = n;
++    else e.i.ve = n;
++    if (n !== null) n.we = t;
++    e.we = null;
+   }
+   runDisposal(e, n);
+ }
+ function runDisposal(e, t) {
+-  let n = t ? e.me : e.we;
++  let n = t ? e.pe : e.Le;
+   if (!n) return;
+   if (Array.isArray(n)) {
+     for (let e = 0; e < n.length; e++) {
+@@ -805,12 +887,12 @@ function runDisposal(e, t) {
+   } else {
+     n.call(n);
+   }
+-  t ? (e.me = null) : (e.we = null);
++  t ? (e.pe = null) : (e.Le = null);
+ }
+ function childId(e, t) {
+   let n = e;
+-  while (n.Ee & CONFIG_TRANSPARENT && n.i) n = n.i;
+-  if (n.id != null) return formatId(n.id, t ? n.ve++ : n.ve);
++  while (n.de & CONFIG_TRANSPARENT && n.i) n = n.i;
++  if (n.id != null) return formatId(n.id, t ? n.Ve++ : n.Ve);
+   throw new Error("Cannot get child id from owner without an id");
+ }
+ function getNextChildId(e) {
+@@ -833,102 +915,105 @@ function getOwner() {
+ }
+ function cleanup(e) {
+   if (!context) return e;
+-  if (!context.we) context.we = e;
+-  else if (Array.isArray(context.we)) context.we.push(e);
+-  else context.we = [context.we, e];
++  if (!context.Le) context.Le = e;
++  else if (Array.isArray(context.Le)) context.Le.push(e);
++  else context.Le = [context.Le, e];
+   return e;
+ }
+ function isDisposed(e) {
+-  return !!(e.R & (REACTIVE_DISPOSED | REACTIVE_ZOMBIE));
++  return !!(e.O & (REACTIVE_DISPOSED | REACTIVE_ZOMBIE));
++}
++function disposeRootSelf(e = true) {
++  disposeChildren(this, e);
+ }
+ function createOwner(e) {
+   const t = context;
+   const n = e?.transparent ?? false;
+   const i = {
+     id: e?.id ?? (n ? t?.id : t?.id != null ? getNextChildId(t) : undefined),
+-    Ee: n ? CONFIG_TRANSPARENT : 0,
++    de: n ? CONFIG_TRANSPARENT : 0,
+     t: true,
+     u: t?.t ? t.u : t,
+-    Ce: null,
+-    ge: null,
+-    we: null,
+-    $: t?.$ ?? globalQueue,
+-    Ve: t?.Ve || defaultContext,
+-    ve: 0,
++    ve: null,
+     me: null,
+-    ye: null,
++    we: null,
++    Le: null,
++    Z: t?.Z ?? globalQueue,
++    Ue: t?.Ue || defaultContext,
++    Ve: 0,
++    pe: null,
++    Ie: null,
+     i: t,
+-    dispose(e = true) {
+-      disposeChildren(i, e);
+-    }
++    dispose: disposeRootSelf
+   };
+   if (t) {
+-    const e = t.Ce;
++    const e = t.ve;
+     if (e === null) {
+-      t.Ce = i;
++      t.ve = i;
+     } else {
+-      i.ge = e;
+-      t.Ce = i;
++      i.me = e;
++      e.we = i;
++      t.ve = i;
+     }
+   }
+   return i;
+ }
+ function createRoot(e, t) {
+   const n = createOwner(t);
+-  return runWithOwner(n, () => e(n.dispose));
++  return runWithOwner(n, () => e(() => n.dispose()));
+ }
+ function addPendingSource(e, t) {
+-  if (e.Re === t || e._e?.has(t)) return false;
+-  if (!e.Re) {
+-    e.Re = t;
++  if (e.he === t || e.Ne?.has(t)) return false;
++  if (!e.he) {
++    e.he = t;
+     return true;
+   }
+-  if (!e._e) {
+-    e._e = new Set([e.Re, t]);
++  if (!e.Ne) {
++    e.Ne = new Set([e.he, t]);
+   } else {
+-    e._e.add(t);
++    e.Ne.add(t);
+   }
+-  e.Re = undefined;
++  e.he = undefined;
+   return true;
+ }
+ function removePendingSource(e, t) {
+-  if (e.Re) {
+-    if (e.Re !== t) return false;
+-    e.Re = undefined;
++  if (e.he) {
++    if (e.he !== t) return false;
++    e.he = undefined;
+     return true;
+   }
+-  if (!e._e?.delete(t)) return false;
+-  if (e._e.size === 1) {
+-    e.Re = e._e.values().next().value;
+-    e._e = undefined;
+-  } else if (e._e.size === 0) {
+-    e._e = undefined;
++  if (!e.Ne?.delete(t)) return false;
++  if (e.Ne.size === 1) {
++    e.he = e.Ne.values().next().value;
++    e.Ne = undefined;
++  } else if (e.Ne.size === 0) {
++    e.Ne = undefined;
+   }
+   return true;
+ }
+ function clearPendingSources(e) {
+-  e.Re = undefined;
+-  e._e?.clear();
+-  e._e = undefined;
++  e.he = undefined;
++  e.Ne?.clear();
++  e.Ne = undefined;
+ }
+ function setPendingError(e, t, n) {
+   if (!t) {
+-    e.Te = null;
++    e.Se = null;
+     return;
+   }
+   if (n instanceof NotReadyError && n.source === t) {
+-    e.Te = n;
++    e.Se = n;
+     return;
+   }
+-  const i = e.Te;
++  const i = e.Se;
+   if (!(i instanceof NotReadyError) || i.source !== t) {
+-    e.Te = new NotReadyError(t);
++    e.Se = new NotReadyError(t);
+   }
+ }
+ function forEachDependent(e, t) {
+-  for (let n = e.I; n !== null; n = n.h) t(n.p);
++  for (let n = e.I; n !== null; n = n.p) t(n.h);
+   for (let n = e.N; n !== null; n = n.A) {
+-    for (let e = n.I; e !== null; e = e.h) t(e.p);
++    for (let e = n.I; e !== null; e = e.p) t(e.h);
+   }
+ }
+ function settlePendingSource(e) {
+@@ -937,30 +1022,30 @@ function settlePendingSource(e) {
+   const settle = i => {
+     if (n.has(i) || !removePendingSource(i, e)) return;
+     n.add(i);
+-    i.Se = clock;
+-    const r = i.Re ?? i._e?.values().next().value;
++    i._e = clock;
++    const r = i.he ?? i.Ne?.values().next().value;
+     if (r) {
+       setPendingError(i, r);
+       updatePendingSignal(i);
+     } else {
+-      i.Oe &= ~STATUS_PENDING;
++      i.Re &= ~STATUS_PENDING;
+       setPendingError(i);
+       updatePendingSignal(i);
+-      if (i.be) {
+-        if (i.M === EFFECT_TRACKED) {
++      if (i.Ge) {
++        if (i.K === EFFECT_TRACKED) {
+           const e = i;
+-          if (!e.j) {
+-            e.j = true;
+-            e.$.enqueue(EFFECT_USER, e.K);
++          if (!e.Y) {
++            e.Y = true;
++            e.Z.enqueue(EFFECT_USER, e.B);
+           }
+         } else {
+-          const e = i.R & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue;
++          const e = i.O & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue;
+           if (e.P > i.o) e.P = i.o;
+           insertIntoHeap(i, e);
+         }
+         t = true;
+       }
+-      i.be = false;
++      i.Ge = false;
+     }
+     forEachDependent(i, settle);
+   };
+@@ -968,46 +1053,51 @@ function settlePendingSource(e) {
+   if (t) schedule();
+ }
+ function handleAsync(e, t, n) {
+-  const i = typeof t === "object" && t !== null;
+-  const r = i && untrack(() => t[Symbol.asyncIterator]);
+-  const s = !r && i && untrack(() => typeof t.then === "function");
+-  if (!s && !r) {
+-    e.De = null;
++  let i = false;
++  let r = false;
++  if (typeof t === "object" && t !== null) {
++    untrack(() => {
++      i = t[Symbol.asyncIterator];
++      r = !i && typeof t.then === "function";
++    });
++  }
++  if (!r && !i) {
++    e.be = null;
+     return t;
+   }
+-  e.De = t;
+-  let o;
++  e.be = t;
++  let s;
+   const handleError = n => {
+-    if (e.De !== t) return;
++    if (e.be !== t) return;
+     globalQueue.initTransition(resolveTransition(e));
+     notifyStatus(e, n instanceof NotReadyError ? STATUS_PENDING : STATUS_ERROR, n);
+-    e.Se = clock;
++    e._e = clock;
+   };
+   const asyncWrite = (i, r) => {
+-    if (e.De !== t) return;
+-    if (e.R & (REACTIVE_DIRTY | REACTIVE_OPTIMISTIC_DIRTY)) return;
++    if (e.be !== t) return;
++    if (e.O & (REACTIVE_DIRTY | REACTIVE_OPTIMISTIC_DIRTY)) return;
+     globalQueue.initTransition(resolveTransition(e));
+-    const s = !!(e.Oe & STATUS_UNINITIALIZED);
++    const s = !!(e.Re & STATUS_UNINITIALIZED);
+     clearStatus(e);
+     const o = resolveLane(e);
+-    if (o) o.W.delete(e);
++    if (o) o.j.delete(e);
+     if (n) n(i);
+-    else if (e.G !== undefined) {
+-      if (e.G !== undefined && e.G !== NOT_PENDING) e.U = i;
++    else if (e.W !== undefined) {
++      if (e.W !== undefined && e.W !== NOT_PENDING) e.k = i;
+       else {
+-        e.ne = i;
++        e.ie = i;
+         insertSubs(e);
+       }
+-      e.Se = clock;
++      e._e = clock;
+     } else if (o) {
+-      const t = e.M;
+-      const n = e.ne;
+-      const r = e.Le;
++      const t = e.K;
++      const n = e.ie;
++      const r = e.Fe;
+       if ((!t && s) || !r || !r(i, n)) {
+-        e.ne = i;
+-        e.Se = clock;
+-        if (e.Ue) {
+-          setSignal(e.Ue, i);
++        e.ie = i;
++        e._e = clock;
++        if (e.ke) {
++          setSignal(e.ke, i);
+         }
+         insertSubs(e, true);
+       }
+@@ -1019,13 +1109,13 @@ function handleAsync(e, t, n) {
+     flush();
+     r?.();
+   };
+-  if (s) {
++  if (r) {
+     let n = false,
+       i = true;
+     t.then(
+       e => {
+         if (i) {
+-          o = e;
++          s = e;
+           n = true;
+         } else asyncWrite(e);
+       },
+@@ -1039,7 +1129,7 @@ function handleAsync(e, t, n) {
+       throw new NotReadyError(context);
+     }
+   }
+-  if (r) {
++  if (i) {
+     const n = t[Symbol.asyncIterator]();
+     let i = false;
+     let r = false;
+@@ -1054,16 +1144,16 @@ function handleAsync(e, t, n) {
+       } catch {}
+     });
+     const iterate = () => {
+-      let s,
++      let o,
+         u = false,
+         c = true;
+       n.next().then(
+         n => {
+           if (c) {
+-            s = n;
++            o = n;
+             u = true;
+             if (n.done) r = true;
+-          } else if (e.De !== t) {
++          } else if (e.be !== t) {
+             return;
+           } else if (!n.done) asyncWrite(n.value, iterate);
+           else {
+@@ -1073,79 +1163,79 @@ function handleAsync(e, t, n) {
+           }
+         },
+         n => {
+-          if (!c && e.De === t) {
++          if (!c && e.be === t) {
+             r = true;
+             handleError(n);
+           }
+         }
+       );
+       c = false;
+-      if (u && !s.done) {
+-        o = s.value;
++      if (u && !o.done) {
++        s = o.value;
+         i = true;
+         return iterate();
+       }
+-      return u && s.done;
++      return u && o.done;
+     };
+-    const s = iterate();
+-    if (!i && !s) {
++    const o = iterate();
++    if (!i && !o) {
+       globalQueue.initTransition(resolveTransition(e));
+       throw new NotReadyError(context);
+     }
+   }
+-  return o;
++  return s;
+ }
+ function clearStatus(e, t = false) {
+-  clearPendingSources(e);
+-  e.be = false;
+-  e.Oe = t ? 0 : e.Oe & STATUS_UNINITIALIZED;
+-  setPendingError(e);
+-  updatePendingSignal(e);
+-  e.Ge?.();
++  if (e.he || e.Ne) clearPendingSources(e);
++  if (e.Ge) e.Ge = false;
++  e.Re = t ? 0 : e.Re & STATUS_UNINITIALIZED;
++  if (e.Se) setPendingError(e);
++  if (e.We) updatePendingSignal(e);
++  if (e.xe) e.xe();
+ }
+ function notifyStatus(e, t, n, i, r) {
+   if (t === STATUS_ERROR && !(n instanceof StatusError) && !(n instanceof NotReadyError))
+     n = new StatusError(e, n);
+   const s = t === STATUS_PENDING && n instanceof NotReadyError ? n.source : undefined;
+   const o = s === e;
+-  const u = t === STATUS_PENDING && e.G !== undefined && !o;
++  const u = t === STATUS_PENDING && e.W !== undefined && !o;
+   const c = u && hasActiveOverride(e);
+   if (!i) {
+     if (t === STATUS_PENDING && s) {
+       addPendingSource(e, s);
+-      e.Oe = STATUS_PENDING | (e.Oe & STATUS_UNINITIALIZED);
++      e.Re = STATUS_PENDING | (e.Re & STATUS_UNINITIALIZED);
+       setPendingError(e, s, n);
+     } else {
+       clearPendingSources(e);
+-      e.Oe = t | (t !== STATUS_ERROR ? e.Oe & STATUS_UNINITIALIZED : 0);
+-      e.Te = n;
++      e.Re = t | (t !== STATUS_ERROR ? e.Re & STATUS_UNINITIALIZED : 0);
++      e.Se = n;
+     }
+     updatePendingSignal(e);
+   }
+   if (r && !i) {
+     assignOrMergeLane(e, r);
+   }
+-  const a = i || c;
+-  const l = i || u ? undefined : r;
+-  if (e.Ge) {
++  const l = i || c;
++  const a = i || u ? undefined : r;
++  if (e.xe) {
+     if (i && t === STATUS_PENDING) {
+       return;
+     }
+-    if (a) {
+-      e.Ge(t, n);
++    if (l) {
++      e.xe(t, n);
+     } else {
+-      e.Ge();
++      e.xe();
+     }
+     return;
+   }
+   forEachDependent(e, e => {
+-    e.Se = clock;
++    e._e = clock;
+     if (
+-      (t === STATUS_PENDING && s && e.Re !== s && !e._e?.has(s)) ||
+-      (t !== STATUS_PENDING && (e.Te !== n || e.Re || e._e))
++      (t === STATUS_PENDING && s && e.he !== s && !e.Ne?.has(s)) ||
++      (t !== STATUS_PENDING && (e.Se !== n || e.he || e.Ne))
+     ) {
+-      if (!a && !e.Z) globalQueue.ue.push(e);
+-      notifyStatus(e, t, n, a, l);
++      if (!l && !e.J) queuePendingNode(e);
++      notifyStatus(e, t, n, l, a);
+     }
+   });
+ }
+@@ -1172,11 +1262,12 @@ function enableExternalSource(e) {
+     externalSourceConfig = { factory: t, untrack: n };
+   }
+ }
+-GlobalQueue.ce = recompute;
++GlobalQueue.le = recompute;
+ GlobalQueue.ae = disposeChildren;
+ let tracking = false;
+ let stale = false;
+ let refreshing = false;
++let refreshTrigger = false;
+ let pendingCheckActive = false;
+ let foundPending = false;
+ let latestReadActive = false;
+@@ -1186,7 +1277,7 @@ let snapshotCaptureActive = false;
+ let snapshotSources = null;
+ function ownerInSnapshotScope(e) {
+   while (e) {
+-    if (e.ke) return true;
++    if (e.He) return true;
+     e = e.i;
+   }
+   return false;
+@@ -1196,38 +1287,38 @@ function setSnapshotCapture(e) {
+   if (e && !snapshotSources) snapshotSources = new Set();
+ }
+ function markSnapshotScope(e) {
+-  e.ke = true;
++  e.He = true;
+ }
+ function releaseSnapshotScope(e) {
+-  e.ke = false;
++  e.He = false;
+   releaseSubtree(e);
+   schedule();
+ }
+ function releaseSubtree(e) {
+-  let t = e.Ce;
++  let t = e.ve;
+   while (t) {
+-    if (t.ke) {
+-      t = t.ge;
++    if (t.He) {
++      t = t.me;
+       continue;
+     }
+     if (t.L) {
+       const e = t;
+-      e.Ee &= ~CONFIG_IN_SNAPSHOT_SCOPE;
+-      if (e.R & REACTIVE_SNAPSHOT_STALE) {
+-        e.R &= ~REACTIVE_SNAPSHOT_STALE;
+-        e.R |= REACTIVE_DIRTY;
++      e.de &= ~CONFIG_IN_SNAPSHOT_SCOPE;
++      if (e.O & REACTIVE_SNAPSHOT_STALE) {
++        e.O &= ~REACTIVE_SNAPSHOT_STALE;
++        e.O |= REACTIVE_DIRTY;
+         if (dirtyQueue.P > e.o) dirtyQueue.P = e.o;
+         insertIntoHeap(e, dirtyQueue);
+       }
+     }
+     releaseSubtree(t);
+-    t = t.ge;
++    t = t.me;
+   }
+ }
+ function clearSnapshots() {
+   if (snapshotSources) {
+     for (const e of snapshotSources) {
+-      delete e.de;
++      delete e.Oe;
+       delete e[STORE_SNAPSHOT_PROPS];
+     }
+     snapshotSources = null;
+@@ -1235,236 +1326,315 @@ function clearSnapshots() {
+   snapshotCaptureActive = false;
+ }
+ function recompute(e, t = false) {
+-  const n = e.M;
++  const n = e.K;
+   if (!t) {
+-    if (e.Z && (!n || activeTransition) && activeTransition !== e.Z)
+-      globalQueue.initTransition(e.Z);
+-    deleteFromHeap(e, e.R & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
+-    e.De = null;
+-    if (e.Z || n === EFFECT_TRACKED) disposeChildren(e);
+-    else {
++    if (e.J && (!n || activeTransition) && activeTransition !== e.J)
++      globalQueue.initTransition(e.J);
++    deleteFromHeap(e, e.O & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
++    e.be = null;
++    if (e.J || n === EFFECT_TRACKED) disposeChildren(e);
++    else if (e.ve !== null || e.Le !== null) {
+       markDisposal(e);
+-      e.me = e.we;
+-      e.ye = e.Ce;
+-      e.we = null;
+-      e.Ce = null;
+-      e.ve = 0;
+-    }
+-  }
+-  let i = !!(e.R & REACTIVE_OPTIMISTIC_DIRTY);
+-  const r = e.G !== undefined && e.G !== NOT_PENDING;
+-  const s = !!(e.Oe & STATUS_PENDING);
+-  const o = !!(e.Oe & STATUS_UNINITIALIZED);
++      e.pe = e.Le;
++      e.Ie = e.ve;
++      e.Le = null;
++      e.ve = null;
++      e.Ve = 0;
++    } else;
++  }
++  let i = !!(e.O & REACTIVE_OPTIMISTIC_DIRTY);
++  const r = e.W !== undefined && e.W !== NOT_PENDING;
++  const s = !!(e.Re & STATUS_PENDING);
++  const o = !!(e.Re & STATUS_UNINITIALIZED);
+   const u = context;
+   context = e;
+-  e.Pe = null;
+-  e.R = REACTIVE_RECOMPUTING_DEPS;
+-  e.Se = clock;
+-  let c = e.U === NOT_PENDING ? e.ne : e.U;
+-  let a = e.o;
+-  let l = tracking;
++  e.ye = null;
++  e.O = REACTIVE_RECOMPUTING_DEPS;
++  e._e = clock;
++  let c = e.k === NOT_PENDING ? e.ie : e.k;
++  let l = e.o;
++  let a = tracking;
+   let f = currentOptimisticLane;
+   tracking = true;
+   if (i) {
+     const t = resolveLane(e);
+     if (t) currentOptimisticLane = t;
+-  } else if (activeTransition && !t && activeTransition.q.length) {
++  } else if (activeTransition && !t && activeTransition.G.length) {
+     for (let t = e.C; t; t = t.D) {
+       const n = t.m;
+-      if (n.R & REACTIVE_OPTIMISTIC_DIRTY) {
++      if (n.O & REACTIVE_OPTIMISTIC_DIRTY) {
+         const t = resolveLane(n);
+         if (t) {
+           i = true;
+           currentOptimisticLane = t;
+-          e.R |= REACTIVE_OPTIMISTIC_DIRTY;
++          e.O |= REACTIVE_OPTIMISTIC_DIRTY;
+           assignOrMergeLane(e, t);
+           break;
+         }
+       }
+     }
+   }
++  const E = n && n !== EFFECT_USER;
++  const T = stale;
++  if (E) stale = true;
+   try {
+-    const n = e.De;
+-    const i = e.L(c);
+-    c = e.De !== n ? i : handleAsync(e, i);
++    if (!false && e.de & CONFIG_SYNC) {
++      c = e.L(c);
++      e.be = null;
++    } else {
++      const t = e.be;
++      const n = e.L(c);
++      const i = typeof n === "object" && n !== null;
++      const r = e.be !== t;
++      c = r || !i ? n : handleAsync(e, n);
++      if (!r && !i) e.be = null;
++    }
+     clearStatus(e, t);
+-    const r = resolveLane(e);
+-    if (r) {
+-      r.W.delete(e);
+-      updatePendingSignal(r.ie);
++    if (e.ne) {
++      const t = resolveLane(e);
++      if (t) {
++        t.j.delete(e);
++        updatePendingSignal(t.re);
++      }
+     }
+   } catch (t) {
+     if (t instanceof NotReadyError && currentOptimisticLane) {
+       const t = findLane(currentOptimisticLane);
+-      if (t.ie !== e) {
+-        t.W.add(e);
+-        e.te = t;
+-        updatePendingSignal(t.ie);
++      if (t.re !== e) {
++        t.j.add(e);
++        e.ne = t;
++        updatePendingSignal(t.re);
+       }
+     }
+-    if (t instanceof NotReadyError) e.be = true;
++    if (t instanceof NotReadyError) e.Ge = true;
+     notifyStatus(
+       e,
+       t instanceof NotReadyError ? STATUS_PENDING : STATUS_ERROR,
+       t,
+       undefined,
+-      t instanceof NotReadyError ? e.te : undefined
++      t instanceof NotReadyError ? e.ne : undefined
+     );
+   } finally {
+-    tracking = l;
+-    e.R = REACTIVE_NONE | (t ? e.R & REACTIVE_SNAPSHOT_STALE : 0);
++    tracking = a;
++    if (E) stale = T;
++    e.O = REACTIVE_NONE | (t ? e.O & REACTIVE_SNAPSHOT_STALE : 0);
+     context = u;
+   }
+-  if (!e.Te) {
+-    const u = e.Pe;
+-    let l = u !== null ? u.D : e.C;
+-    if (l !== null) {
++  if (!e.Se) {
++    const u = e.ye;
++    let a = u !== null ? u.D : e.C;
++    if (a !== null) {
+       do {
+-        l = unlinkSubs(l);
+-      } while (l !== null);
++        a = unlinkSubs(a);
++      } while (a !== null);
+       if (u !== null) u.D = null;
+       else e.C = null;
+     }
+-    const f = r ? e.G : e.U === NOT_PENDING ? e.ne : e.U;
+-    const E = (!n && o) || !e.Le || !e.Le(f, c);
++    const f = r ? e.W : e.k === NOT_PENDING ? e.ie : e.k;
++    const E = (!n && o) || !e.Fe || !e.Fe(f, c);
++    if (n && E) {
++      e.Y = !e.Se;
++      if (!t) e.Z.enqueue(n, GlobalQueue.fe.bind(null, e));
++    }
+     if (E) {
+-      const o = r ? e.G : undefined;
+-      if (t || (n && activeTransition !== e.Z) || i) {
+-        e.ne = c;
++      const o = r ? e.W : undefined;
++      if (t || (n && activeTransition !== e.J) || i) {
++        e.ie = c;
+         if (r && i) {
+-          e.G = c;
+-          e.U = c;
++          e.W = c;
++          e.k = c;
+         }
+-      } else e.U = c;
+-      if (r && !i && s && !e.pe) e.G = c;
+-      if (!r || i || e.G !== o) insertSubs(e, i || r);
++      } else e.k = c;
++      if (r && !i && s && !e.Ce) e.W = c;
++      if (!r || i || e.W !== o) insertSubs(e, i || r);
+     } else if (r) {
+-      e.U = c;
+-    } else if (e.o != a) {
+-      for (let t = e.I; t !== null; t = t.h) {
+-        insertIntoHeapHeight(t.p, t.p.R & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
++      e.k = c;
++    } else if (e.o != l) {
++      for (let t = e.I; t !== null; t = t.p) {
++        insertIntoHeapHeight(t.h, t.h.O & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
+       }
+     }
+   }
+   currentOptimisticLane = f;
+-  (!t || e.Oe & STATUS_PENDING) && !e.Z && !(activeTransition && r) && globalQueue.ue.push(e);
+-  e.Z && n && activeTransition !== e.Z && runInTransition(e.Z, () => recompute(e));
++  const d =
++    e.k !== NOT_PENDING ||
++    e.Ie !== null ||
++    e.pe !== null ||
++    !!(e.Re & (STATUS_PENDING | STATUS_UNINITIALIZED));
++  d && (!t || e.Re & STATUS_PENDING) && !e.J && !(activeTransition && r) && queuePendingNode(e);
++  e.J && n && activeTransition !== e.J && runInTransition(e.J, () => recompute(e));
+ }
+ function updateIfNecessary(e) {
+-  if (e.R & REACTIVE_CHECK) {
++  if (e.O & REACTIVE_CHECK) {
+     for (let t = e.C; t; t = t.D) {
+       const n = t.m;
+       const i = n.V || n;
+       if (i.L) {
+         updateIfNecessary(i);
+       }
+-      if (e.R & REACTIVE_DIRTY) {
++      if (e.O & REACTIVE_DIRTY) {
+         break;
+       }
+     }
+   }
+-  if (e.R & (REACTIVE_DIRTY | REACTIVE_OPTIMISTIC_DIRTY) || (e.Te && e.Se < clock && !e.De)) {
++  if (e.O & (REACTIVE_DIRTY | REACTIVE_OPTIMISTIC_DIRTY) || (e.Se && e._e < clock && !e.be)) {
+     recompute(e);
+   }
+-  e.R = e.R & (REACTIVE_SNAPSHOT_STALE | REACTIVE_IN_HEAP | REACTIVE_IN_HEAP_HEIGHT);
++  e.O = e.O & (REACTIVE_SNAPSHOT_STALE | REACTIVE_IN_HEAP | REACTIVE_IN_HEAP_HEIGHT);
+ }
+ function computed(e, t) {
+   const n = t?.transparent ?? false;
+   const i = {
+     id: t?.id ?? (n ? context?.id : context?.id != null ? getNextChildId(context) : undefined),
+-    Ee:
++    de:
+       (n ? CONFIG_TRANSPARENT : 0) |
+       (t?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
+       (!context || t?.lazy ? CONFIG_AUTO_DISPOSE : 0) |
++      (t?.sync ? CONFIG_SYNC : 0) |
+       (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
+-    Le: t?.equals != null ? t.equals : isEqual,
+-    k: t?.unobserved,
+-    we: null,
+-    $: context?.$ ?? globalQueue,
+-    Ve: context?.Ve ?? defaultContext,
+-    ve: 0,
++    Fe: t?.equals != null ? t.equals : isEqual,
++    H: t?.unobserved,
++    Le: null,
++    Z: context?.Z ?? globalQueue,
++    Ue: context?.Ue ?? defaultContext,
++    Ve: 0,
+     L: e,
+-    ne: undefined,
++    ie: undefined,
+     o: 0,
+     N: null,
+     S: undefined,
+     T: null,
+     C: null,
+-    Pe: null,
++    ye: null,
+     I: null,
+-    Ae: null,
++    De: null,
+     i: context,
+-    ge: null,
+-    Ce: null,
+-    R: t?.lazy ? REACTIVE_LAZY : REACTIVE_NONE,
+-    Oe: STATUS_UNINITIALIZED,
+-    Se: clock,
+-    U: NOT_PENDING,
+     me: null,
++    we: null,
++    ve: null,
++    O: t?.lazy ? REACTIVE_LAZY : REACTIVE_NONE,
++    Re: STATUS_UNINITIALIZED,
++    _e: clock,
++    k: NOT_PENDING,
++    pe: null,
++    Ie: null,
++    be: null,
++    J: null
++  };
++  setupComputedNode(i, t);
++  return i;
++}
++function createEffectNode(e, t, n, i, r, s) {
++  const o = s?.transparent ?? false;
++  const u = {
++    id: s?.id ?? (o ? context?.id : context?.id != null ? getNextChildId(context) : undefined),
++    de:
++      (o ? CONFIG_TRANSPARENT : 0) |
++      (s?.ownedWrite ? CONFIG_OWNED_WRITE : 0) |
++      (s?.sync ? CONFIG_SYNC : 0) |
++      (snapshotCaptureActive && ownerInSnapshotScope(context) ? CONFIG_IN_SNAPSHOT_SCOPE : 0),
++    Fe: false,
++    H: s?.unobserved,
++    Le: null,
++    Z: context?.Z ?? globalQueue,
++    Ue: context?.Ue ?? defaultContext,
++    Ve: 0,
++    L: e,
++    ie: undefined,
++    o: 0,
++    N: null,
++    S: undefined,
++    T: null,
++    C: null,
+     ye: null,
++    I: null,
+     De: null,
+-    Z: null
++    i: context,
++    me: null,
++    we: null,
++    ve: null,
++    O: REACTIVE_LAZY,
++    Re: STATUS_UNINITIALIZED,
++    _e: clock,
++    k: NOT_PENDING,
++    pe: null,
++    Ie: null,
++    be: null,
++    J: null,
++    Y: false,
++    Me: undefined,
++    Qe: t,
++    je: n,
++    $e: undefined,
++    Ke: false,
++    K: i,
++    xe: r
+   };
+-  i.T = i;
+-  const r = context?.t ? context.u : context;
++  setupComputedNode(u, lazyOptions);
++  return u;
++}
++const lazyOptions = { lazy: true };
++function setupComputedNode(e, t) {
++  e.T = e;
++  const n = context?.t ? context.u : context;
+   if (context) {
+-    const e = context.Ce;
+-    if (e === null) {
+-      context.Ce = i;
++    const t = context.ve;
++    if (t === null) {
++      context.ve = e;
+     } else {
+-      i.ge = e;
+-      context.Ce = i;
++      e.me = t;
++      t.we = e;
++      context.ve = e;
+     }
+   }
+-  if (r) i.o = r.o + 1;
++  if (n) e.o = n.o + 1;
+   if (externalSourceConfig) {
+-    const e = signal(undefined, { equals: false, ownedWrite: true });
+-    const t = externalSourceConfig.factory(i.L, () => {
+-      setSignal(e, undefined);
++    const t = signal(undefined, { equals: false, ownedWrite: true });
++    const n = externalSourceConfig.factory(e.L, () => {
++      setSignal(t, undefined);
+     });
+-    cleanup(() => t.dispose());
+-    i.L = n => {
+-      read(e);
+-      return t.track(n);
++    cleanup(() => n.dispose());
++    e.L = e => {
++      read(t);
++      return n.track(e);
+     };
+   }
+-  !t?.lazy && recompute(i, true);
++  !t?.lazy && recompute(e, true);
+   if (snapshotCaptureActive && !t?.lazy) {
+-    if (!(i.Oe & STATUS_PENDING)) {
+-      i.de = i.ne === undefined ? NO_SNAPSHOT : i.ne;
+-      snapshotSources.add(i);
++    if (!(e.Re & STATUS_PENDING)) {
++      e.Oe = e.ie === undefined ? NO_SNAPSHOT : e.ie;
++      snapshotSources.add(e);
+     }
+   }
+-  return i;
+ }
+ function signal(e, t, n = null) {
+   const i = {
+-    Le: t?.equals != null ? t.equals : isEqual,
+-    Ee: (t?.ownedWrite ? CONFIG_OWNED_WRITE : 0) | (t?.Fe ? CONFIG_NO_SNAPSHOT : 0),
+-    k: t?.unobserved,
+-    ne: e,
++    Fe: t?.equals != null ? t.equals : isEqual,
++    de: (t?.ownedWrite ? CONFIG_OWNED_WRITE : 0) | (t?.Ye ? CONFIG_NO_SNAPSHOT : 0),
++    H: t?.unobserved,
++    ie: e,
+     I: null,
+-    Ae: null,
+-    Se: clock,
++    De: null,
++    _e: clock,
+     V: n,
+     A: n?.N || null,
+-    U: NOT_PENDING
++    k: NOT_PENDING
+   };
+   n && (n.N = i);
+-  if (snapshotCaptureActive && !(i.Ee & CONFIG_NO_SNAPSHOT) && !((n?.Oe ?? 0) & STATUS_PENDING)) {
+-    i.de = e === undefined ? NO_SNAPSHOT : e;
++  if (snapshotCaptureActive && !(i.de & CONFIG_NO_SNAPSHOT) && !((n?.Re ?? 0) & STATUS_PENDING)) {
++    i.Oe = e === undefined ? NO_SNAPSHOT : e;
+     snapshotSources.add(i);
+   }
+   return i;
+ }
+ function optimisticSignal(e, t) {
+   const n = signal(e, t);
+-  n.G = NOT_PENDING;
++  n.W = NOT_PENDING;
+   return n;
+ }
+ function optimisticComputed(e, t) {
+   const n = computed(e, t);
+-  n.G = NOT_PENDING;
++  n.W = NOT_PENDING;
+   return n;
+ }
+ function isEqual(e, t) {
+@@ -1486,7 +1656,7 @@ function read(e) {
+     const t = getLatestValueComputed(e);
+     const n = latestReadActive;
+     latestReadActive = false;
+-    const i = e.G !== undefined && e.G !== NOT_PENDING ? e.G : e.ne;
++    const i = e.W !== undefined && e.W !== NOT_PENDING ? e.W : e.ie;
+     let r;
+     try {
+       r = read(t);
+@@ -1496,11 +1666,11 @@ function read(e) {
+     } finally {
+       latestReadActive = n;
+     }
+-    if (t.Oe & STATUS_PENDING) return i;
+-    if (stale && currentOptimisticLane && t.te) {
+-      const e = findLane(t.te);
++    if (t.Re & STATUS_PENDING) return i;
++    if (stale && currentOptimisticLane && t.ne) {
++      const e = findLane(t.ne);
+       const n = findLane(currentOptimisticLane);
+-      if (e !== n && e.W.size > 0) {
++      if (e !== n && e.j.size > 0) {
+         return i;
+       }
+     }
+@@ -1510,8 +1680,8 @@ function read(e) {
+     const t = e.V;
+     const n = pendingCheckActive;
+     pendingCheckActive = false;
+-    if (t && e.G !== undefined) {
+-      if (e.G !== NOT_PENDING && (t.De || !!(t.Oe & STATUS_PENDING))) {
++    if (t && e.W !== undefined) {
++      if (e.W !== NOT_PENDING && (t.be || !!(t.Re & STATUS_PENDING))) {
+         foundPending = true;
+       }
+       let n = context;
+@@ -1524,26 +1694,43 @@ function read(e) {
+       if (t && read(getPendingSignal(t))) foundPending = true;
+     }
+     pendingCheckActive = n;
+-    return e.ne;
++    return e.ie;
+   }
+   let t = context;
+   if (t?.t) t = t.u;
+   const n = e;
+   if (typeof n.L === "function") {
+     const t = e;
+-    if (refreshing && !(t.R & REACTIVE_DISPOSED)) recompute(t);
+-    if (t.R & REACTIVE_LAZY) {
+-      t.R &= ~REACTIVE_LAZY;
++    if (refreshTrigger && !(t.O & REACTIVE_DISPOSED)) {
++      refreshTrigger = false;
++      recompute(t);
++      refreshTrigger = true;
++    }
++    if (t.O & REACTIVE_LAZY) {
++      t.O &= ~REACTIVE_LAZY;
+       recompute(t, true);
+-    } else if (t.R & REACTIVE_DISPOSED) {
++    } else if (t.O & REACTIVE_DISPOSED) {
+       recompute(t, true);
+     }
+   }
+   const i = e.V || e;
++  if (
++    !n.L &&
++    i === e &&
++    e.W === undefined &&
++    e.Oe === undefined &&
++    activeTransition === null &&
++    currentOptimisticLane === null &&
++    !snapshotCaptureActive &&
++    true
++  ) {
++    if (t && tracking) link(e, t);
++    return !t || e.k === NOT_PENDING ? e.ie : e.k;
++  }
+   if (t && tracking) {
+     link(e, t);
+     if (i.L) {
+-      const n = e.R & REACTIVE_ZOMBIE;
++      const n = e.O & REACTIVE_ZOMBIE;
+       if (i.o >= (n ? zombieQueue.P : dirtyQueue.P)) {
+         markNode(t);
+         markHeap(n ? zombieQueue : dirtyQueue);
+@@ -1555,71 +1742,71 @@ function read(e) {
+       }
+     }
+   }
+-  if (i.Oe & STATUS_PENDING) {
+-    if (t && !(stale && i.Z && activeTransition !== i.Z)) {
++  if (i.Re & STATUS_PENDING) {
++    if (t && !(stale && i.J && activeTransition !== i.J)) {
+       if (currentOptimisticLane) {
+-        const n = i.te;
++        const n = i.ne;
+         const r = findLane(currentOptimisticLane);
+         if (n && findLane(n) === r && !hasActiveOverride(i)) {
+           if (!tracking && e !== t) link(e, t);
+-          throw i.Te;
++          throw i.Se;
+         }
+       } else {
+         if (!tracking && e !== t) link(e, t);
+-        throw i.Te;
++        throw i.Se;
+       }
+-    } else if (t && i !== e && i.Oe & STATUS_UNINITIALIZED) {
++    } else if (t && i !== e && i.Re & STATUS_UNINITIALIZED) {
+       if (!tracking && e !== t) link(e, t);
+-      throw i.Te;
+-    } else if (!t && i.Oe & STATUS_UNINITIALIZED) {
+-      throw i.Te;
++      throw i.Se;
++    } else if (!t && i.Re & STATUS_UNINITIALIZED) {
++      throw i.Se;
+     }
+   }
+-  if (e.L && e.Oe & STATUS_ERROR) {
+-    if (e.Se < clock) {
++  if (e.L && e.Re & STATUS_ERROR) {
++    if (e._e < clock) {
+       recompute(e);
+       return read(e);
+-    } else throw e.Te;
++    } else throw e.Se;
+   }
+-  if (snapshotCaptureActive && t && t.Ee & CONFIG_IN_SNAPSHOT_SCOPE) {
+-    const n = e.de;
++  if (snapshotCaptureActive && t && t.de & CONFIG_IN_SNAPSHOT_SCOPE) {
++    const n = e.Oe;
+     if (n !== undefined) {
+       const i = n === NO_SNAPSHOT ? undefined : n;
+-      const r = e.U !== NOT_PENDING ? e.U : e.ne;
+-      if (r !== i) t.R |= REACTIVE_SNAPSHOT_STALE;
++      const r = e.k !== NOT_PENDING ? e.k : e.ie;
++      if (r !== i) t.O |= REACTIVE_SNAPSHOT_STALE;
+       return i;
+     }
+   }
+-  if (e.G !== undefined && e.G !== NOT_PENDING) {
+-    if (t && stale && shouldReadStashedOptimisticValue(e)) return e.ne;
+-    return e.G;
++  if (e.W !== undefined && e.W !== NOT_PENDING) {
++    if (t && stale && shouldReadStashedOptimisticValue(e)) return e.ie;
++    return e.W;
+   }
+   if (
+     activeTransition !== null &&
+     currentOptimisticLane !== null &&
+     !latestReadActive &&
+-    e.U !== NOT_PENDING &&
++    e.k !== NOT_PENDING &&
+     i === e &&
+     !e.L &&
+     t
+   ) {
+-    activeTransition.ee.add(t);
+-    return e.ne;
++    activeTransition.te.add(t);
++    return e.ie;
+   }
+   const r =
+     !t ||
+     (currentOptimisticLane !== null &&
+-      (e.G !== undefined || e.te || (i === e && stale) || !!(i.Oe & STATUS_PENDING))) ||
+-    e.U === NOT_PENDING ||
+-    (stale && e.Z && activeTransition !== e.Z)
+-      ? e.ne
+-      : e.U;
++      (e.W !== undefined || e.ne || (i === e && stale) || !!(i.Re & STATUS_PENDING))) ||
++    e.k === NOT_PENDING ||
++    (stale && e.J && activeTransition !== e.J)
++      ? e.ie
++      : e.k;
+   if (
+     !t &&
+     i === e &&
+     typeof n.L === "function" &&
+-    e.Ee & CONFIG_AUTO_DISPOSE &&
+-    !(i.Oe & STATUS_PENDING) &&
++    e.de & CONFIG_AUTO_DISPOSE &&
++    !(i.Re & STATUS_PENDING) &&
+     !e.I
+   ) {
+     unobserved(e);
+@@ -1627,12 +1814,12 @@ function read(e) {
+   return r;
+ }
+ function setSignal(e, t) {
+-  if (e.Z && activeTransition !== e.Z) globalQueue.initTransition(e.Z);
+-  const n = e.G !== undefined && !projectionWriteActive;
+-  const i = e.G !== undefined && e.G !== NOT_PENDING;
+-  const r = n ? (i ? e.G : e.ne) : e.U === NOT_PENDING ? e.ne : e.U;
++  if (e.J && activeTransition !== e.J) globalQueue.initTransition(e.J);
++  const n = e.W !== undefined && !projectionWriteActive;
++  const i = e.W !== undefined && e.W !== NOT_PENDING;
++  const r = n ? (i ? e.W : e.ie) : e.k === NOT_PENDING ? e.ie : e.k;
+   if (typeof t === "function") t = t(r);
+-  const s = !e.Le || !e.Le(r, t) || !!(e.Oe & STATUS_UNINITIALIZED);
++  const s = !e.Fe || !e.Fe(r, t) || !!(e.Re & STATUS_UNINITIALIZED);
+   if (!s) {
+     if (n && i && e.L) {
+       insertSubs(e, true);
+@@ -1641,29 +1828,39 @@ function setSignal(e, t) {
+     return t;
+   }
+   if (n) {
+-    const n = e.G === NOT_PENDING;
++    const n = e.W === NOT_PENDING;
+     if (!n) globalQueue.initTransition(resolveTransition(e));
+     if (n) {
+-      e.U = e.ne;
+-      globalQueue.q.push(e);
++      e.k = e.ie;
++      globalQueue.G.push(e);
+     }
+-    e.pe = true;
++    e.Ce = true;
+     const i = getOrCreateLane(e);
+-    e.te = i;
+-    e.G = t;
++    e.ne = i;
++    e.W = t;
+   } else {
+-    if (e.U === NOT_PENDING) globalQueue.ue.push(e);
+-    e.U = t;
++    if (e.k === NOT_PENDING) queuePendingNode(e);
++    e.k = t;
+   }
+-  updatePendingSignal(e);
+-  if (e.Ue) {
+-    setSignal(e.Ue, t);
++  if (e.We) updatePendingSignal(e);
++  if (e.ke) {
++    setSignal(e.ke, t);
+   }
+-  e.Se = clock;
++  e._e = clock;
+   insertSubs(e, n);
+   schedule();
+   return t;
+ }
++function suppressComputedRecompute(e) {
++  deleteFromHeap(e, e.O & REACTIVE_ZOMBIE ? zombieQueue : dirtyQueue);
++  if (!(e.O & REACTIVE_MANUAL_WRITE) && e.k === NOT_PENDING) queuePendingNode(e);
++  e.O = (e.O & -4) | REACTIVE_MANUAL_WRITE;
++}
++function setMemo(e, t) {
++  const n = setSignal(e, t);
++  suppressComputedRecompute(e);
++  return n;
++}
+ function runWithOwner(e, t) {
+   const n = context;
+   const i = tracking;
+@@ -1679,8 +1876,8 @@ function runWithOwner(e, t) {
+ function getPendingSignal(e) {
+   if (!e.We) {
+     e.We = optimisticSignal(false, { ownedWrite: true });
+-    if (e.Ie) {
+-      e.We.Ie = e;
++    if (e.Ae) {
++      e.We.Ae = e;
+     }
+     if (computePendingState(e)) setSignal(e.We, true);
+   }
+@@ -1689,56 +1886,56 @@ function getPendingSignal(e) {
+ function computePendingState(e) {
+   const t = e;
+   const n = e.V;
+-  if (n && e.U !== NOT_PENDING) {
+-    return !n.De && !(n.Oe & STATUS_PENDING);
++  if (n && e.k !== NOT_PENDING) {
++    return !n.be && !(n.Re & STATUS_PENDING);
+   }
+-  if (e.G !== undefined && e.G !== NOT_PENDING) {
+-    if (t.Oe & STATUS_PENDING && !(t.Oe & STATUS_UNINITIALIZED)) return true;
+-    if (e.Ie) {
+-      const t = e.te ? findLane(e.te) : null;
+-      return !!(t && t.W.size > 0);
++  if (e.W !== undefined && e.W !== NOT_PENDING) {
++    if (t.Re & STATUS_PENDING && !(t.Re & STATUS_UNINITIALIZED)) return true;
++    if (e.Ae) {
++      const t = e.ne ? findLane(e.ne) : null;
++      return !!(t && t.j.size > 0);
+     }
+     return true;
+   }
+-  if (e.G !== undefined && e.G === NOT_PENDING && !e.Ie) {
++  if (e.W !== undefined && e.W === NOT_PENDING && !e.Ae) {
+     return false;
+   }
+-  if (e.U !== NOT_PENDING && !(t.Oe & STATUS_UNINITIALIZED)) return true;
+-  return !!(t.Oe & STATUS_PENDING && !(t.Oe & STATUS_UNINITIALIZED));
++  if (e.k !== NOT_PENDING && !(t.Re & STATUS_UNINITIALIZED)) return true;
++  return !!(t.Re & STATUS_PENDING && !(t.Re & STATUS_UNINITIALIZED));
+ }
+ function updatePendingSignal(e) {
+   if (e.We) {
+     const t = computePendingState(e);
+     const n = e.We;
+     setSignal(n, t);
+-    if (!t && n.te) {
++    if (!t && n.ne) {
+       const t = resolveLane(e);
+-      if (t && t.W.size > 0) {
+-        const e = findLane(n.te);
++      if (t && t.j.size > 0) {
++        const e = findLane(n.ne);
+         if (e !== t) {
+           mergeLanes(t, e);
+         }
+       }
+       signalLanes.delete(n);
+-      n.te = undefined;
++      n.ne = undefined;
+     }
+   }
+ }
+ function getLatestValueComputed(e) {
+-  if (!e.Ue) {
++  if (!e.ke) {
+     const t = latestReadActive;
+     latestReadActive = false;
+     const n = pendingCheckActive;
+     pendingCheckActive = false;
+     const i = context;
+     context = null;
+-    e.Ue = optimisticComputed(() => read(e));
+-    e.Ue.Ie = e;
++    e.ke = optimisticComputed(() => read(e));
++    e.ke.Ae = e;
+     context = i;
+     pendingCheckActive = n;
+     latestReadActive = t;
+   }
+-  return e.Ue;
++  return e.ke;
+ }
+ function staleValues(e, t = true) {
+   const n = stale;
+@@ -1775,15 +1972,19 @@ function isPending(e) {
+ }
+ function refresh(e) {
+   let t = refreshing;
++  let n = refreshTrigger;
+   refreshing = true;
++  refreshTrigger = true;
+   try {
+     if (typeof e !== "function") {
++      refreshTrigger = false;
+       recompute(e[$REFRESH]);
+       return e;
+     }
+     return untrack(e);
+   } finally {
+     refreshing = t;
++    refreshTrigger = n;
+     if (!t) {
+       schedule();
+     }
+@@ -1799,7 +2000,7 @@ function getContext(e, t = getOwner()) {
+   if (!t) {
+     throw new NoOwnerError();
+   }
+-  const n = hasContext(e, t) ? t.Ve[e.id] : e.defaultValue;
++  const n = hasContext(e, t) ? t.Ue[e.id] : e.defaultValue;
+   if (isUndefined(n)) {
+     throw new ContextNotFoundError();
+   }
+@@ -1809,111 +2010,99 @@ function setContext(e, t, n = getOwner()) {
+   if (!n) {
+     throw new NoOwnerError();
+   }
+-  n.Ve = { ...n.Ve, [e.id]: isUndefined(t) ? e.defaultValue : t };
++  n.Ue = { ...n.Ue, [e.id]: isUndefined(t) ? e.defaultValue : t };
+ }
+ function hasContext(e, t) {
+-  return !isUndefined(t?.Ve[e.id]);
++  return !isUndefined(t?.Ue[e.id]);
+ }
+ function isUndefined(e) {
+   return typeof e === "undefined";
+ }
+ function effect(e, t, n, i) {
+-  let r = false;
+-  const s = !!i?.user;
+-  const o = computed(s ? e : t => staleValues(() => e(t)), {
+-    ...i,
+-    equals: () => {
+-      o.j = !o.Te;
+-      if (r) o.$.enqueue(o.M, runEffect.bind(o));
+-      return false;
+-    },
+-    lazy: true
+-  });
+-  o.Ee &= ~CONFIG_AUTO_DISPOSE;
+-  o.xe = undefined;
+-  o.He = t;
+-  o.Me = n;
+-  o.Qe = undefined;
+-  o.M = s ? EFFECT_USER : EFFECT_RENDER;
+-  o.Ge = (e, t) => {
+-    const n = e !== undefined ? e : o.Oe;
+-    const i = t !== undefined ? t : o.Te;
+-    if (n & STATUS_ERROR) {
+-      let e = i;
+-      o.$.notify(o, STATUS_PENDING, 0);
+-      if (o.M === EFFECT_USER) {
+-        try {
+-          return o.Me
+-            ? o.Me(e, () => {
+-                o.Qe?.();
+-                o.Qe = undefined;
+-              })
+-            : console.error(e);
+-        } catch (t) {
+-          e = t;
+-        }
++  const r = !!i?.user;
++  const s = createEffectNode(e, t, n, r ? EFFECT_USER : EFFECT_RENDER, notifyEffectStatus, i);
++  recompute(s, true);
++  !i?.defer &&
++    (s.K === EFFECT_USER || i?.schedule ? s.Z.enqueue(s.K, runEffect.bind(null, s)) : runEffect(s));
++}
++function notifyEffectStatus(e, t) {
++  const n = e !== undefined ? e : this.Re;
++  const i = t !== undefined ? t : this.Se;
++  if (n & STATUS_ERROR) {
++    let e = i;
++    this.Z.notify(this, STATUS_PENDING, 0);
++    if (this.K === EFFECT_USER) {
++      try {
++        return this.je
++          ? this.je(e, () => {
++              this.$e?.();
++              this.$e = undefined;
++            })
++          : console.error(e);
++      } catch (t) {
++        e = t;
+       }
+-      if (!o.$.notify(o, STATUS_ERROR, STATUS_ERROR)) throw e;
+-    } else if (o.M === EFFECT_RENDER) {
+-      o.$.notify(o, STATUS_PENDING | STATUS_ERROR, n, i);
+     }
+-  };
+-  recompute(o, true);
+-  !i?.defer &&
+-    (o.M === EFFECT_USER || i?.schedule ? o.$.enqueue(o.M, runEffect.bind(o)) : runEffect.call(o));
+-  r = true;
+-  cleanup(() => o.Qe?.());
+-}
+-function runEffect() {
+-  if (!this.j || this.R & REACTIVE_DISPOSED) return;
+-  this.Qe?.();
+-  this.Qe = undefined;
++    if (!this.Z.notify(this, STATUS_ERROR, STATUS_ERROR)) throw e;
++  } else if (this.K === EFFECT_RENDER) {
++    this.Z.notify(this, STATUS_PENDING | STATUS_ERROR, n, i);
++  }
++}
++function runEffect(e) {
++  if (!e.Y || e.O & REACTIVE_DISPOSED) return;
++  e.$e?.();
++  e.$e = undefined;
+   try {
+-    const e = this.He(this.ne, this.xe);
+-    if (false && e !== undefined && typeof e !== "function");
+-    this.Qe = e;
+-  } catch (e) {
+-    this.Te = new StatusError(this, e);
+-    this.Oe |= STATUS_ERROR;
+-    if (!this.$.notify(this, STATUS_ERROR, STATUS_ERROR)) throw e;
++    const t = e.Qe(e.ie, e.Me);
++    if (false && t !== undefined && typeof t !== "function");
++    e.$e = t;
++    if (e.$e && !e.Ke) {
++      e.Ke = true;
++      runWithOwner(e.i, () => cleanup(() => e.$e?.()));
++    }
++  } catch (t) {
++    e.Se = new StatusError(e, t);
++    e.Re |= STATUS_ERROR;
++    if (!e.Z.notify(e, STATUS_ERROR, STATUS_ERROR)) throw t;
+   } finally {
+-    this.xe = this.ne;
+-    this.j = false;
++    e.Me = e.ie;
++    e.Y = false;
+   }
+ }
++GlobalQueue.fe = runEffect;
+ function trackedEffect(e, t) {
+   const run = () => {
+-    if (!n.j || n.R & REACTIVE_DISPOSED) return;
++    if (!n.Y || n.O & REACTIVE_DISPOSED) return;
+     try {
+-      n.j = false;
++      n.Y = false;
+       recompute(n);
+     } finally {
+     }
+   };
+   const n = computed(
+     () => {
+-      n.Qe?.();
+-      n.Qe = undefined;
++      n.$e?.();
++      n.$e = undefined;
+       const t = staleValues(e);
+-      n.Qe = t;
++      n.$e = t;
+     },
+     { ...t, lazy: true }
+   );
+-  n.Qe = undefined;
+-  n.Ee = (n.Ee & ~CONFIG_AUTO_DISPOSE) | CONFIG_CHILDREN_FORBIDDEN;
+-  n.j = true;
+-  n.M = EFFECT_TRACKED;
+-  n.Ge = (e, t) => {
+-    const i = e !== undefined ? e : n.Oe;
++  n.$e = undefined;
++  n.de = (n.de & ~CONFIG_AUTO_DISPOSE) | CONFIG_CHILDREN_FORBIDDEN;
++  n.Y = true;
++  n.K = EFFECT_TRACKED;
++  n.xe = (e, t) => {
++    const i = e !== undefined ? e : n.Re;
+     if (i & STATUS_ERROR) {
+-      n.$.notify(n, STATUS_PENDING, 0);
+-      const e = t !== undefined ? t : n.Te;
+-      if (!n.$.notify(n, STATUS_ERROR, STATUS_ERROR)) throw e;
++      n.Z.notify(n, STATUS_PENDING, 0);
++      const e = t !== undefined ? t : n.Se;
++      if (!n.Z.notify(n, STATUS_ERROR, STATUS_ERROR)) throw e;
+     }
+   };
+-  n.K = run;
+-  n.$.enqueue(EFFECT_USER, run);
+-  cleanup(() => n.Qe?.());
++  n.B = run;
++  n.Z.enqueue(EFFECT_USER, run);
++  cleanup(() => n.$e?.());
+ }
+ function restoreTransition(e, t) {
+   globalQueue.initTransition(e);
+@@ -1927,11 +2116,11 @@ function action(e) {
+       const r = e(...t);
+       globalQueue.initTransition();
+       let s = activeTransition;
+-      s.B.push(r);
++      s.X.push(r);
+       const done = (e, t) => {
+         s = currentTransition(s);
+-        const o = s.B.indexOf(r);
+-        if (o >= 0) s.B.splice(o, 1);
++        const o = s.X.indexOf(r);
++        if (o >= 0) s.X.splice(o, 1);
+         setActiveTransition(s);
+         schedule();
+         t ? i(t) : n(e);
+@@ -1968,8 +2157,8 @@ function accessor(e) {
+ function createSignal(e, t) {
+   if (typeof e === "function") {
+     const n = computed(e, t);
+-    n.Ee &= ~CONFIG_AUTO_DISPOSE;
+-    return [accessor(n), setSignal.bind(null, n)];
++    n.de &= ~CONFIG_AUTO_DISPOSE;
++    return [accessor(n), setMemo.bind(null, n)];
+   }
+   const n = signal(e, t);
+   return [accessor(n), setSignal.bind(null, n)];
+@@ -2025,7 +2214,7 @@ function resolve(e) {
+ function createOptimistic(e, t) {
+   if (typeof e === "function") {
+     const n = optimisticComputed(e, t);
+-    n.Ee &= ~CONFIG_AUTO_DISPOSE;
++    n.de &= ~CONFIG_AUTO_DISPOSE;
+     return [accessor(n), setSignal.bind(null, n)];
+   }
+   const n = optimisticSignal(e, t);
+@@ -2033,7 +2222,7 @@ function createOptimistic(e, t) {
+ }
+ function onSettled(e) {
+   const t = getOwner();
+-  t && !(t.Ee & CONFIG_CHILDREN_FORBIDDEN)
++  t && !(t.de & CONFIG_CHILDREN_FORBIDDEN)
+     ? createTrackedEffect(() => untrack(e), undefined)
+     : globalQueue.enqueue(EFFECT_USER, () => {
+         const t = e();
+@@ -2067,65 +2256,65 @@ function applyState(e, t, n) {
+     let t = false;
+     const c = getOverrideValue(r, s, u, "length", o);
+     if (e.length && c && e[0] && n(e[0]) != null) {
+-      let a, l, f, E, T, S, d, O;
++      let l, a, f, E, T, d, S, _;
+       for (
+         f = 0, E = Math.min(c, e.length);
+         f < E &&
+-        ((S = getOverrideValue(r, s, u, f, o)) === e[f] || (S && e[f] && n(S) === n(e[f])));
++        ((d = getOverrideValue(r, s, u, f, o)) === e[f] || (d && e[f] && n(d) === n(e[f])));
+         f++
+       ) {
+-        applyState(e[f], wrap(S, i), n);
++        applyState(e[f], wrap(d, i), n);
+       }
+-      const R = new Array(e.length),
+-        _ = new Map();
++      const O = new Array(e.length),
++        R = new Map();
+       for (
+         E = c - 1, T = e.length - 1;
+         E >= f &&
+         T >= f &&
+-        ((S = getOverrideValue(r, s, u, E, o)) === e[T] || (S && e[T] && n(S) === n(e[T])));
++        ((d = getOverrideValue(r, s, u, E, o)) === e[T] || (d && e[T] && n(d) === n(e[T])));
+         E--, T--
+       ) {
+-        R[T] = S;
++        O[T] = d;
+       }
+       if (f > T || f > E) {
+-        for (l = f; l <= T; l++) {
++        for (a = f; a <= T; a++) {
+           t = true;
+-          i[STORE_NODE][l] && setSignal(i[STORE_NODE][l], wrap(e[l], i));
++          i[STORE_NODE][a] && setSignal(i[STORE_NODE][a], wrap(e[a], i));
+         }
+-        for (; l < e.length; l++) {
++        for (; a < e.length; a++) {
+           t = true;
+-          const r = wrap(R[l], i);
+-          i[STORE_NODE][l] && setSignal(i[STORE_NODE][l], r);
+-          applyState(e[l], r, n);
++          const r = wrap(O[a], i);
++          i[STORE_NODE][a] && setSignal(i[STORE_NODE][a], r);
++          applyState(e[a], r, n);
+         }
+         t && i[STORE_NODE][$TRACK] && setSignal(i[STORE_NODE][$TRACK], void 0);
+         c !== e.length && i[STORE_NODE].length && setSignal(i[STORE_NODE].length, e.length);
+         return;
+       }
+-      d = new Array(T + 1);
+-      for (l = T; l >= f; l--) {
+-        S = e[l];
+-        O = S ? n(S) : S;
+-        a = _.get(O);
+-        d[l] = a === undefined ? -1 : a;
+-        _.set(O, l);
+-      }
+-      for (a = f; a <= E; a++) {
+-        S = getOverrideValue(r, s, u, a, o);
+-        O = S ? n(S) : S;
+-        l = _.get(O);
+-        if (l !== undefined && l !== -1) {
+-          R[l] = S;
+-          l = d[l];
+-          _.set(O, l);
++      S = new Array(T + 1);
++      for (a = T; a >= f; a--) {
++        d = e[a];
++        _ = d ? n(d) : d;
++        l = R.get(_);
++        S[a] = l === undefined ? -1 : l;
++        R.set(_, a);
++      }
++      for (l = f; l <= E; l++) {
++        d = getOverrideValue(r, s, u, l, o);
++        _ = d ? n(d) : d;
++        a = R.get(_);
++        if (a !== undefined && a !== -1) {
++          O[a] = d;
++          a = S[a];
++          R.set(_, a);
+         }
+       }
+-      for (l = f; l < e.length; l++) {
+-        if (l in R) {
+-          const t = wrap(R[l], i);
+-          i[STORE_NODE][l] && setSignal(i[STORE_NODE][l], t);
+-          applyState(e[l], t, n);
+-        } else i[STORE_NODE][l] && setSignal(i[STORE_NODE][l], wrap(e[l], i));
++      for (a = f; a < e.length; a++) {
++        if (a in O) {
++          const t = wrap(O[a], i);
++          i[STORE_NODE][a] && setSignal(i[STORE_NODE][a], t);
++          applyState(e[a], t, n);
++        } else i[STORE_NODE][a] && setSignal(i[STORE_NODE][a], wrap(e[a], i));
+       }
+       if (f < e.length) t = true;
+     } else if (e.length) {
+@@ -2146,11 +2335,11 @@ function applyState(e, t, n) {
+   if (u) {
+     const t = u[$TRACK];
+     const c = t ? getAllKeys(r, s, e) : Object.keys(u);
+-    for (let a = 0, l = c.length; a < l; a++) {
+-      const l = c[a];
+-      const f = u[l];
+-      const E = unwrap(getOverrideValue(r, s, u, l, o));
+-      let T = unwrap(e[l]);
++    for (let l = 0, a = c.length; l < a; l++) {
++      const a = c[l];
++      const f = u[a];
++      const E = unwrap(getOverrideValue(r, s, u, a, o));
++      let T = unwrap(e[a]);
+       if (E === T) continue;
+       if (!E || !isWrappable(E) || !isWrappable(T) || (n(E) != null && n(E) !== n(T))) {
+         t && setSignal(t, void 0);
+@@ -2201,7 +2390,7 @@ function createProjectionInternal(e, t, n) {
+     if (!i) i = getOwner();
+     runProjectionComputed(s, e, n?.key || "id");
+   }, undefined);
+-  i.Ee &= ~CONFIG_AUTO_DISPOSE;
++  i.de &= ~CONFIG_AUTO_DISPOSE;
+   return { store: s, node: i };
+ }
+ function createProjection(e, t, n) {
+@@ -2213,7 +2402,7 @@ function runProjectionComputed(e, t, n, i) {
+   let o;
+   const u = new Proxy(
+     e,
+-    createWriteTraps(() => !s || r.De === o)
++    createWriteTraps(() => !s || r.be === o)
+   );
+   storeSetter(u, u => {
+     o = t(u);
+@@ -2361,11 +2550,11 @@ function getNode(e, t, n, i, r = isEqual, s, o) {
+     i
+   );
+   if (s) {
+-    u.G = NOT_PENDING;
++    u.W = NOT_PENDING;
+   }
+   if (o && t in o) {
+     const e = o[t];
+-    u.de = e === undefined ? NO_SNAPSHOT : e;
++    u.Oe = e === undefined ? NO_SNAPSHOT : e;
+     snapshotSources?.add(u);
+   }
+   return (e[t] = u);
+@@ -2398,8 +2587,8 @@ function getPropertyDescriptor(e, t, n) {
+ function prepareStoreWrite(e, t, n) {
+   if (e[STORE_OPTIMISTIC]) {
+     const t = e[STORE_FIREWALL];
+-    if (t?.Z) {
+-      globalQueue.initTransition(t.Z);
++    if (t?.J) {
++      globalQueue.initTransition(t.J);
+     }
+   }
+   const i = e[STORE_VALUE];
+@@ -2407,7 +2596,7 @@ function prepareStoreWrite(e, t, n) {
+   if (
+     snapshotCaptureActive &&
+     typeof n !== "symbol" &&
+-    !((e[STORE_FIREWALL]?.Oe ?? 0) & STATUS_PENDING)
++    !((e[STORE_FIREWALL]?.Re ?? 0) & STATUS_PENDING)
+   ) {
+     if (!e[STORE_SNAPSHOT_PROPS]) {
+       e[STORE_SNAPSHOT_PROPS] = Object.create(null);
+@@ -2439,28 +2628,28 @@ function notifyStoreProperty(e, t, n, i, r, s) {
+     const n = upsertStoreNode(e, getNodes(e, STORE_HAS), t, s);
+     setSignal(n, u);
+   }
+-  const a = getNodes(e, STORE_NODE);
++  const l = getNodes(e, STORE_NODE);
+   if (n === "set") {
+-    if (a[t]) {
+-      setSignal(a[t], () => (isWrappable(i) ? wrap(i, e) : i));
++    if (l[t]) {
++      setSignal(l[t], () => (isWrappable(i) ? wrap(i, e) : i));
+     } else if (!o) {
+-      const n = upsertStoreNode(e, a, t, r, e[STORE_SNAPSHOT_PROPS]);
++      const n = upsertStoreNode(e, l, t, r, e[STORE_SNAPSHOT_PROPS]);
+       setSignal(n, () => (isWrappable(i) ? wrap(i, e) : i));
+     }
+   } else if (n === "invalidate") {
+-    if (a[t]) {
+-      setSignal(a[t], {});
+-      delete a[t];
++    if (l[t]) {
++      setSignal(l[t], {});
++      delete l[t];
+     }
+   } else {
+-    if (a[t]) {
+-      setSignal(a[t], undefined);
++    if (l[t]) {
++      setSignal(l[t], undefined);
+     } else if (!o) {
+-      const n = upsertStoreNode(e, a, t, r, e[STORE_SNAPSHOT_PROPS]);
++      const n = upsertStoreNode(e, l, t, r, e[STORE_SNAPSHOT_PROPS]);
+       setSignal(n, undefined);
+     }
+   }
+-  a[$TRACK] && setSignal(a[$TRACK], undefined);
++  l[$TRACK] && setSignal(l[$TRACK], undefined);
+ }
+ let Writing = null;
+ const storeTraps = {
+@@ -2474,48 +2663,63 @@ const storeTraps = {
+     }
+     const i = getNodes(e, STORE_NODE);
+     const r = i[t];
+-    const s = e[STORE_OPTIMISTIC_OVERRIDE] && t in e[STORE_OPTIMISTIC_OVERRIDE];
+-    const o = s || (e[STORE_OVERRIDE] && t in e[STORE_OVERRIDE]);
+-    const u = !!e[STORE_VALUE][$TARGET];
+-    const c = s
++    const s = e[STORE_VALUE];
++    if (
++      !r &&
++      !e[STORE_OVERRIDE] &&
++      !e[STORE_OPTIMISTIC_OVERRIDE] &&
++      !e[STORE_CUSTOM_PROTO] &&
++      !e[STORE_OPTIMISTIC] &&
++      !e[STORE_SNAPSHOT_PROPS] &&
++      !s[$TARGET] &&
++      !(t in s) &&
++      getObserver() &&
++      !writeOnly(n)
++    ) {
++      return read(getNode(i, t, undefined, e[STORE_FIREWALL]));
++    }
++    const o = e[STORE_OPTIMISTIC_OVERRIDE] && t in e[STORE_OPTIMISTIC_OVERRIDE];
++    const u = o || (e[STORE_OVERRIDE] && t in e[STORE_OVERRIDE]);
++    const c = !!e[STORE_VALUE][$TARGET];
++    const l = o
+       ? e[STORE_OPTIMISTIC_OVERRIDE]
+       : e[STORE_OVERRIDE] && t in e[STORE_OVERRIDE]
+         ? e[STORE_OVERRIDE]
+         : e[STORE_VALUE];
+     if (!r) {
+-      const i = Object.getOwnPropertyDescriptor(c, t);
++      const i = Object.getOwnPropertyDescriptor(l, t);
+       if (i && i.get) return i.get.call(n);
+-      if (!i && !o && e[STORE_CUSTOM_PROTO]) {
+-        const e = unwrapStoreValue(c);
++      if (!i && !u && e[STORE_CUSTOM_PROTO]) {
++        const e = unwrapStoreValue(l);
+         if (hasInheritedAccessor(e, t)) {
+-          return Reflect.get(c, t, n);
++          return Reflect.get(l, t, n);
+         }
+       }
+     }
+     if (writeOnly(n)) {
+       let n =
+-        r && (o || !u)
+-          ? r.G !== undefined && r.G !== NOT_PENDING
+-            ? r.G
+-            : r.U !== NOT_PENDING
+-              ? r.U
+-              : r.ne
+-          : c[t];
++        r && (u || !c)
++          ? r.W !== undefined && r.W !== NOT_PENDING
++            ? r.W
++            : r.k !== NOT_PENDING
++              ? r.k
++              : r.ie
++          : l[t];
+       n === $DELETED && (n = undefined);
+       if (!isWrappable(n)) return n;
+       const i = wrap(n, e);
+       Writing?.add(i);
+       return i;
+     }
+-    let a = r ? (o || !u ? read(i[t]) : (read(i[t]), c[t])) : c[t];
++    let a = r ? (u || !c ? read(i[t]) : (read(i[t]), l[t])) : l[t];
+     a === $DELETED && (a = undefined);
+     if (!r) {
+-      if (!o && typeof a === "function" && !c.hasOwnProperty(t)) {
++      if (!u && typeof a === "function" && !l.hasOwnProperty(t)) {
+         let t;
+         return !Array.isArray(e[STORE_VALUE]) &&
+           (t = Object.getPrototypeOf(e[STORE_VALUE])) &&
+           t !== Object.prototype
+-          ? a.bind(c)
++          ? a.bind(l)
+           : a;
+       } else if (getObserver()) {
+         return read(
+@@ -2566,25 +2770,25 @@ const storeTraps = {
+             : e[STORE_OVERRIDE] && t in e[STORE_OVERRIDE]
+               ? e[STORE_OVERRIDE][t] !== $DELETED
+               : t in e[STORE_VALUE];
+-        const a = unwrapStoreValue(n);
+-        const l = Array.isArray(o) && t !== "length";
+-        const f = l ? parseInt(t) + 1 : 0;
++        const l = unwrapStoreValue(n);
++        const a = Array.isArray(o) && t !== "length";
++        const f = a ? parseInt(t) + 1 : 0;
+         const E =
+-          l &&
++          a &&
+           (e[STORE_OPTIMISTIC_OVERRIDE] && "length" in e[STORE_OPTIMISTIC_OVERRIDE]
+             ? e[STORE_OPTIMISTIC_OVERRIDE].length
+             : e[STORE_OVERRIDE] && "length" in e[STORE_OVERRIDE]
+               ? e[STORE_OVERRIDE].length
+               : o.length);
+-        const T = l && f > E ? f : undefined;
+-        if (u === a && T === undefined) return true;
+-        if (a !== undefined && a === r && T === undefined) delete e[s]?.[t];
++        const T = a && f > E ? f : undefined;
++        if (u === l && T === undefined) return true;
++        if (l !== undefined && l === r && T === undefined) delete e[s]?.[t];
+         else {
+           const n = e[s] || (e[s] = Object.create(null));
+-          n[t] = a;
++          n[t] = l;
+           if (T !== undefined) n.length = T;
+         }
+-        notifyStoreProperty(e, t, "set", a, u, c);
++        notifyStoreProperty(e, t, "set", l, u, c);
+         if (Array.isArray(o) && t !== "length" && T !== undefined) {
+           const t = getNodes(e, STORE_NODE);
+           if (t.length) {
+@@ -2698,10 +2902,13 @@ function storeSetter(e, t) {
+ function createStore(e, t, n) {
+   const i = typeof e === "function",
+     r = i ? createProjectionInternal(e, t, n).store : wrap(e);
+-  return [r, e => storeSetter(r, e)];
++  return [
++    r,
++    i ? e => (storeSetter(r, e), suppressComputedRecompute(r[$REFRESH])) : e => storeSetter(r, e)
++  ];
+ }
+ function createOptimisticStore(e, t, n) {
+-  GlobalQueue.le ||= clearOptimisticStore;
++  GlobalQueue.Ee ||= clearOptimisticStore;
+   const i = typeof e === "function";
+   const r = i ? t : e;
+   const s = i ? e : undefined;
+@@ -2718,7 +2925,7 @@ function clearOptimisticStore(e) {
+     if (i) {
+       for (const e of Reflect.ownKeys(n)) {
+         if (i[e]) {
+-          i[e].te = undefined;
++          i[e].ne = undefined;
+           const n =
+             t[STORE_OVERRIDE] && e in t[STORE_OVERRIDE] ? t[STORE_OVERRIDE][e] : t[STORE_VALUE][e];
+           const r = n === $DELETED ? undefined : n;
+@@ -2726,7 +2933,7 @@ function clearOptimisticStore(e) {
+         }
+       }
+       if (i[$TRACK]) {
+-        i[$TRACK].te = undefined;
++        i[$TRACK].ne = undefined;
+         setSignal(i[$TRACK], undefined);
+       }
+     }
+@@ -2774,7 +2981,7 @@ function createOptimisticProjectionInternal(e, t, n) {
+         setProjectionWriteActive(false);
+       }
+     }, undefined);
+-    i.Ee &= ~CONFIG_AUTO_DISPOSE;
++    i.de &= ~CONFIG_AUTO_DISPOSE;
+   }
+   return { store: s, node: i };
+ }
+@@ -2851,7 +3058,7 @@ const storePath = Object.assign(
+   { DELETE: DELETE }
+ );
+ function snapshotImpl(e, t, n, i) {
+-  let r, s, o, u, c, a;
++  let r, s, o, u, c, l;
+   if (!isWrappable(e)) return e;
+   if (n && n.has(e)) return n.get(e);
+   if (!n) n = new Map();
+@@ -2871,24 +3078,24 @@ function snapshotImpl(e, t, n, i) {
+   }
+   if (s) {
+     const s = o?.length || e.length;
+-    for (let l = 0; l < s; l++) {
+-      a = o && l in o ? o[l] : e[l];
+-      if (a === $DELETED) continue;
+-      if (t && isWrappable(a)) wrap(a, r);
+-      if ((c = snapshotImpl(a, t, n, i)) !== a || u) {
++    for (let a = 0; a < s; a++) {
++      l = o && a in o ? o[a] : e[a];
++      if (l === $DELETED) continue;
++      if (t && isWrappable(l)) wrap(l, r);
++      if ((c = snapshotImpl(l, t, n, i)) !== l || u) {
+         if (!u) n.set(e, (u = [...e]));
+-        u[l] = c;
++        u[a] = c;
+       }
+     }
+   } else {
+     const s = getKeys(e, o);
+-    for (let l = 0, f = s.length; l < f; l++) {
+-      let f = s[l];
++    for (let a = 0, f = s.length; a < f; a++) {
++      let f = s[a];
+       const E = getPropertyDescriptor(e, o, f);
+       if (E.get) continue;
+-      a = o && f in o ? o[f] : e[f];
+-      if (t && isWrappable(a)) wrap(a, r);
+-      if ((c = snapshotImpl(a, t, n, i)) !== e[f] || u) {
++      l = o && f in o ? o[f] : e[f];
++      if (t && isWrappable(l)) wrap(l, r);
++      if ((c = snapshotImpl(l, t, n, i)) !== e[f] || u) {
+         if (!u) {
+           u = Object.create(Object.getPrototypeOf(e));
+           Object.assign(u, e);
+@@ -2946,8 +3153,9 @@ function merge(...e) {
+     const r = e[i];
+     t = t || (!!r && $PROXY in r);
+     const s = !!r && r[$SOURCES];
+-    if (s) n.push(...s);
+-    else n.push(typeof r === "function" ? ((t = true), createMemo(r)) : r);
++    if (s) {
++      for (let e = 0; e < s.length; e++) n.push(s[e]);
++    } else n.push(typeof r === "function" ? ((t = true), createMemo(r)) : r);
+   }
+   if (SUPPORTS_PROXY && t) {
+     return new Proxy(
+@@ -2966,9 +3174,12 @@ function merge(...e) {
+           return false;
+         },
+         keys() {
+-          const e = [];
+-          for (let t = 0; t < n.length; t++) e.push(...Object.keys(resolveSource(n[t])));
+-          return [...new Set(e)];
++          const e = new Set();
++          for (let t = 0; t < n.length; t++) {
++            const i = Object.keys(resolveSource(n[t]));
++            for (let t = 0; t < i.length; t++) e.add(i[t]);
++          }
++          return [...e];
+         }
+       },
+       propTraps
+@@ -3007,261 +3218,262 @@ function merge(...e) {
+   return o;
+ }
+ function omit(e, ...t) {
+-  const n = new Set(t);
+   if (SUPPORTS_PROXY && $PROXY in e) {
+     return new Proxy(
+       {
+-        get(t) {
+-          return n.has(t) ? undefined : e[t];
++        get(n) {
++          return t.includes(n) ? undefined : e[n];
+         },
+-        has(t) {
+-          return !n.has(t) && t in e;
++        has(n) {
++          return !t.includes(n) && n in e;
+         },
+         keys() {
+-          return Object.keys(e).filter(e => !n.has(e));
++          return Object.keys(e).filter(e => !t.includes(e));
+         }
+       },
+       propTraps
+     );
+   }
+-  const i = {};
+-  for (const t of Object.getOwnPropertyNames(e)) {
+-    if (!n.has(t)) {
+-      const n = Object.getOwnPropertyDescriptor(e, t);
+-      !n.get && !n.set && n.enumerable && n.writable && n.configurable
+-        ? (i[t] = n.value)
+-        : Object.defineProperty(i, t, n);
++  const n = {};
++  const i = Object.getOwnPropertyNames(e);
++  const r = t.length > 4 && i.length > t.length ? new Set(t) : undefined;
++  for (const s of i) {
++    if (r ? !r.has(s) : !t.includes(s)) {
++      const t = Object.getOwnPropertyDescriptor(e, s);
++      !t.get && !t.set && t.enumerable && t.writable && t.configurable
++        ? (n[s] = t.value)
++        : Object.defineProperty(n, s, t);
+     }
+   }
+-  return i;
++  return n;
+ }
+ function mapArray(e, t, n) {
+   const i = typeof n?.keyed === "function" ? n.keyed : undefined;
+   const r = t.length > 1;
+   const s = t;
+   const o = {
+-    je: createOwner(),
+-    $e: 0,
+-    Ke: e,
+-    Ye: [],
+-    Be: s,
+-    Ze: [],
+-    qe: [],
+-    ze: i,
+-    Xe: i || n?.keyed === false ? [] : undefined,
+-    Je: r ? [] : undefined,
+-    et: n?.fallback
++    Ze: createOwner(),
++    Be: 0,
++    qe: e,
++    ze: [],
++    Xe: s,
++    Je: [],
++    et: [],
++    tt: i,
++    nt: i || n?.keyed === false ? [] : undefined,
++    it: r ? [] : undefined,
++    rt: n?.fallback
+   };
+   const u = computed(updateKeyedMap.bind(o));
+-  o.je.u = u;
+-  u.Ee &= ~CONFIG_AUTO_DISPOSE;
++  o.Ze.u = u;
++  u.de &= ~CONFIG_AUTO_DISPOSE;
+   return accessor(u);
+ }
+ const pureOptions = { ownedWrite: true };
+ function updateKeyedMap() {
+-  const e = this.Ke() || [],
++  const e = this.qe() || [],
+     t = e.length;
+   e[$TRACK];
+-  runWithOwner(this.je, () => {
++  runWithOwner(this.Ze, () => {
+     let n,
+       i,
+-      r = this.Xe
++      r = this.nt
+         ? () => {
+-            this.Xe[i] = signal(e[i], pureOptions);
+-            this.Je && (this.Je[i] = signal(i, pureOptions));
+-            return this.Be(accessor(this.Xe[i]), this.Je ? accessor(this.Je[i]) : undefined);
++            this.nt[i] = signal(e[i], pureOptions);
++            this.it && (this.it[i] = signal(i, pureOptions));
++            return this.Xe(accessor(this.nt[i]), this.it ? accessor(this.it[i]) : undefined);
+           }
+-        : this.Je
++        : this.it
+           ? () => {
+               const t = e[i];
+-              this.Je[i] = signal(i, pureOptions);
+-              return this.Be(() => t, accessor(this.Je[i]));
++              this.it[i] = signal(i, pureOptions);
++              return this.Xe(() => t, accessor(this.it[i]));
+             }
+           : () => {
+               const t = e[i];
+-              return this.Be(() => t);
++              return this.Xe(() => t);
+             };
+     if (t === 0) {
+-      if (this.$e !== 0) {
+-        this.je.dispose(false);
+-        this.qe = [];
+-        this.Ye = [];
+-        this.Ze = [];
+-        this.$e = 0;
+-        this.Xe && (this.Xe = []);
+-        this.Je && (this.Je = []);
+-      }
+-      if (this.et && !this.Ze[0]) {
+-        this.Ze[0] = runWithOwner((this.qe[0] = createOwner()), this.et);
+-      }
+-    } else if (this.$e === 0) {
+-      if (this.qe[0]) this.qe[0].dispose();
+-      this.Ze = new Array(t);
++      if (this.Be !== 0) {
++        this.Ze.dispose(false);
++        this.et = [];
++        this.ze = [];
++        this.Je = [];
++        this.Be = 0;
++        this.nt && (this.nt = []);
++        this.it && (this.it = []);
++      }
++      if (this.rt && !this.Je[0]) {
++        this.Je[0] = runWithOwner((this.et[0] = createOwner()), this.rt);
++      }
++    } else if (this.Be === 0) {
++      if (this.et[0]) this.et[0].dispose();
++      this.Je = new Array(t);
+       for (i = 0; i < t; i++) {
+-        this.Ye[i] = e[i];
+-        this.Ze[i] = runWithOwner((this.qe[i] = createOwner()), r);
++        this.ze[i] = e[i];
++        this.Je[i] = runWithOwner((this.et[i] = createOwner()), r);
+       }
+-      this.$e = t;
++      this.Be = t;
+     } else {
+       let s,
+         o,
+         u,
+         c,
+-        a,
+         l,
++        a,
+         f,
+         E = new Array(t),
+         T = new Array(t),
+-        S = this.Xe ? new Array(t) : undefined,
+-        d = this.Je ? new Array(t) : undefined;
++        d = this.nt ? new Array(t) : undefined,
++        S = this.it ? new Array(t) : undefined;
+       for (
+-        s = 0, o = Math.min(this.$e, t);
+-        s < o && (this.Ye[s] === e[s] || (this.Xe && compare(this.ze, this.Ye[s], e[s])));
++        s = 0, o = Math.min(this.Be, t);
++        s < o && (this.ze[s] === e[s] || (this.nt && compare(this.tt, this.ze[s], e[s])));
+         s++
+       ) {
+-        if (this.Xe) setSignal(this.Xe[s], e[s]);
++        if (this.nt) setSignal(this.nt[s], e[s]);
+       }
+       for (
+-        o = this.$e - 1, u = t - 1;
++        o = this.Be - 1, u = t - 1;
+         o >= s &&
+         u >= s &&
+-        (this.Ye[o] === e[u] || (this.Xe && compare(this.ze, this.Ye[o], e[u])));
++        (this.ze[o] === e[u] || (this.nt && compare(this.tt, this.ze[o], e[u])));
+         o--, u--
+       ) {
+-        E[u] = this.Ze[o];
+-        T[u] = this.qe[o];
+-        S && (S[u] = this.Xe[o]);
+-        d && (d[u] = this.Je[o]);
++        E[u] = this.Je[o];
++        T[u] = this.et[o];
++        d && (d[u] = this.nt[o]);
++        S && (S[u] = this.it[o]);
+       }
+-      l = new Map();
++      a = new Map();
+       f = new Array(u + 1);
+       for (i = u; i >= s; i--) {
+         c = e[i];
+-        a = this.ze ? this.ze(c) : c;
+-        n = l.get(a);
++        l = this.tt ? this.tt(c) : c;
++        n = a.get(l);
+         f[i] = n === undefined ? -1 : n;
+-        l.set(a, i);
++        a.set(l, i);
+       }
+       for (n = s; n <= o; n++) {
+-        c = this.Ye[n];
+-        a = this.ze ? this.ze(c) : c;
+-        i = l.get(a);
++        c = this.ze[n];
++        l = this.tt ? this.tt(c) : c;
++        i = a.get(l);
+         if (i !== undefined && i !== -1) {
+-          E[i] = this.Ze[n];
+-          T[i] = this.qe[n];
+-          S && (S[i] = this.Xe[n]);
+-          d && (d[i] = this.Je[n]);
++          E[i] = this.Je[n];
++          T[i] = this.et[n];
++          d && (d[i] = this.nt[n]);
++          S && (S[i] = this.it[n]);
+           i = f[i];
+-          l.set(a, i);
+-        } else this.qe[n].dispose();
++          a.set(l, i);
++        } else this.et[n].dispose();
+       }
+       for (i = s; i < t; i++) {
+         if (i in E) {
+-          this.Ze[i] = E[i];
+-          this.qe[i] = T[i];
+-          if (S) {
+-            this.Xe[i] = S[i];
+-            setSignal(this.Xe[i], e[i]);
+-          }
++          this.Je[i] = E[i];
++          this.et[i] = T[i];
+           if (d) {
+-            this.Je[i] = d[i];
+-            setSignal(this.Je[i], i);
++            this.nt[i] = d[i];
++            setSignal(this.nt[i], e[i]);
++          }
++          if (S) {
++            this.it[i] = S[i];
++            setSignal(this.it[i], i);
+           }
+         } else {
+-          this.Ze[i] = runWithOwner((this.qe[i] = createOwner()), r);
++          this.Je[i] = runWithOwner((this.et[i] = createOwner()), r);
+         }
+       }
+-      this.Ze = this.Ze.slice(0, (this.$e = t));
+-      this.Ye = e.slice(0);
++      this.Je = this.Je.slice(0, (this.Be = t));
++      this.ze = e.slice(0);
+     }
+   });
+-  return this.Ze;
++  return this.Je;
+ }
+ function repeat(e, t, n) {
+   const i = t;
+   const r = computed(
+     updateRepeat.bind({
+-      je: createOwner(),
+-      $e: 0,
+-      tt: 0,
+-      nt: e,
+-      Be: i,
+-      qe: [],
+-      Ze: [],
+-      it: n?.from,
+-      et: n?.fallback
++      Ze: createOwner(),
++      Be: 0,
++      st: 0,
++      ot: e,
++      Xe: i,
++      et: [],
++      Je: [],
++      ut: n?.from,
++      rt: n?.fallback
+     })
+   );
+-  r.Ee &= ~CONFIG_AUTO_DISPOSE;
++  r.de &= ~CONFIG_AUTO_DISPOSE;
+   return accessor(r);
+ }
+ function updateRepeat() {
+-  const e = this.nt();
+-  const t = this.it?.() || 0;
+-  runWithOwner(this.je, () => {
++  const e = this.ot();
++  const t = this.ut?.() || 0;
++  runWithOwner(this.Ze, () => {
+     if (e === 0) {
+-      if (this.$e !== 0) {
+-        this.je.dispose(false);
+-        this.qe = [];
+-        this.Ze = [];
+-        this.$e = 0;
++      if (this.Be !== 0) {
++        this.Ze.dispose(false);
++        this.et = [];
++        this.Je = [];
++        this.Be = 0;
+       }
+-      if (this.et && !this.Ze[0]) {
+-        this.Ze[0] = runWithOwner((this.qe[0] = createOwner()), this.et);
++      if (this.rt && !this.Je[0]) {
++        this.Je[0] = runWithOwner((this.et[0] = createOwner()), this.rt);
+       }
+       return;
+     }
+     const n = t + e;
+-    const i = this.tt + this.$e;
+-    if (this.$e === 0 && this.qe[0]) this.qe[0].dispose();
+-    for (let e = n; e < i; e++) this.qe[e - this.tt].dispose();
+-    if (this.tt < t) {
+-      let e = this.tt;
+-      while (e < t && e < this.$e) this.qe[e++].dispose();
+-      this.qe.splice(0, t - this.tt);
+-      this.Ze.splice(0, t - this.tt);
+-    } else if (this.tt > t) {
+-      let n = i - this.tt - 1;
+-      let r = this.tt - t;
+-      this.qe.length = this.Ze.length = e;
++    const i = this.st + this.Be;
++    if (this.Be === 0 && this.et[0]) this.et[0].dispose();
++    for (let e = n; e < i; e++) this.et[e - this.st].dispose();
++    if (this.st < t) {
++      let e = this.st;
++      while (e < t && e < this.Be) this.et[e++].dispose();
++      this.et.splice(0, t - this.st);
++      this.Je.splice(0, t - this.st);
++    } else if (this.st > t) {
++      let n = i - this.st - 1;
++      let r = this.st - t;
++      this.et.length = this.Je.length = e;
+       while (n >= r) {
+-        this.qe[n] = this.qe[n - r];
+-        this.Ze[n] = this.Ze[n - r];
++        this.et[n] = this.et[n - r];
++        this.Je[n] = this.Je[n - r];
+         n--;
+       }
+       for (let e = 0; e < r; e++) {
+-        this.Ze[e] = runWithOwner((this.qe[e] = createOwner()), () => this.Be(e + t));
++        this.Je[e] = runWithOwner((this.et[e] = createOwner()), () => this.Xe(e + t));
+       }
+     }
+     for (let e = i; e < n; e++) {
+-      this.Ze[e - t] = runWithOwner((this.qe[e - t] = createOwner()), () => this.Be(e));
++      this.Je[e - t] = runWithOwner((this.et[e - t] = createOwner()), () => this.Xe(e));
+     }
+-    this.Ze = this.Ze.slice(0, e);
+-    this.tt = t;
+-    this.$e = e;
++    this.Je = this.Je.slice(0, e);
++    this.st = t;
++    this.Be = e;
+   });
+-  return this.Ze;
++  return this.Je;
+ }
+ function compare(e, t, n) {
+   return e ? e(t) === e(n) : true;
+ }
+ function boundaryComputed(e, t) {
+   const n = computed(e, { lazy: true });
+-  n.Ge = (e, t) => {
+-    const i = e !== undefined ? e : n.Oe;
+-    const r = t !== undefined ? t : n.Te;
+-    n.Oe &= ~n.rt;
+-    n.$.notify(n, n.rt, i, r);
++  n.xe = (e, t) => {
++    const i = e !== undefined ? e : n.Re;
++    const r = t !== undefined ? t : n.Se;
++    n.Re &= ~n.ct;
++    n.Z.notify(n, n.ct, i, r);
+   };
+-  n.rt = t;
+-  n.Ee &= ~CONFIG_AUTO_DISPOSE;
++  n.ct = t;
++  n.de &= ~CONFIG_AUTO_DISPOSE;
+   recompute(n, true);
+   return n;
+ }
+ function createBoundChildren(e, t, n, i) {
+-  const r = e.$;
+-  r.addChild((e.$ = n));
+-  cleanup(() => r.removeChild(e.$));
++  const r = e.Z;
++  r.addChild((e.Z = n));
++  cleanup(() => r.removeChild(e.Z));
+   return runWithOwner(e, () => {
+     const e = computed(t);
+     return boundaryComputed(() => staleValues(() => flatten(read(e))), i);
+@@ -3276,52 +3488,52 @@ function isRevealController(e) {
+   return e instanceof RevealController;
+ }
+ function isSlotReady(e) {
+-  return isRevealController(e) ? e.isReady() : e.st.size === 0 && !e.ot;
++  return isRevealController(e) ? e.isReady() : e.lt.size === 0 && !e.ft;
+ }
+ function isSlotMinimallyReady(e) {
+   return isRevealController(e) ? e.isMinimallyReady() : isSlotReady(e);
+ }
+ function setSlotState(e, t, n, i) {
+-  setSignal(e.ut, n);
+-  setSignal(e.ct, i);
++  setSignal(e.Et, n);
++  setSignal(e.Tt, i);
+   if (isRevealController(e)) {
+-    if (!n && e.lt === t) e.lt = undefined;
++    if (!n && e.dt === t) e.dt = undefined;
+     return e.evaluate(n, i);
+   }
+-  if (!n && e.ft === t && e.Et) e.ft = undefined;
++  if (!n && e.St === t && e._t) e.St = undefined;
+ }
+ class RevealController {
+-  Tt;
+-  St;
+-  dt = [];
+-  lt;
+-  ut = signal(false, { ownedWrite: true, Fe: true });
+-  ct = signal(false, { ownedWrite: true, Fe: true });
+-  Ot = true;
+-  Rt = true;
+-  _t = false;
++  Ot;
++  Rt;
++  It = [];
++  dt;
++  Et = signal(false, { ownedWrite: true, Ye: true });
++  Tt = signal(false, { ownedWrite: true, Ye: true });
++  ht = true;
++  Nt = true;
++  At = false;
+   constructor(e, t) {
+-    this.Tt = e;
+-    this.St = t;
++    this.Ot = e;
++    this.Rt = t;
+   }
+-  It(e) {
+-    for (let t = 0; t < this.dt.length; t++) {
+-      const n = this.dt[t];
+-      if ((isRevealController(n) ? n.lt : n.ft) !== this) continue;
++  Pt(e) {
++    for (let t = 0; t < this.It.length; t++) {
++      const n = this.It[t];
++      if ((isRevealController(n) ? n.dt : n.St) !== this) continue;
+       if (e(n) === false) return false;
+     }
+     return true;
+   }
+   isReady() {
+-    return this.It(isSlotReady);
++    return this.Pt(isSlotReady);
+   }
+   isMinimallyReady() {
+-    const e = untrack(this.Tt);
++    const e = untrack(this.Ot);
+     if (e === "together") return this.isReady();
+     if (e === "natural") {
+       let e = false;
+       let t = false;
+-      this.It(n => {
++      this.Pt(n => {
+         e = true;
+         if (isSlotMinimallyReady(n)) {
+           t = true;
+@@ -3331,58 +3543,58 @@ class RevealController {
+       return !e || t;
+     }
+     let t = true;
+-    this.It(e => {
++    this.Pt(e => {
+       t = isSlotMinimallyReady(e);
+       return false;
+     });
+     return t;
+   }
+   register(e) {
+-    if (this.dt.includes(e)) return;
+-    this.dt.push(e);
+-    const t = untrack(this.Tt);
+-    (setSignal(e.ut, true), setSignal(e.ct, t === "sequential" ? !!untrack(this.St) : false));
++    if (this.It.includes(e)) return;
++    this.It.push(e);
++    const t = untrack(this.Ot);
++    (setSignal(e.Et, true), setSignal(e.Tt, t === "sequential" ? !!untrack(this.Rt) : false));
+     untrack(() => this.evaluate());
+   }
+   unregister(e) {
+-    const t = this.dt.indexOf(e);
+-    if (t >= 0) this.dt.splice(t, 1);
++    const t = this.It.indexOf(e);
++    if (t >= 0) this.It.splice(t, 1);
+     untrack(() => this.evaluate());
+   }
+   evaluate(e, t) {
+-    if (this._t) return;
+-    this._t = true;
+-    const n = this.Ot;
+-    const i = this.Rt;
++    if (this.At) return;
++    this.At = true;
++    const n = this.ht;
++    const i = this.Nt;
+     try {
+-      const n = e ?? read(this.ut),
+-        i = untrack(this.Tt),
+-        r = i === "sequential" && !!untrack(this.St),
++      const n = e ?? read(this.Et),
++        i = untrack(this.Ot),
++        r = i === "sequential" && !!untrack(this.Rt),
+         s = t ?? r;
+       if (n) {
+-        this.It(e => setSlotState(e, this, true, s));
++        this.Pt(e => setSlotState(e, this, true, s));
+       } else if (i === "natural") {
+-        this.It(e => {
++        this.Pt(e => {
+           if (isRevealController(e)) {
+-            setSignal(e.ct, false);
+-            setSignal(e.ut, false);
++            setSignal(e.Tt, false);
++            setSignal(e.Et, false);
+             e.evaluate(false, false);
+           } else {
+             setSlotState(e, this, !isSlotReady(e), false);
+           }
+         });
+       } else if (i === "together") {
+-        const e = this.It(isSlotMinimallyReady);
+-        this.It(t => setSlotState(t, this, !e, false));
++        const e = this.Pt(isSlotMinimallyReady);
++        this.Pt(t => setSlotState(t, this, !e, false));
+       } else {
+         let e = false;
+-        this.It(t => {
++        this.Pt(t => {
+           if (e) return setSlotState(t, this, true, r);
+           if (isSlotReady(t)) return setSlotState(t, this, false, false);
+           e = true;
+           if (isRevealController(t)) {
+-            setSignal(t.ct, false);
+-            setSignal(t.ut, false);
++            setSignal(t.Tt, false);
++            setSignal(t.Et, false);
+             t.evaluate(false, false);
+           } else {
+             setSlotState(t, this, true, false);
+@@ -3390,96 +3602,96 @@ class RevealController {
+         });
+       }
+     } finally {
+-      this.Ot = this.isReady();
+-      this.Rt = this.isMinimallyReady();
+-      this._t = false;
++      this.ht = this.isReady();
++      this.Nt = this.isMinimallyReady();
++      this.At = false;
+     }
+-    if (this.lt && (n !== this.Ot || i !== this.Rt)) this.lt.evaluate();
++    if (this.dt && (n !== this.ht || i !== this.Nt)) this.dt.evaluate();
+   }
+ }
+ class CollectionQueue extends Queue {
+-  ht;
+-  st = new Set();
+-  Nt;
+-  ot = true;
+-  ut = signal(false, { ownedWrite: true, Fe: true });
+-  ct = signal(false, { ownedWrite: true, Fe: true });
+-  ft;
+-  Et = false;
+-  At;
+-  Pt = ON_INIT;
++  Ct;
++  lt = new Set();
++  gt;
++  ft = true;
++  Et = signal(false, { ownedWrite: true, Ye: true });
++  Tt = signal(false, { ownedWrite: true, Ye: true });
++  St;
++  _t = false;
++  Dt;
++  yt = ON_INIT;
+   constructor(e) {
+     super();
+-    this.ht = e;
++    this.Ct = e;
+   }
+   run(e) {
+-    if (!e || (read(this.ut) && (!_revealUsed || read(this.ct)))) return;
++    if (!e || (read(this.Et) && (!_revealUsed || read(this.Tt)))) return;
+     return super.run(e);
+   }
+   notify(e, t, n, i) {
+-    if (!(t & this.ht)) return super.notify(e, t, n, i);
+-    if (this.Et && this.At) {
++    if (!(t & this.Ct)) return super.notify(e, t, n, i);
++    if (this._t && this.Dt) {
+       const e = untrack(() => {
+         try {
+-          return this.At();
++          return this.Dt();
+         } catch {
+           return ON_INIT;
+         }
+       });
+-      if (e !== this.Pt) {
+-        this.Pt = e;
+-        this.Et = false;
+-        this.st.clear();
++      if (e !== this.yt) {
++        this.yt = e;
++        this._t = false;
++        this.lt.clear();
+       }
+     }
+-    if (this.ht & STATUS_PENDING && this.Et) return super.notify(e, t, n, i);
+-    if (this.ht & STATUS_PENDING && n & STATUS_ERROR) {
++    if (this.Ct & STATUS_PENDING && this._t) return super.notify(e, t, n, i);
++    if (this.Ct & STATUS_PENDING && n & STATUS_ERROR) {
+       return super.notify(e, STATUS_ERROR, n, i);
+     }
+-    if (n & this.ht) {
+-      this.ot = true;
+-      const t = i?.source || e.Te?.source;
++    if (n & this.Ct) {
++      this.ft = true;
++      const t = i?.source || e.Se?.source;
+       if (t) {
+-        const e = this.st.size === 0;
+-        this.st.add(t);
+-        if (e) setSignal(this.ut, true);
++        const e = this.lt.size === 0;
++        this.lt.add(t);
++        if (e) setSignal(this.Et, true);
+       }
+     }
+-    t &= ~this.ht;
++    t &= ~this.Ct;
+     return t ? super.notify(e, t, n, i) : true;
+   }
+   checkSources() {
+-    for (const e of this.st) {
++    for (const e of this.lt) {
+       if (
+-        e.R & REACTIVE_DISPOSED ||
+-        (!(e.Oe & this.ht) && !(this.ht & STATUS_ERROR && e.Oe & STATUS_PENDING))
++        e.O & REACTIVE_DISPOSED ||
++        (!(e.Re & this.Ct) && !(this.Ct & STATUS_ERROR && e.Re & STATUS_PENDING))
+       )
+-        this.st.delete(e);
++        this.lt.delete(e);
+     }
+-    if (!this.st.size) {
+-      if (this.ht & STATUS_PENDING && this.ot && !this.Et && this.Nt) {
+-        this.ot = !!(this.Nt.Oe & this.ht);
++    if (!this.lt.size) {
++      if (this.Ct & STATUS_PENDING && this.ft && !this._t && this.gt) {
++        this.ft = !!(this.gt.Re & this.Ct);
+       } else {
+-        this.ot = false;
++        this.ft = false;
+       }
+-      if (!this.ot) {
+-        setSignal(this.ut, false);
+-        if (this.At) {
++      if (!this.ft) {
++        setSignal(this.Et, false);
++        if (this.Dt) {
+           try {
+-            this.Pt = untrack(() => this.At());
++            this.yt = untrack(() => this.Dt());
+           } catch {}
+         }
+       }
+     }
+-    if (_revealUsed) this.ft?.evaluate();
++    if (_revealUsed) this.St?.evaluate();
+   }
+ }
+ function createCollectionBoundary(e, t, n, i) {
+   const r = createOwner();
+   if (_revealUsed) setContext(RevealControllerContext, null, r);
+   const s = new CollectionQueue(e);
+-  if (i) s.At = i;
+-  const o = (s.Nt = createBoundChildren(r, t, s, e));
++  if (i) s.Dt = i;
++  const o = (s.gt = createBoundChildren(r, t, s, e));
+   untrack(() => {
+     let t = false;
+     try {
+@@ -3488,21 +3700,21 @@ function createCollectionBoundary(e, t, n, i) {
+       if (e instanceof NotReadyError) t = true;
+       else throw e;
+     }
+-    s.ot = t || !!(o.Oe & e) || o.Te instanceof NotReadyError;
++    s.ft = t || !!(o.Re & e) || o.Se instanceof NotReadyError;
+   });
+   const u = _revealUsed && e === STATUS_PENDING ? getContext(RevealControllerContext) : null;
+   if (u) {
+-    s.ft = u;
++    s.St = u;
+     u.register(s);
+     cleanup(() => u.unregister(s));
+   }
+   return accessor(
+     computed(() => {
+-      if (!read(s.ut)) {
++      if (!read(s.Et)) {
+         const e = read(o);
+-        if (!untrack(() => read(s.ut))) return ((s.Et = true), e);
++        if (!untrack(() => read(s.Et))) return ((s._t = true), e);
+       }
+-      if (_revealUsed && read(s.ct)) return undefined;
++      if (_revealUsed && read(s.Tt)) return undefined;
+       return n(s);
+     })
+   );
+@@ -3512,10 +3724,10 @@ function createLoadingBoundary(e, t, n) {
+ }
+ function createErrorBoundary(e, t) {
+   return createCollectionBoundary(STATUS_ERROR, e, e => {
+-    let n = e.st.values().next().value;
+-    const i = n.Te?.cause ?? n.Te;
++    let n = e.lt.values().next().value;
++    const i = n.Se?.cause ?? n.Se;
+     return t(i, () => {
+-      for (const t of e.st) recompute(t);
++      for (const t of e.lt) recompute(t);
+       schedule();
+     });
+   });
+@@ -3536,7 +3748,7 @@ function createRevealOrder(e, t) {
+       o.evaluate();
+     });
+     if (i) {
+-      o.lt = i;
++      o.dt = i;
+       i.register(o);
+       cleanup(() => i.unregister(o));
+     }
+diff --git a/dist/types/core/constants.d.ts b/dist/types/core/constants.d.ts
+index 51370c459abf391dcf202efac2a86da4f880d0c6..489e853a30fb04a54bfd16a53d2cf845a13001d2 100644
+--- a/dist/types/core/constants.d.ts
++++ b/dist/types/core/constants.d.ts
+@@ -9,12 +9,14 @@ export declare const REACTIVE_DISPOSED: number;
+ export declare const REACTIVE_OPTIMISTIC_DIRTY: number;
+ export declare const REACTIVE_SNAPSHOT_STALE: number;
+ export declare const REACTIVE_LAZY: number;
++export declare const REACTIVE_MANUAL_WRITE: number;
+ export declare const CONFIG_OWNED_WRITE: number;
+ export declare const CONFIG_NO_SNAPSHOT: number;
+ export declare const CONFIG_TRANSPARENT: number;
+ export declare const CONFIG_IN_SNAPSHOT_SCOPE: number;
+ export declare const CONFIG_CHILDREN_FORBIDDEN: number;
+ export declare const CONFIG_AUTO_DISPOSE: number;
++export declare const CONFIG_SYNC: number;
+ export declare const STATUS_NONE = 0;
+ export declare const STATUS_PENDING: number;
+ export declare const STATUS_ERROR: number;
+diff --git a/dist/types/core/core.d.ts b/dist/types/core/core.d.ts
+index a77960ebf837dabfd4993a195531961ad00f774f..fe6bae5ae83b4d243234550c979d7b03bde66e72 100644
+--- a/dist/types/core/core.d.ts
++++ b/dist/types/core/core.d.ts
+@@ -19,6 +19,13 @@ export declare function clearSnapshots(): void;
+ export declare function recompute(el: Computed<any>, create?: boolean): void;
+ export declare function computed<T>(fn: (prev?: T) => T | PromiseLike<T> | AsyncIterable<T>): Computed<T>;
+ export declare function computed<T>(fn: (prev: T) => T | PromiseLike<T> | AsyncIterable<T>, options?: NodeOptions<T>): Computed<T>;
++/**
++ * Build an Effect node with all effect-specific fields baked into a single object literal,
++ * so V8 sees the full hidden class shape at construction time. Effects always run in lazy
++ * mode (recompute is called explicitly by `effect()`), so we hardcode the lazy bits and skip
++ * the auto-dispose CONFIG bit (effect() previously cleared it post-construction).
++ */
++export declare function createEffectNode<T>(fn: (prev?: T) => T, effectFn: (val: T, prev: T | undefined) => void | (() => void), errorFn: ((err: unknown, cleanup: () => void) => void | (() => void)) | undefined, type: number, notifyStatus: ((status?: number, error?: any) => void) | undefined, options: NodeOptions<T> | undefined): any;
+ export declare function signal<T>(v: T, options?: NodeOptions<T>): Signal<T>;
+ export declare function signal<T>(v: T, options?: NodeOptions<T>, firewall?: Computed<any>): FirewallSignal<T>;
+ export declare function optimisticSignal<T>(v: T, options?: NodeOptions<T>): Signal<T>;
+@@ -55,6 +62,21 @@ export declare function setStrictRead(v: string | false): string | false;
+ export declare function untrack<T>(fn: () => T, strictReadLabel?: string | false): T;
+ export declare function read<T>(el: Signal<T> | Computed<T>): T;
+ export declare function setSignal<T>(el: Signal<T> | Computed<T>, v: T | ((prev: T) => T)): T;
++/**
++ * Suppresses automatic recomputation of `el` until the scheduler drains. Used
++ * when a manual write should win over dependency changes queued in the same
++ * tick. The MANUAL_WRITE flag is cleared by the pending-node drain; projection
++ * computeds don't commit values, but they still need the same end-of-tick
++ * cleanup point.
++ */
++export declare function suppressComputedRecompute(el: Computed<unknown>): void;
++/**
++ * User-facing setter for the memo form of `createSignal(fn)`. Behaves like
++ * `setSignal`, but also cancels any pending recompute of the memo so the
++ * manual value wins over a value that would otherwise be produced by an
++ * upstream change in the same tick.
++ */
++export declare function setMemo<T>(el: Computed<T>, v: T | ((prev: T) => T)): T;
+ /**
+  * Executes `fn` with the given `owner` set as the current owner. Any reactive
+  * primitives (`createSignal`, `createMemo`, `createEffect`, `onCleanup`,
+diff --git a/dist/types/core/dev.d.ts b/dist/types/core/dev.d.ts
+index 8ddf369a977ffb17208e6112999b8e2b06967f21..0bf54f032a71e08d57657b4c0958cc1583f9018d 100644
+--- a/dist/types/core/dev.d.ts
++++ b/dist/types/core/dev.d.ts
+@@ -6,7 +6,7 @@ export interface DevHooks {
+     onStoreNodeUpdate?: (state: any, property: PropertyKey, value: any, prev: any) => void;
+ }
+ export type DiagnosticSeverity = "warn" | "error";
+-export type DiagnosticCode = "STRICT_READ_UNTRACKED" | "PENDING_ASYNC_UNTRACKED_READ" | "PENDING_ASYNC_FORBIDDEN_SCOPE" | "SIGNAL_WRITE_IN_OWNED_SCOPE" | "RUN_WITH_DISPOSED_OWNER" | "NO_OWNER_CLEANUP" | "CLEANUP_IN_FORBIDDEN_SCOPE" | "PRIMITIVE_IN_FORBIDDEN_SCOPE" | "NO_OWNER_EFFECT" | "NO_OWNER_BOUNDARY" | "ASYNC_OUTSIDE_LOADING_BOUNDARY" | "MISSING_EFFECT_FN";
++export type DiagnosticCode = "STRICT_READ_UNTRACKED" | "PENDING_ASYNC_UNTRACKED_READ" | "PENDING_ASYNC_FORBIDDEN_SCOPE" | "SIGNAL_WRITE_IN_OWNED_SCOPE" | "RUN_WITH_DISPOSED_OWNER" | "NO_OWNER_CLEANUP" | "CLEANUP_IN_FORBIDDEN_SCOPE" | "PRIMITIVE_IN_FORBIDDEN_SCOPE" | "NO_OWNER_EFFECT" | "NO_OWNER_BOUNDARY" | "ASYNC_OUTSIDE_LOADING_BOUNDARY" | "MISSING_EFFECT_FN" | "SYNC_NODE_RECEIVED_ASYNC";
+ export type DiagnosticKind = "strict-read" | "async" | "write" | "lifecycle" | "owner";
+ export interface DiagnosticEvent {
+     sequence: number;
+diff --git a/dist/types/core/effect.d.ts b/dist/types/core/effect.d.ts
+index 734312e93a250a9e61ee7a6bf1a5968d4ab8e2f6..33e94cc2cb995069cd6ee5850a6bd1bf74dd8e7e 100644
+--- a/dist/types/core/effect.d.ts
++++ b/dist/types/core/effect.d.ts
+@@ -3,6 +3,7 @@ export interface Effect<T> extends Computed<T>, Owner {
+     _effectFn: (val: T, prev: T | undefined) => void | (() => void);
+     _errorFn?: (err: unknown, cleanup: () => void) => void;
+     _cleanup?: () => void;
++    _cleanupRegistered?: boolean;
+     _modified: boolean;
+     _prevValue: T | undefined;
+     _type: number;
+diff --git a/dist/types/core/index.d.ts b/dist/types/core/index.d.ts
+index 166076aed72290c92fba4e57032e056e4a602393..60d2e91ea4dc645045d9a7e69e133c6bbe4c9c38 100644
+--- a/dist/types/core/index.d.ts
++++ b/dist/types/core/index.d.ts
+@@ -1,5 +1,5 @@
+ export { ContextNotFoundError, NoOwnerError, NotReadyError } from "./error.js";
+-export { isEqual, untrack, runWithOwner, computed, signal, read, setSignal, optimisticSignal, optimisticComputed, isPending, latest, refresh, isRefreshing, staleValues, setSnapshotCapture, markSnapshotScope, releaseSnapshotScope, clearSnapshots } from "./core.js";
++export { isEqual, untrack, runWithOwner, computed, signal, read, setSignal, setMemo, suppressComputedRecompute, optimisticSignal, optimisticComputed, isPending, latest, refresh, isRefreshing, staleValues, setSnapshotCapture, markSnapshotScope, releaseSnapshotScope, clearSnapshots } from "./core.js";
+ export { enableExternalSource, _resetExternalSourceConfig, type ExternalSourceFactory, type ExternalSource, type ExternalSourceConfig } from "./external.js";
+ export { createOwner, createRoot, dispose, getNextChildId, getObserver, getOwner, isDisposed, cleanup, peekNextChildId } from "./owner.js";
+ export { createContext, getContext, setContext, type Context, type ContextRecord } from "./context.js";
+diff --git a/dist/types/core/scheduler.d.ts b/dist/types/core/scheduler.d.ts
+index 9d66ee8868c1c5e4294b256259e9cdd9036f7521..712039c8cfb467fff906e35dc3e7787e247de93a 100644
+--- a/dist/types/core/scheduler.d.ts
++++ b/dist/types/core/scheduler.d.ts
+@@ -67,28 +67,33 @@ export declare class Queue implements IQueue {
+ }
+ export declare class GlobalQueue extends Queue {
+     _running: boolean;
++    _pendingNode: Signal<any> | null;
+     _pendingNodes: Signal<any>[];
+     _optimisticNodes: OptimisticNode[];
+     _optimisticStores: Set<any>;
+     static _update: (el: Computed<unknown>) => void;
+     static _dispose: (el: Computed<unknown>, self: boolean, zombie: boolean) => void;
++    static _runEffect: (el: Computed<unknown>) => void;
+     static _clearOptimisticStore: ((store: any) => void) | null;
+     flush(): void;
+     notify(node: Computed<any>, mask: number, flags: number, error?: any): boolean;
+     initTransition(transition?: Transition | null): void;
+ }
++export declare function queuePendingNode(node: Signal<any>): void;
+ export declare function insertSubs(node: Signal<any> | Computed<any>, optimistic?: boolean): void;
+ export declare function finalizePureQueue(completingTransition?: Transition | null, incomplete?: boolean): void;
+ export declare function trackOptimisticStore(store: any): void;
+ export declare const globalQueue: GlobalQueue;
+ /**
+- * Synchronously processes the pending reactive queue: runs every scheduled
+- * memo/effect/computation that has dirty inputs, until the graph is settled.
++ * Synchronously processes the pending reactive queue, or runs `fn` in a synchronous
++ * flush scope before draining the queue.
+  *
+  * Reactive updates are normally batched onto the microtask queue, so multiple
+  * writes in a row collapse into a single update pass. Call `flush()` when you
+  * need to *observe* the result of those writes synchronously — most commonly
+- * in tests, but also at the boundary of imperative integration code.
++ * in tests, but also at the boundary of imperative integration code. Pass a
++ * callback when the writes themselves should bypass microtask scheduling and
++ * drain synchronously when the callback returns.
+  *
+  * @example
+  * ```ts
+@@ -98,9 +103,20 @@ export declare const globalQueue: GlobalQueue;
+  * setCount(5);
+  * flush();
+  * expect(doubled()).toBe(10);
++ *
++ * flush(() => setCount(6));
++ * expect(doubled()).toBe(12);
++ *
++ * // Nested flushes drain at each level:
++ * flush(() => {
++ *   setCount(7);
++ *   flush(() => setCount(8)); // inner drain — effects fire here
++ *   // outer continues with up-to-date state
++ * });
+  * ```
+  */
+ export declare function flush(): void;
++export declare function flush<T>(fn: () => T): T;
+ export declare function currentTransition(transition: Transition): Transition;
+ export declare function setActiveTransition(transition: Transition | null): void;
+ export declare function runInTransition<T>(transition: Transition, fn: () => T): T;
+diff --git a/dist/types/core/types.d.ts b/dist/types/core/types.d.ts
+index 971777f860d11ece280ebc76a95eb82a4e0d9624..f7afab1b0c34f997a8fcb22bd06965adcb13c704 100644
+--- a/dist/types/core/types.d.ts
++++ b/dist/types/core/types.d.ts
+@@ -21,6 +21,7 @@ export interface NodeOptions<T> {
+     _noSnapshot?: boolean;
+     unobserved?: () => void;
+     lazy?: boolean;
++    sync?: boolean;
+ }
+ export interface RawSignal<T> {
+     _subs: Link | null;
+@@ -56,6 +57,7 @@ export interface Owner {
+     _queue: IQueue;
+     _firstChild: Owner | null;
+     _nextSibling: Owner | null;
++    _prevSibling: Owner | null;
+     _pendingDisposal: Disposable | Disposable[] | null;
+     _pendingFirstChild: Owner | null;
+ }
+diff --git a/dist/types/signals.d.ts b/dist/types/signals.d.ts
+index 17371e9ca4bd5e02222957f419fddc2ebb0c8467..9839481ce5875dc087dedc72c04185b38607e30d 100644
+--- a/dist/types/signals.d.ts
++++ b/dist/types/signals.d.ts
+@@ -89,6 +89,16 @@ export interface EffectOptions extends BaseEffectOptions {
+      * `insert()` in `render()`).
+      */
+     schedule?: boolean;
++    /**
++     * Advanced. When true, asserts the compute function returns synchronous
++     * values only (never `PromiseLike` / `AsyncIterable`). Skips the
++     * async-shape probe in `recompute` for a small fixed-cost win per run.
++     * Intended for compiler emissions (`_$effect`) and library code that
++     * provably returns sync values. Returning a Promise or async iterable
++     * from a `sync: true` effect is undefined behavior — the value will be
++     * stored as-is and never awaited.
++     */
++    sync?: boolean;
+ }
+ /** Options for plain signals created with `createSignal(value)` or `createOptimistic(value)`. */
+ export interface SignalOptions<T> {
+@@ -136,6 +146,16 @@ export interface MemoOptions<T> {
+      * never autodispose.
+      */
+     lazy?: boolean;
++    /**
++     * Advanced. When true, asserts the compute function returns synchronous
++     * values only (never `PromiseLike` / `AsyncIterable`). Skips the
++     * async-shape probe in `recompute` for a small fixed-cost win per run.
++     * Intended for compiler emissions (`_$memo`) and library code that
++     * provably returns sync values. Returning a Promise or async iterable
++     * from a `sync: true` memo is undefined behavior — the value will be
++     * stored as-is and never awaited.
++     */
++    sync?: boolean;
+ }
+ export type NoInfer<T extends any> = [T][T extends any ? 0 : never];
+ /**
+diff --git a/dist/types-cjs/core/constants.d.cts b/dist/types-cjs/core/constants.d.cts
+index 51370c459abf391dcf202efac2a86da4f880d0c6..489e853a30fb04a54bfd16a53d2cf845a13001d2 100644
+--- a/dist/types-cjs/core/constants.d.cts
++++ b/dist/types-cjs/core/constants.d.cts
+@@ -9,12 +9,14 @@ export declare const REACTIVE_DISPOSED: number;
+ export declare const REACTIVE_OPTIMISTIC_DIRTY: number;
+ export declare const REACTIVE_SNAPSHOT_STALE: number;
+ export declare const REACTIVE_LAZY: number;
++export declare const REACTIVE_MANUAL_WRITE: number;
+ export declare const CONFIG_OWNED_WRITE: number;
+ export declare const CONFIG_NO_SNAPSHOT: number;
+ export declare const CONFIG_TRANSPARENT: number;
+ export declare const CONFIG_IN_SNAPSHOT_SCOPE: number;
+ export declare const CONFIG_CHILDREN_FORBIDDEN: number;
+ export declare const CONFIG_AUTO_DISPOSE: number;
++export declare const CONFIG_SYNC: number;
+ export declare const STATUS_NONE = 0;
+ export declare const STATUS_PENDING: number;
+ export declare const STATUS_ERROR: number;
+diff --git a/dist/types-cjs/core/core.d.cts b/dist/types-cjs/core/core.d.cts
+index 0f140d62edd7fa8c5d5b1fceed0bd431ece95847..f250593c7ad6a7c33314e8e6253de6d62ff58e40 100644
+--- a/dist/types-cjs/core/core.d.cts
++++ b/dist/types-cjs/core/core.d.cts
+@@ -19,6 +19,13 @@ export declare function clearSnapshots(): void;
+ export declare function recompute(el: Computed<any>, create?: boolean): void;
+ export declare function computed<T>(fn: (prev?: T) => T | PromiseLike<T> | AsyncIterable<T>): Computed<T>;
+ export declare function computed<T>(fn: (prev: T) => T | PromiseLike<T> | AsyncIterable<T>, options?: NodeOptions<T>): Computed<T>;
++/**
++ * Build an Effect node with all effect-specific fields baked into a single object literal,
++ * so V8 sees the full hidden class shape at construction time. Effects always run in lazy
++ * mode (recompute is called explicitly by `effect()`), so we hardcode the lazy bits and skip
++ * the auto-dispose CONFIG bit (effect() previously cleared it post-construction).
++ */
++export declare function createEffectNode<T>(fn: (prev?: T) => T, effectFn: (val: T, prev: T | undefined) => void | (() => void), errorFn: ((err: unknown, cleanup: () => void) => void | (() => void)) | undefined, type: number, notifyStatus: ((status?: number, error?: any) => void) | undefined, options: NodeOptions<T> | undefined): any;
+ export declare function signal<T>(v: T, options?: NodeOptions<T>): Signal<T>;
+ export declare function signal<T>(v: T, options?: NodeOptions<T>, firewall?: Computed<any>): FirewallSignal<T>;
+ export declare function optimisticSignal<T>(v: T, options?: NodeOptions<T>): Signal<T>;
+@@ -55,6 +62,21 @@ export declare function setStrictRead(v: string | false): string | false;
+ export declare function untrack<T>(fn: () => T, strictReadLabel?: string | false): T;
+ export declare function read<T>(el: Signal<T> | Computed<T>): T;
+ export declare function setSignal<T>(el: Signal<T> | Computed<T>, v: T | ((prev: T) => T)): T;
++/**
++ * Suppresses automatic recomputation of `el` until the scheduler drains. Used
++ * when a manual write should win over dependency changes queued in the same
++ * tick. The MANUAL_WRITE flag is cleared by the pending-node drain; projection
++ * computeds don't commit values, but they still need the same end-of-tick
++ * cleanup point.
++ */
++export declare function suppressComputedRecompute(el: Computed<unknown>): void;
++/**
++ * User-facing setter for the memo form of `createSignal(fn)`. Behaves like
++ * `setSignal`, but also cancels any pending recompute of the memo so the
++ * manual value wins over a value that would otherwise be produced by an
++ * upstream change in the same tick.
++ */
++export declare function setMemo<T>(el: Computed<T>, v: T | ((prev: T) => T)): T;
+ /**
+  * Executes `fn` with the given `owner` set as the current owner. Any reactive
+  * primitives (`createSignal`, `createMemo`, `createEffect`, `onCleanup`,
+diff --git a/dist/types-cjs/core/dev.d.cts b/dist/types-cjs/core/dev.d.cts
+index 8ef3da27aa092fb083d02797f4bf590b270c134f..3d2c8444b22b3d578555a0552d2d3030ae120882 100644
+--- a/dist/types-cjs/core/dev.d.cts
++++ b/dist/types-cjs/core/dev.d.cts
+@@ -6,7 +6,7 @@ export interface DevHooks {
+     onStoreNodeUpdate?: (state: any, property: PropertyKey, value: any, prev: any) => void;
+ }
+ export type DiagnosticSeverity = "warn" | "error";
+-export type DiagnosticCode = "STRICT_READ_UNTRACKED" | "PENDING_ASYNC_UNTRACKED_READ" | "PENDING_ASYNC_FORBIDDEN_SCOPE" | "SIGNAL_WRITE_IN_OWNED_SCOPE" | "RUN_WITH_DISPOSED_OWNER" | "NO_OWNER_CLEANUP" | "CLEANUP_IN_FORBIDDEN_SCOPE" | "PRIMITIVE_IN_FORBIDDEN_SCOPE" | "NO_OWNER_EFFECT" | "NO_OWNER_BOUNDARY" | "ASYNC_OUTSIDE_LOADING_BOUNDARY" | "MISSING_EFFECT_FN";
++export type DiagnosticCode = "STRICT_READ_UNTRACKED" | "PENDING_ASYNC_UNTRACKED_READ" | "PENDING_ASYNC_FORBIDDEN_SCOPE" | "SIGNAL_WRITE_IN_OWNED_SCOPE" | "RUN_WITH_DISPOSED_OWNER" | "NO_OWNER_CLEANUP" | "CLEANUP_IN_FORBIDDEN_SCOPE" | "PRIMITIVE_IN_FORBIDDEN_SCOPE" | "NO_OWNER_EFFECT" | "NO_OWNER_BOUNDARY" | "ASYNC_OUTSIDE_LOADING_BOUNDARY" | "MISSING_EFFECT_FN" | "SYNC_NODE_RECEIVED_ASYNC";
+ export type DiagnosticKind = "strict-read" | "async" | "write" | "lifecycle" | "owner";
+ export interface DiagnosticEvent {
+     sequence: number;
+diff --git a/dist/types-cjs/core/effect.d.cts b/dist/types-cjs/core/effect.d.cts
+index 957e5541bc97b4797bae14b1c5e61c2cf8c169a4..6dd07979fee371e258e51771a8c2e3ae04a636f3 100644
+--- a/dist/types-cjs/core/effect.d.cts
++++ b/dist/types-cjs/core/effect.d.cts
+@@ -3,6 +3,7 @@ export interface Effect<T> extends Computed<T>, Owner {
+     _effectFn: (val: T, prev: T | undefined) => void | (() => void);
+     _errorFn?: (err: unknown, cleanup: () => void) => void;
+     _cleanup?: () => void;
++    _cleanupRegistered?: boolean;
+     _modified: boolean;
+     _prevValue: T | undefined;
+     _type: number;
+diff --git a/dist/types-cjs/core/index.d.cts b/dist/types-cjs/core/index.d.cts
+index a716a07b07c3c5e754e8dee0f123ab297f301fcb..bbebce60e7933eb1d2c2a8effa56ff647c716145 100644
+--- a/dist/types-cjs/core/index.d.cts
++++ b/dist/types-cjs/core/index.d.cts
+@@ -1,5 +1,5 @@
+ export { ContextNotFoundError, NoOwnerError, NotReadyError } from "./error.cjs";
+-export { isEqual, untrack, runWithOwner, computed, signal, read, setSignal, optimisticSignal, optimisticComputed, isPending, latest, refresh, isRefreshing, staleValues, setSnapshotCapture, markSnapshotScope, releaseSnapshotScope, clearSnapshots } from "./core.cjs";
++export { isEqual, untrack, runWithOwner, computed, signal, read, setSignal, setMemo, suppressComputedRecompute, optimisticSignal, optimisticComputed, isPending, latest, refresh, isRefreshing, staleValues, setSnapshotCapture, markSnapshotScope, releaseSnapshotScope, clearSnapshots } from "./core.cjs";
+ export { enableExternalSource, _resetExternalSourceConfig, type ExternalSourceFactory, type ExternalSource, type ExternalSourceConfig } from "./external.cjs";
+ export { createOwner, createRoot, dispose, getNextChildId, getObserver, getOwner, isDisposed, cleanup, peekNextChildId } from "./owner.cjs";
+ export { createContext, getContext, setContext, type Context, type ContextRecord } from "./context.cjs";
+diff --git a/dist/types-cjs/core/scheduler.d.cts b/dist/types-cjs/core/scheduler.d.cts
+index b2629f22b3b36e6b6842210f0d732a192bfbd0e8..3fb95df238c6a5c8ee40c85cbee9f261c48e96aa 100644
+--- a/dist/types-cjs/core/scheduler.d.cts
++++ b/dist/types-cjs/core/scheduler.d.cts
+@@ -67,28 +67,33 @@ export declare class Queue implements IQueue {
+ }
+ export declare class GlobalQueue extends Queue {
+     _running: boolean;
++    _pendingNode: Signal<any> | null;
+     _pendingNodes: Signal<any>[];
+     _optimisticNodes: OptimisticNode[];
+     _optimisticStores: Set<any>;
+     static _update: (el: Computed<unknown>) => void;
+     static _dispose: (el: Computed<unknown>, self: boolean, zombie: boolean) => void;
++    static _runEffect: (el: Computed<unknown>) => void;
+     static _clearOptimisticStore: ((store: any) => void) | null;
+     flush(): void;
+     notify(node: Computed<any>, mask: number, flags: number, error?: any): boolean;
+     initTransition(transition?: Transition | null): void;
+ }
++export declare function queuePendingNode(node: Signal<any>): void;
+ export declare function insertSubs(node: Signal<any> | Computed<any>, optimistic?: boolean): void;
+ export declare function finalizePureQueue(completingTransition?: Transition | null, incomplete?: boolean): void;
+ export declare function trackOptimisticStore(store: any): void;
+ export declare const globalQueue: GlobalQueue;
+ /**
+- * Synchronously processes the pending reactive queue: runs every scheduled
+- * memo/effect/computation that has dirty inputs, until the graph is settled.
++ * Synchronously processes the pending reactive queue, or runs `fn` in a synchronous
++ * flush scope before draining the queue.
+  *
+  * Reactive updates are normally batched onto the microtask queue, so multiple
+  * writes in a row collapse into a single update pass. Call `flush()` when you
+  * need to *observe* the result of those writes synchronously — most commonly
+- * in tests, but also at the boundary of imperative integration code.
++ * in tests, but also at the boundary of imperative integration code. Pass a
++ * callback when the writes themselves should bypass microtask scheduling and
++ * drain synchronously when the callback returns.
+  *
+  * @example
+  * ```ts
+@@ -98,9 +103,20 @@ export declare const globalQueue: GlobalQueue;
+  * setCount(5);
+  * flush();
+  * expect(doubled()).toBe(10);
++ *
++ * flush(() => setCount(6));
++ * expect(doubled()).toBe(12);
++ *
++ * // Nested flushes drain at each level:
++ * flush(() => {
++ *   setCount(7);
++ *   flush(() => setCount(8)); // inner drain — effects fire here
++ *   // outer continues with up-to-date state
++ * });
+  * ```
+  */
+ export declare function flush(): void;
++export declare function flush<T>(fn: () => T): T;
+ export declare function currentTransition(transition: Transition): Transition;
+ export declare function setActiveTransition(transition: Transition | null): void;
+ export declare function runInTransition<T>(transition: Transition, fn: () => T): T;
+diff --git a/dist/types-cjs/core/types.d.cts b/dist/types-cjs/core/types.d.cts
+index e1024c4f4ba8399173dcc340f87ef96783bc473f..b2cfdcece4af9eed038474aeeec923d9b1d347b7 100644
+--- a/dist/types-cjs/core/types.d.cts
++++ b/dist/types-cjs/core/types.d.cts
+@@ -21,6 +21,7 @@ export interface NodeOptions<T> {
+     _noSnapshot?: boolean;
+     unobserved?: () => void;
+     lazy?: boolean;
++    sync?: boolean;
+ }
+ export interface RawSignal<T> {
+     _subs: Link | null;
+@@ -56,6 +57,7 @@ export interface Owner {
+     _queue: IQueue;
+     _firstChild: Owner | null;
+     _nextSibling: Owner | null;
++    _prevSibling: Owner | null;
+     _pendingDisposal: Disposable | Disposable[] | null;
+     _pendingFirstChild: Owner | null;
+ }
+diff --git a/dist/types-cjs/signals.d.cts b/dist/types-cjs/signals.d.cts
+index e21f987cf772f433d02795715b844dab24bcc2ed..6fbdda83398b8ef2b852323d5dc6c1ec0c23b0d2 100644
+--- a/dist/types-cjs/signals.d.cts
++++ b/dist/types-cjs/signals.d.cts
+@@ -89,6 +89,16 @@ export interface EffectOptions extends BaseEffectOptions {
+      * `insert()` in `render()`).
+      */
+     schedule?: boolean;
++    /**
++     * Advanced. When true, asserts the compute function returns synchronous
++     * values only (never `PromiseLike` / `AsyncIterable`). Skips the
++     * async-shape probe in `recompute` for a small fixed-cost win per run.
++     * Intended for compiler emissions (`_$effect`) and library code that
++     * provably returns sync values. Returning a Promise or async iterable
++     * from a `sync: true` effect is undefined behavior — the value will be
++     * stored as-is and never awaited.
++     */
++    sync?: boolean;
+ }
+ /** Options for plain signals created with `createSignal(value)` or `createOptimistic(value)`. */
+ export interface SignalOptions<T> {
+@@ -136,6 +146,16 @@ export interface MemoOptions<T> {
+      * never autodispose.
+      */
+     lazy?: boolean;
++    /**
++     * Advanced. When true, asserts the compute function returns synchronous
++     * values only (never `PromiseLike` / `AsyncIterable`). Skips the
++     * async-shape probe in `recompute` for a small fixed-cost win per run.
++     * Intended for compiler emissions (`_$memo`) and library code that
++     * provably returns sync values. Returning a Promise or async iterable
++     * from a `sync: true` memo is undefined behavior — the value will be
++     * stored as-is and never awaited.
++     */
++    sync?: boolean;
+ }
+ export type NoInfer<T extends any> = [T][T extends any ? 0 : never];
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,11 @@ overrides:
   '@tanstack/start-static-server-functions': workspace:*
   '@tanstack/nitro-v2-vite-plugin': workspace:*
 
+patchedDependencies:
+  '@solidjs/signals@2.0.0-beta.10':
+    hash: 1d5de47facd32b65a19e9d46610fb2c5ac2b16983219bf8806b97bad2f376364
+    path: patches/@solidjs__signals@2.0.0-beta.10.patch
+
 importers:
 
   .:
@@ -30988,7 +30993,7 @@ snapshots:
     dependencies:
       solid-js: 2.0.0-beta.10
 
-  '@solidjs/signals@2.0.0-beta.10': {}
+  '@solidjs/signals@2.0.0-beta.10(patch_hash=1d5de47facd32b65a19e9d46610fb2c5ac2b16983219bf8806b97bad2f376364)': {}
 
   '@solidjs/testing-library@0.8.10(solid-js@2.0.0-beta.10)':
     dependencies:
@@ -38581,7 +38586,7 @@ snapshots:
 
   solid-js@2.0.0-beta.10:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.10
+      '@solidjs/signals': 2.0.0-beta.10(patch_hash=1d5de47facd32b65a19e9d46610fb2c5ac2b16983219bf8806b97bad2f376364)
       csstype: 3.2.3
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)


### PR DESCRIPTION
Applies upstream solidjs/solid commits up to e16371fa to the published @solidjs/signals 2.0.0-beta.10 build via pnpm patch:

- 7d4d0c3a perf(signals): optimize synchronous scheduler paths
- 263be3f8 fix(signals): refresh() should only refresh top-level targets
- b0db6c90 fix(signals): preserve manual writes to derived state
- 47c0e6fa fix(signals): splice individually-disposed owners out of parent chain
- e16371fa perf(signals): reduce effect overhead, add sync opt-in, fix nested flush

Local benchmark (benchmarks/client-nav, solid, 5-run avg):
  before: 120.32 hz / 8.31 ms mean
  after:  142.26 hz / 7.03 ms mean (+18.2% throughput)