### PR TITLE
update bundlesize benchmark

### DIFF
--- a/benchmarks/bundle-size/README.md
+++ b/benchmarks/bundle-size/README.md
@@ -21,8 +21,9 @@ Each package has `minimal` and `full` scenarios:
 - Start Vite scenarios use `@tanstack/<framework>-start/plugin/vite` with router code-splitting enabled.
 - React Start also includes Rsbuild scenarios using `@tanstack/react-start/plugin/rsbuild`.
 - Full-surface coverage is manually maintained (no strict export-coverage gate).
-- Metrics are measured from initial-load JS graph only and reported as raw/gzip/brotli bytes.
-- Gzip is the primary tracking signal for PR deltas and historical charting.
+- Primary metrics measure all emitted client JS chunks and are reported as raw/gzip/brotli bytes.
+- Initial-load JS graph metrics are also recorded as `initialRawBytes`, `initialGzipBytes`, and `initialBrotliBytes` for context.
+- Gzip for all emitted client JS is the primary tracking signal for PR deltas and historical charting.
 
 ## Local Run
 

--- a/scripts/benchmarks/bundle-size/measure.mjs
+++ b/scripts/benchmarks/bundle-size/measure.mjs
@@ -168,6 +168,10 @@ function resolveManifestChunkKey(manifest, keyOrFile) {
   return undefined
 }
 
+function isJsFile(file) {
+  return file.endsWith('.js') || file.endsWith('.mjs')
+}
+
 function collectInitialJsFiles(manifest, entryKey) {
   const visitedKeys = new Set()
   const files = new Set()
@@ -184,7 +188,7 @@ function collectInitialJsFiles(manifest, entryKey) {
       return
     }
 
-    if (typeof chunk.file === 'string' && chunk.file.endsWith('.js')) {
+    if (typeof chunk.file === 'string' && isJsFile(chunk.file)) {
       files.add(chunk.file)
     }
 
@@ -197,6 +201,18 @@ function collectInitialJsFiles(manifest, entryKey) {
   }
 
   visitByKey(entryKey)
+
+  return [...files].sort()
+}
+
+function collectAllViteJsFiles(manifest) {
+  const files = new Set()
+
+  for (const chunk of Object.values(manifest)) {
+    if (typeof chunk?.file === 'string' && isJsFile(chunk.file)) {
+      files.add(chunk.file)
+    }
+  }
 
   return [...files].sort()
 }
@@ -461,36 +477,63 @@ function collectRsbuildInitialJsFiles(manifest, entryKey) {
   }
 
   return files
-    .filter(
-      (file) =>
-        typeof file === 'string' &&
-        (file.endsWith('.js') || file.endsWith('.mjs')),
-    )
+    .filter((file) => typeof file === 'string' && isJsFile(file))
     .sort()
+}
+
+function collectRsbuildAllJsFiles(manifest) {
+  const files = new Set()
+
+  for (const file of manifest.allFiles || []) {
+    if (typeof file === 'string' && isJsFile(file)) {
+      files.add(file)
+    }
+  }
+
+  if (files.size === 0) {
+    for (const entry of Object.values(manifest.entries || {})) {
+      for (const file of entry?.initial?.js || []) {
+        if (typeof file === 'string' && isJsFile(file)) {
+          files.add(file)
+        }
+      }
+      for (const file of entry?.async?.js || []) {
+        if (typeof file === 'string' && isJsFile(file)) {
+          files.add(file)
+        }
+      }
+    }
+  }
+
+  return [...files].sort()
 }
 
 async function resolveBundleFiles({ outDir, scenario }) {
   if (scenario.toolchain === 'rsbuild') {
     const manifestInfo = await resolveRsbuildManifest(outDir, scenario.id)
-    const jsFiles = collectRsbuildInitialJsFiles(
+    const initialJsFiles = collectRsbuildInitialJsFiles(
       manifestInfo.manifest,
       manifestInfo.entryKey,
     )
+    const jsFiles = collectRsbuildAllJsFiles(manifestInfo.manifest)
 
     return {
       ...manifestInfo,
+      initialJsFiles,
       jsFiles,
     }
   }
 
   const manifestInfo = await resolveManifestAndEntry(outDir, scenario.id)
-  const jsFiles = collectInitialJsFiles(
+  const initialJsFiles = collectInitialJsFiles(
     manifestInfo.manifest,
     manifestInfo.entryKey,
   )
+  const jsFiles = collectAllViteJsFiles(manifestInfo.manifest)
 
   return {
     ...manifestInfo,
+    initialJsFiles,
     jsFiles,
   }
 }
@@ -589,6 +632,10 @@ async function main() {
 
     const bundleInfo = await resolveBundleFiles({ outDir, scenario })
     const sizes = bytesForFiles(bundleInfo.manifestOutDir, bundleInfo.jsFiles)
+    const initialSizes = bytesForFiles(
+      bundleInfo.manifestOutDir,
+      bundleInfo.initialJsFiles,
+    )
 
     metrics.push({
       id: scenario.id,
@@ -599,7 +646,11 @@ async function main() {
       case: scenario.case,
       entryKey: bundleInfo.entryKey,
       manifestPath: path.relative(outDir, bundleInfo.manifestPath),
+      initialJsFiles: bundleInfo.initialJsFiles,
       jsFiles: bundleInfo.jsFiles,
+      initialRawBytes: initialSizes.rawBytes,
+      initialGzipBytes: initialSizes.gzipBytes,
+      initialBrotliBytes: initialSizes.brotliBytes,
       ...sizes,
     })
   }
@@ -617,7 +668,7 @@ async function main() {
     name: metric.id,
     unit: 'bytes',
     value: metric.gzipBytes,
-    extra: `raw=${metric.rawBytes}; brotli=${metric.brotliBytes}`,
+    extra: `raw=${metric.rawBytes}; brotli=${metric.brotliBytes}; initial_gzip=${metric.initialGzipBytes}`,
   }))
 
   const currentPath = path.join(resultsDir, 'current.json')

--- a/scripts/benchmarks/bundle-size/pr-report.mjs
+++ b/scripts/benchmarks/bundle-size/pr-report.mjs
@@ -290,6 +290,7 @@ async function main() {
       current: metric.gzipBytes,
       raw: metric.rawBytes,
       brotli: metric.brotliBytes,
+      initial: metric.initialGzipBytes,
       deltaCell: formatDelta(metric.gzipBytes, baselineValue),
       trendCell: sparkline(historySeries.slice(-args.trendPoints)),
     })
@@ -309,19 +310,19 @@ async function main() {
   }
   lines.push('')
   lines.push(
-    '| Scenario | Current (gzip) | Delta vs baseline | Raw | Brotli | Trend |',
+    '| Scenario | Current (gzip) | Delta vs baseline | Initial gzip | Raw | Brotli | Trend |',
   )
-  lines.push('| --- | ---: | ---: | ---: | ---: | --- |')
+  lines.push('| --- | ---: | ---: | ---: | ---: | ---: | --- |')
 
   for (const row of rows) {
     lines.push(
-      `| \`${row.id}\` | ${formatBytes(row.current)} | ${row.deltaCell} | ${formatBytes(row.raw)} | ${formatBytes(row.brotli)} | ${row.trendCell} |`,
+      `| \`${row.id}\` | ${formatBytes(row.current)} | ${row.deltaCell} | ${formatBytes(row.initial)} | ${formatBytes(row.raw)} | ${formatBytes(row.brotli)} | ${row.trendCell} |`,
     )
   }
 
   lines.push('')
   lines.push(
-    '_Trend sparkline is historical gzip bytes ending with this PR measurement; lower is better._',
+    '_Current gzip tracks all emitted client JS chunks. Initial gzip tracks only the entry/import graph. Trend sparkline is historical current gzip ending with this PR measurement; lower is better._',
   )
 
   const markdown = lines.join('\n') + '\n'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bundle size metrics documentation to clarify primary metrics coverage and initial-load measurements.

* **New Features**
  * Enhanced bundle size benchmarking to separately track initial JS bundle sizes (raw, gzip, and brotli).
  * PR reports now display initial gzip metrics alongside current metrics for more detailed performance insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->