### PR TITLE
fix(router-core): fix missing closing paren in CSS.supports check for view transition types

### DIFF
--- a/.changeset/fix-view-transition-types-typo.md
+++ b/.changeset/fix-view-transition-types-typo.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+fix(router-core): fix missing closing paren in CSS.supports check for view transition types

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1178,7 +1178,7 @@ export class RouterCore<
       typeof window.CSS?.supports === 'function'
     ) {
       this.isViewTransitionTypesSupported = window.CSS.supports(
-        'selector(:active-view-transition-type(a)',
+        'selector(:active-view-transition-type(a))',
       )
     }
   }


### PR DESCRIPTION
## Summary

The `isViewTransitionTypesSupported` feature check in `RouterCore` passes an unbalanced selector string to `CSS.supports()`:

```js
// Before (broken)
CSS.supports('selector(:active-view-transition-type(a)')
//                                                    ^ missing )

// After (fixed)
CSS.supports('selector(:active-view-transition-type(a))')
```

The unbalanced parenthesis makes the string invalid CSS, so `CSS.supports()` always returns `false` — even in browsers that fully support View Transition Level 2 types.

### Impact

- `isViewTransitionTypesSupported` is always `false`
- The `types` array passed via `navigate({ viewTransition: { types: [...] } })` is silently dropped
- `document.startViewTransition()` is called without types (falls back to bare callback)
- Any CSS rules using `:active-view-transition-type()` never match
- All view transitions fall back to the browser's default crossfade instead of using custom typed animations

### Fix

Add the missing closing parenthesis — a one-character change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected view transition feature detection to ensure proper browser capability identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->