### PR TITLE
fix(router-core): hydrate before initial client route match

### DIFF
--- a/.changeset/bright-rivers-hydrate.md
+++ b/.changeset/bright-rivers-hydrate.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Run custom router hydration before the initial client route match so hydrated router configuration, such as request-specific URL rewrites, can be installed before SSR hydration compares matches.

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -94,6 +94,10 @@ export async function hydrate(router: AnyRouter): Promise<any> {
     nonce,
   }
 
+  // Allow the user to handle custom hydration data before matching routes.
+  // This lets hydration install router config that affects matching, e.g. rewrites.
+  await router.options.hydrate?.(dehydratedData)
+
   // Hydrate the router state
   const matches = router.matchRoutes(router.stores.location.get())
 
@@ -163,9 +167,6 @@ export async function hydrate(router: AnyRouter): Promise<any> {
   })
 
   router.stores.setMatches(matches)
-
-  // Allow the user to handle custom hydration data
-  await router.options.hydrate?.(dehydratedData)
 
   // now that all necessary data is hydrated:
   // 1) fully reconstruct the route context

--- a/packages/router-core/tests/hydrate.test.ts
+++ b/packages/router-core/tests/hydrate.test.ts
@@ -4,6 +4,7 @@ import { BaseRootRoute, BaseRoute, notFound } from '../src'
 import { hydrate } from '../src/ssr/client'
 import { createTestRouter } from './routerTestUtils'
 import { dehydrateSsrMatchId } from '../src/ssr/ssr-match-id'
+import type { LocationRewrite } from '../src'
 import type { TsrSsrGlobal } from '../src/ssr/types'
 import type { AnyRouteMatch } from '../src'
 
@@ -393,6 +394,73 @@ describe('hydrate', () => {
 
     expect(loadSpy).not.toHaveBeenCalled()
     expect((mockRouter.state.matches[0] as AnyRouteMatch).id).toBe('/')
+  })
+
+  it('should run custom hydration before matching routes', async () => {
+    const history = createMemoryHistory({ initialEntries: ['/public'] })
+
+    const rootRoute = new BaseRootRoute({})
+    const internalRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/internal',
+      component: () => 'Internal',
+    })
+
+    const rewrite: LocationRewrite = {
+      input: ({ url }) => {
+        if (url.pathname === '/public') {
+          url.pathname = '/internal'
+        }
+        return url
+      },
+    }
+
+    mockRouter = createTestRouter({
+      routeTree: rootRoute.addChildren([internalRoute]),
+      history,
+      isServer: true,
+      hydrate: (dehydrated: { rewrite?: boolean }) => {
+        if (dehydrated.rewrite) {
+          mockRouter.update({ rewrite })
+        }
+      },
+    })
+
+    mockWindow.$_TSR = {
+      router: {
+        manifest: { routes: {} },
+        dehydratedData: { rewrite: true },
+        lastMatchId: '/internal/internal',
+        matches: [
+          {
+            i: '__root__/',
+            s: 'success',
+            ssr: true,
+            u: Date.now(),
+          },
+          {
+            i: '/internal/internal',
+            s: 'success',
+            ssr: true,
+            u: Date.now(),
+          },
+        ],
+      },
+      h: vi.fn(),
+      e: vi.fn(),
+      c: vi.fn(),
+      p: vi.fn(),
+      buffer: [],
+      initialized: false,
+    }
+
+    await hydrate(mockRouter)
+
+    expect(mockRouter.state.location.pathname).toBe('/internal')
+    expect(mockRouter.state.location.publicHref).toBe('/public')
+    expect(
+      mockRouter.state.matches.map((match: AnyRouteMatch) => match.routeId),
+    ).toEqual(['__root__', '/internal'])
   })
 
   it('should handle errors during route context hydration', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom router hydration hook execution has been reordered to run after nonce setup but before initial route matching, ensuring request-specific router configurations are installed at the correct stage during the SSR hydration process.

* **Tests**
  * Added test case to verify that custom hydration executes before route matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->