### PR TITLE
docs(start): compare deferred hydration to Astro islands

### DIFF
--- a/docs/start/framework/react/guide/deferred-hydration.md
+++ b/docs/start/framework/react/guide/deferred-hydration.md
@@ -89,6 +89,21 @@ Poor candidates are parts of the page users may need immediately:
 Measure each boundary. A useful boundary reduces startup JavaScript or hydration
 work without making expected interactions feel late.
 
+## Comparison To Astro Islands
+
+Astro starts static and asks "what should come alive?" Each answer is an
+isolated framework root dropped into HTML. Islands are independent runtimes
+sharing a DOM.
+
+TanStack Start starts fully interactive and asks "what can wait?" The whole
+document hydrates as one React tree by default; `Hydrate` boundaries are gates
+inside that tree. Context, state, and events flow through normally, and
+hydration is parent-first.
+
+Same trigger vocabulary, different substrate: Astro composes runtimes, Start
+schedules one. That is why Start gets `interaction()`, `condition()`, and intent
+bubbling, and why Astro gets multi-framework.
+
 ## The Three Decisions
 
 Each `Hydrate` boundary has three performance decisions:

--- a/docs/start/framework/solid/guide/deferred-hydration.md
+++ b/docs/start/framework/solid/guide/deferred-hydration.md
@@ -3,6 +3,7 @@ ref: docs/start/framework/react/guide/deferred-hydration.md
 replace:
   '@tanstack/react-start': '@tanstack/solid-start'
   'React handlers': 'Solid handlers'
+  'one React tree': 'one Solid tree'
   'ReactNode': 'JSX.Element'
   "Deferred hydration is a performance hint for React's initial hydration work. React may hydrate a deferred boundary earlier than its strategy would normally allow if state, props, context, or store updates outside the boundary require React to reconcile inside it before the gate opens. This preserves correctness and avoids showing stale server HTML after the surrounding app has changed.": "Deferred hydration is a performance hint for Solid's initial hydration work. Once a boundary gate opens, TanStack Start clears the preserved server DOM inside the marker and mounts the live Solid subtree in its place."
   'Hook calls directly inside extracted JSX': 'Render-time `use*` calls directly inside extracted JSX'


### PR DESCRIPTION
## Summary
- Adds a short "Comparison To Astro Islands" section to the deferred hydration guide, framing the inverted defaults (Astro: static-first, opt in per island; Start: interactive-first, opt out per `Hydrate` boundary).
- Highlights the substrate difference — Astro composes independent runtimes, Start schedules a single React tree — which is why Start gets `interaction()`, `condition()`, and intent bubbling, and why Astro gets multi-framework.
- Mirrored to the Solid guide via a `'one React tree' → 'one Solid tree'` transform.

## Test plan
- [ ] Render the docs site locally and confirm the new section appears between "Choose What To Defer" and "The Three Decisions" in both React and Solid variants.
- [ ] Confirm the Solid variant reads "one Solid tree" via the transform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Comparison To Astro Islands" section explaining deferred hydration approach in React framework guide
  * Updated Solid framework guide for consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->