### PR TITLE
fix: revert plugin changes, allow createMiddleware self compilation, fix HMR tests

### DIFF
--- a/packages/start-client-core/src/createCsrfMiddleware.ts
+++ b/packages/start-client-core/src/createCsrfMiddleware.ts
@@ -1,4 +1,5 @@
-import { createIsomorphicFn, createMiddleware } from '@tanstack/start-fn-stubs'
+import { createIsomorphicFn } from '@tanstack/start-fn-stubs'
+import { createMiddleware } from './createMiddleware'
 import type {
   RequestMiddlewareAfterServer,
   RequestServerOptions,
@@ -76,8 +77,8 @@ type CreateCsrfMiddleware = <TRegister, TMiddlewares>(
   opts?: CsrfMiddlewareOptions<TRegister, TMiddlewares>,
 ) => RequestMiddlewareAfterServer<{}, undefined, undefined>
 
-const innerCreateCsrfMiddleware = ((opts: any = {}) => {
-  const middleware = createMiddleware().server(async (ctx: any) => {
+const innerCreateCsrfMiddleware: CreateCsrfMiddleware = (opts = {}) => {
+  const middleware = createMiddleware().server(async (ctx) => {
     const csrfCtx = ctx as RequestServerOptions<any, any> & typeof ctx
 
     if (opts.filter && !(await opts.filter(csrfCtx))) {
@@ -96,7 +97,7 @@ const innerCreateCsrfMiddleware = ((opts: any = {}) => {
   }
 
   return middleware
-}) as any as CreateCsrfMiddleware
+}
 
 export const createCsrfMiddleware: CreateCsrfMiddleware =
   createIsomorphicFn().server(innerCreateCsrfMiddleware) as CreateCsrfMiddleware

--- a/packages/start-client-core/src/createCsrfMiddleware.ts
+++ b/packages/start-client-core/src/createCsrfMiddleware.ts
@@ -1,5 +1,4 @@
-import { createIsomorphicFn } from '@tanstack/start-fn-stubs'
-import { createMiddleware } from './createMiddleware'
+import { createIsomorphicFn, createMiddleware } from '@tanstack/start-fn-stubs'
 import type {
   RequestMiddlewareAfterServer,
   RequestServerOptions,
@@ -77,8 +76,8 @@ type CreateCsrfMiddleware = <TRegister, TMiddlewares>(
   opts?: CsrfMiddlewareOptions<TRegister, TMiddlewares>,
 ) => RequestMiddlewareAfterServer<{}, undefined, undefined>
 
-const innerCreateCsrfMiddleware: CreateCsrfMiddleware = (opts = {}) => {
-  const middleware = createMiddleware().server(async (ctx) => {
+const innerCreateCsrfMiddleware = ((opts: any = {}) => {
+  const middleware = createMiddleware().server(async (ctx: any) => {
     const csrfCtx = ctx as RequestServerOptions<any, any> & typeof ctx
 
     if (opts.filter && !(await opts.filter(csrfCtx))) {
@@ -97,7 +96,7 @@ const innerCreateCsrfMiddleware: CreateCsrfMiddleware = (opts = {}) => {
   }
 
   return middleware
-}
+}) as any as CreateCsrfMiddleware
 
 export const createCsrfMiddleware: CreateCsrfMiddleware =
   createIsomorphicFn().server(innerCreateCsrfMiddleware) as CreateCsrfMiddleware

--- a/packages/start-client-core/src/createCsrfMiddleware.ts
+++ b/packages/start-client-core/src/createCsrfMiddleware.ts
@@ -78,7 +78,7 @@ type CreateCsrfMiddleware = <TRegister, TMiddlewares>(
 
 const innerCreateCsrfMiddleware = ((opts: any = {}) => {
   const middleware = createMiddleware().server(async (ctx: any) => {
-    const csrfCtx = ctx as RequestServerOptions<any, any> & typeof ctx
+    const csrfCtx = ctx as RequestServerOptions<any, any>
 
     if (opts.filter && !(await opts.filter(csrfCtx))) {
       return ctx.next()

--- a/packages/start-fn-stubs/src/createMiddleware.ts
+++ b/packages/start-fn-stubs/src/createMiddleware.ts
@@ -1,0 +1,13 @@
+export function createMiddleware(opts?: any, opts2?: any): any {
+	const options = { ...(opts2 || opts) }
+	const proxy = new Proxy({}, {
+		get(_, prop) {
+			if (prop === 'options') return options
+			return (value: any) => {
+				options[prop] = value
+				return proxy
+			}
+		}
+	})
+	return proxy
+}

--- a/packages/start-fn-stubs/src/createMiddleware.ts
+++ b/packages/start-fn-stubs/src/createMiddleware.ts
@@ -1,13 +1,16 @@
 export function createMiddleware(opts?: any, opts2?: any): any {
-	const options = { ...(opts2 || opts) }
-	const proxy = new Proxy({}, {
-		get(_, prop) {
-			if (prop === 'options') return options
-			return (value: any) => {
-				options[prop] = value
-				return proxy
-			}
-		}
-	})
-	return proxy
+  const options = { ...(opts2 || opts) }
+  const proxy = new Proxy(
+    {},
+    {
+      get(_, prop) {
+        if (prop === 'options') return options
+        return (value: any) => {
+          options[prop] = value
+          return proxy
+        }
+      },
+    },
+  )
+  return proxy
 }

--- a/packages/start-fn-stubs/src/index.ts
+++ b/packages/start-fn-stubs/src/index.ts
@@ -5,5 +5,6 @@ export {
   type ClientOnlyFn,
   type IsomorphicFnBase,
 } from './createIsomorphicFn'
+export { createMiddleware } from './createMiddleware'
 
 export { createServerOnlyFn, createClientOnlyFn } from './envOnly'

--- a/packages/start-plugin-core/src/start-compiler/compiler.ts
+++ b/packages/start-plugin-core/src/start-compiler/compiler.ts
@@ -694,6 +694,7 @@ export class StartCompiler {
         ['createIsomorphicFn', 'IsomorphicFn'],
         ['createServerOnlyFn', 'ServerOnlyFn'],
         ['createClientOnlyFn', 'ClientOnlyFn'],
+        ['createMiddleware', 'Middleware'],
       ]),
     )
 
@@ -705,6 +706,7 @@ export class StartCompiler {
         ['createIsomorphicFn', 'IsomorphicFn'],
         ['createServerOnlyFn', 'ServerOnlyFn'],
         ['createClientOnlyFn', 'ClientOnlyFn'],
+        ['createMiddleware', 'Middleware'],
       ]),
     )
 

--- a/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks'
 import { VIRTUAL_MODULES } from '@tanstack/start-server-core'
 import { resolve as resolvePath } from 'pathe'
 import {
@@ -45,20 +44,6 @@ type ModuleInvalidationEnvironment = {
       seen?: Set<EnvironmentModuleNode>,
     ) => void
   }
-}
-
-type StartCompilerPluginContext = {
-  environment: {
-    name: string
-    mode: string
-    transformRequest: (url: string) => Promise<unknown>
-  }
-  load: (options: { id: string }) => Promise<{ code?: string | null }>
-  resolve: (
-    source: string,
-    importer?: string,
-  ) => Promise<{ id: string; external?: boolean | string } | null>
-  error: (message: string) => never
 }
 
 function invalidateMatchingFileModules(
@@ -196,17 +181,6 @@ export function startCompilerPlugin(
   opts: StartCompilerPluginOptions,
 ): PluginOption {
   const compilers = new Map<string, ReturnType<typeof createStartCompiler>>()
-  const compilerContextStorage =
-    new AsyncLocalStorage<StartCompilerPluginContext>()
-
-  const getCompilerContext = () => {
-    const context = compilerContextStorage.getStore()
-    if (!context) {
-      throw new Error('Start compiler Vite context is unavailable.')
-    }
-
-    return context
-  }
 
   // Shared registry of server functions across all environments
   const serverFnsById: Record<string, ServerFn> = {}
@@ -288,30 +262,27 @@ export function startCompilerPlugin(
                   ? createViteDevServerFnModuleSpecifierEncoder(root)
                   : undefined,
               loadModule: async (id: string) => {
-                const compilerContext = getCompilerContext()
-
                 if (mode === 'build') {
-                  const loaded = await compilerContext.load({ id })
+                  const loaded = await this.load({ id })
                   const code = loaded.code ?? ''
 
                   compiler!.ingestModule({ code, id })
                   return
                 }
 
-                if (compilerContext.environment.mode !== 'dev') {
-                  compilerContext.error(
-                    `could not load module ${id}: unknown environment mode ${compilerContext.environment.mode}`,
+                if (this.environment.mode !== 'dev') {
+                  this.error(
+                    `could not load module ${id}: unknown environment mode ${this.environment.mode}`,
                   )
                 }
 
-                await compilerContext.environment.transformRequest(
+                await this.environment.transformRequest(
                   `${id}?${SERVER_FN_LOOKUP}`,
                 )
               },
 
               resolveId: async (source: string, importer?: string) => {
-                const compilerContext = getCompilerContext()
-                const r = await compilerContext.resolve(source, importer)
+                const r = await this.resolve(source, importer)
 
                 if (r) {
                   if (!r.external) {
@@ -331,15 +302,11 @@ export function startCompilerPlugin(
             compilerTransforms,
           })
 
-          const result = await compilerContextStorage.run(
-            this as unknown as StartCompilerPluginContext,
-            () =>
-              compiler.compile({
-                id,
-                code,
-                detectedKinds,
-              }),
-          )
+          const result = await compiler.compile({
+            id,
+            code,
+            detectedKinds,
+          })
           return result
         },
       },


### PR DESCRIPTION
https://github.com/TanStack/router/pull/7373 assumed `createMiddleware` would be imported internally *and still be compiled away* IIF the compiler was made recursive.

It seemed to work, but also the compiler broke HMR E2E tests (and possibly actual HMR, not just tests).

Instead, this PR reverts the compiler changes, and adds a `createMiddleware` stub (registered in the plugin) so it still gets compiled away.

---

This works well, but is a little weird for "where to put the code", the stub is untyped because all types live alongside the actual implementation. 

Another solution could be to move the implementation of `createCsrfMiddleware` to `start-server-core` maybe? We attempt this alternative fix in https://github.com/TanStack/router/pull/7400