### PR TITLE
docs(start): use router package for module declaration to type the request context

### DIFF
--- a/docs/start/framework/react/guide/server-entry-point.md
+++ b/docs/start/framework/react/guide/server-entry-point.md
@@ -64,7 +64,7 @@ export default createServerEntry({
 
 When your server needs to pass additional, typed data into request handlers (for example, authenticated user info, a database connection, or per-request flags), register a request context type via TypeScript module augmentation. The registered context is delivered as the second argument to the server `fetch` handler and is available throughout the server-side middleware chain — including global middleware, request/function middleware, server routes, server functions, and the router itself.
 
-To add types for your request context, augment the `Register` interface from `@tanstack/react-start` with a `server.requestContext` property. The runtime `context` you pass to `handler.fetch` will then match that type. Example:
+To add types for your request context, augment the `Register` interface from `@tanstack/react-router` with a `server.requestContext` property. The runtime `context` you pass to `handler.fetch` will then match that type. Example:
 
 ```tsx
 import handler, { createServerEntry } from '@tanstack/react-start/server-entry'
@@ -74,7 +74,7 @@ type MyRequestContext = {
   foo: number
 }
 
-declare module '@tanstack/react-start' {
+declare module '@tanstack/react-router' {
   interface Register {
     server: {
       requestContext: MyRequestContext

--- a/docs/start/framework/solid/guide/server-entry-point.md
+++ b/docs/start/framework/solid/guide/server-entry-point.md
@@ -1,5 +1,9 @@
 ---
 ref: docs/start/framework/react/guide/server-entry-point.md
 replace:
-  { '@tanstack/react-start': '@tanstack/solid-start', 'React': 'SolidJS' }
+  {
+    '@tanstack/react-start': '@tanstack/solid-start',
+    '@tanstack/react-router': '@tanstack/solid-router',
+    'React': 'SolidJS',
+  }
 ---


### PR DESCRIPTION
Closes #7399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated request context type configuration guidance in React framework server entry point documentation with corrected module reference examples
  * Reformatted Solid framework server entry point documentation with improved code snippet structure for enhanced readability and clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->